### PR TITLE
Add <obsoletedBy> to licenses and exceptions

### DIFF
--- a/schema/ListedLicense.xsd
+++ b/schema/ListedLicense.xsd
@@ -42,6 +42,7 @@
 			</documentation>
 		</annotation>
 		<all>
+			<element name="obsoletedBy" type="tns:obsoletedByType" minOccurs="0" maxOccurs="unbounded" />
 			<element name="crossRefs" type="tns:crossRefsType" minOccurs="0" maxOccurs="1"/>
 			<element name="notes" type="tns:formattedFixedTextType" minOccurs="0" maxOccurs="1"/>
 			<element name="text" type="tns:formattedAltTextType" minOccurs="0" maxOccurs="1"/>
@@ -61,6 +62,7 @@
 			</documentation>
 		</annotation>
 		<all>
+			<element name="obsoletedBy" type="tns:obsoletedByType" minOccurs="0" maxOccurs="unbounded" />
 			<element name="crossRefs" type="tns:crossRefsType" minOccurs="0" maxOccurs="1"/>
 			<element name="notes" type="tns:formattedFixedTextType" minOccurs="0" maxOccurs="1">
 				<annotation>
@@ -164,6 +166,57 @@
 				</annotation>
 			</element>
 		</sequence>
+	</complexType>
+	<complexType name="obsoletedByType" mixed="true">
+		<annotation>
+			<documentation xml:lang="en">
+				<xhtml:p>
+					<xhtml:code>obsoletedByType</xhtml:code> represents a recommended replacement for license expressions containing a given license or exception.  The algorithm for determining the recommended replacement in the context of a given license expression is:
+				</xhtml:p>
+				<xhtml:ol>
+					<xhtml:li>Parse the license expression to extract the short identifiers.</xhtml:li>
+					<xhtml:li>Look up <xhtml:code>obsoletedBy</xhtml:code> entries for the short identifiers.</xhtml:li>
+					<xhtml:li>If any <xhtml:code>obsoletedBy</xhtml:code> has an <xhtml:code>expression</xhtml:code> attribute that matches the source, the value of that <xhtml:code>obsoletedBy</xhtml:code> is the recommended replacement for that expression.  Otherwise, the value of the <xhtml:code>obsoletedBy</xhtml:code> without an expression attribute is the recommended replacement for the short identifier.</xhtml:li>
+				</xhtml:ol>
+				<xhtml:p>
+					For example, the expression <xhtml:code>GPL-2.0+ WITH GCC-exception-2.0</xhtml:code> could be parsed to either of the following short license identifiers:
+				</xhtml:p>
+				<xhtml:ul>
+					<xhtml:li>
+						<xhtml:p>
+							<xhtml:code>GPL-2.0+</xhtml:code>, in which case there would be a single <xhtml:code>obsoletedBy</xhtml:code> with no <xhtml:code>expression</xhtml:code> attribute:
+						</xhtml:p>
+						<xhtml:p>
+							<xhtml:code>&lt;obsoletedBy&gt;GPL-2.0-or-later&lt;/obsoletedBy&gt;</xhtml:code>
+						</xhtml:p>
+						<xhtml:p>
+							So the recommended replacement for <xhtml:code>GPL-2.0+</xhtml:code> would be <xhtml:code>GPL-2.0-or-later</xhtml:code>.
+						</xhtml:p>
+					</xhtml:li>
+					<xhtml:li>
+						<xhtml:p>
+							<xhtml:code>GPL-2.0</xhtml:code>, in which case there would be two <xhtml:code>obsoletedBy</xhtml:code> elements:
+						</xhtml:p>
+						<xhtml:p>
+							<xhtml:code>&lt;obsoletedBy&gt;GPL-2.0-only&lt;/obsoletedBy&gt;</xhtml:code><xhtml:br/>
+							<xhtml:code>&lt;obsoletedBy expression="GPL-2.0+"&gt;GPL-2.0-or-later&lt;/obsoletedBy&gt;</xhtml:code>
+						</xhtml:p>
+						<xhtml:p>
+							The element with <xhtml:code>expression="GPL-2.0+"</xhtml:code> matches the initial license expression, so the recommended replacement for <xhtml:code>GPL-2.0+</xhtml:code> is <xhtml:code>GPL-2.0-or-later</xhtml:code>.
+						</xhtml:p>
+					</xhtml:li>
+				</xhtml:ul>
+			</documentation>
+		</annotation>
+		<attribute name="expression" type="string">
+			<annotation>
+				<documentation xml:lang="en">
+					<xhtml:p>
+						<xhtml:code>expression</xhtml:code> is the license expression which is obsoleted by the expression contained by the element.  Defaults to the bare identifier.
+					</xhtml:p>
+				</documentation>
+			</annotation>
+		</attribute>
 	</complexType>
 	<complexType name="altType" mixed="true">
 		<annotation>

--- a/schema/ListedLicense.xsd
+++ b/schema/ListedLicense.xsd
@@ -42,7 +42,7 @@
 			</documentation>
 		</annotation>
 		<all>
-			<element name="obsoletedBy" type="tns:obsoletedByType" minOccurs="0" maxOccurs="unbounded" />
+			<element name="obsoletedBys" type="tns:obsoletedBysType" minOccurs="0" maxOccurs="1" />
 			<element name="crossRefs" type="tns:crossRefsType" minOccurs="0" maxOccurs="1"/>
 			<element name="notes" type="tns:formattedFixedTextType" minOccurs="0" maxOccurs="1"/>
 			<element name="text" type="tns:formattedAltTextType" minOccurs="0" maxOccurs="1"/>
@@ -62,7 +62,7 @@
 			</documentation>
 		</annotation>
 		<all>
-			<element name="obsoletedBy" type="tns:obsoletedByType" minOccurs="0" maxOccurs="unbounded" />
+			<element name="obsoletedBys" type="tns:obsoletedBysType" minOccurs="0" maxOccurs="1" />
 			<element name="crossRefs" type="tns:crossRefsType" minOccurs="0" maxOccurs="1"/>
 			<element name="notes" type="tns:formattedFixedTextType" minOccurs="0" maxOccurs="1">
 				<annotation>
@@ -165,6 +165,18 @@
 					</documentation>
 				</annotation>
 			</element>
+		</sequence>
+	</complexType>
+	<complexType name="obsoletedBysType">
+		<annotation>
+			<documentation xml:lang="en">
+				<xhtml:p>
+					<xhtml:code>obsoletedBysType</xhtml:code> is a wrapper for a set of <xhtml:code>obsoletedBy</xhtml:code> entries.
+				</xhtml:p>
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="obsoletedBy" type="tns:obsoletedByType" minOccurs="1" maxOccurs="unbounded" />
 		</sequence>
 	</complexType>
 	<complexType name="obsoletedByType" mixed="true">

--- a/src/AGPL-1.0.xml
+++ b/src/AGPL-1.0.xml
@@ -3,8 +3,10 @@
    <license isOsiApproved="false" licenseId="AGPL-1.0"
             name="Affero General Public License v1.0"
             isDeprecated="true" deprecatedVersion="3.1">
-      <obsoletedBy>AGPL-1.0-only</obsoletedBy>
-      <obsoletedBy expression="AGPL-1.0+">AGPL-1.0-or-later</obsoletedBy>
+      <obsoletedBys>
+         <obsoletedBy>AGPL-1.0-only</obsoletedBy>
+         <obsoletedBy expression="AGPL-1.0+">AGPL-1.0-or-later</obsoletedBy>
+      </obsoletedBys>
       <crossRefs>
          <crossRef>http://www.affero.org/oagpl.html</crossRef>
       </crossRefs>

--- a/src/AGPL-1.0.xml
+++ b/src/AGPL-1.0.xml
@@ -3,6 +3,8 @@
    <license isOsiApproved="false" licenseId="AGPL-1.0"
             name="Affero General Public License v1.0"
             isDeprecated="true" deprecatedVersion="3.1">
+      <obsoletedBy>AGPL-1.0-only</obsoletedBy>
+      <obsoletedBy expression="AGPL-1.0+">AGPL-1.0-or-later</obsoletedBy>
       <crossRefs>
          <crossRef>http://www.affero.org/oagpl.html</crossRef>
       </crossRefs>

--- a/src/AGPL-3.0.xml
+++ b/src/AGPL-3.0.xml
@@ -3,8 +3,10 @@
   <license licenseId="AGPL-3.0" isOsiApproved="true"
   name="GNU Affero General Public License v3.0"
   isDeprecated="true" deprecatedVersion="3.0">
-    <obsoletedBy>AGPL-3.0-only</obsoletedBy>
-    <obsoletedBy expression="AGPL-3.0+">AGPL-3.0-or-later</obsoletedBy>
+    <obsoletedBys>
+      <obsoletedBy>AGPL-3.0-only</obsoletedBy>
+      <obsoletedBy expression="AGPL-3.0+">AGPL-3.0-or-later</obsoletedBy>
+    </obsoletedBys>
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/agpl.txt</crossRef>
       <crossRef>http://www.opensource.org/licenses/AGPL-3.0</crossRef>

--- a/src/AGPL-3.0.xml
+++ b/src/AGPL-3.0.xml
@@ -3,14 +3,12 @@
   <license licenseId="AGPL-3.0" isOsiApproved="true"
   name="GNU Affero General Public License v3.0"
   isDeprecated="true" deprecatedVersion="3.0">
+    <obsoletedBy>AGPL-3.0-only</obsoletedBy>
+    <obsoletedBy expression="AGPL-3.0+">AGPL-3.0-or-later</obsoletedBy>
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/agpl.txt</crossRef>
       <crossRef>http://www.opensource.org/licenses/AGPL-3.0</crossRef>
     </crossRefs>
-    <notes>
-      DEPRECATED: Deprecated in lieu of more
-      explicit license identifier of AGPL-3.0-only
-    </notes>
     <standardLicenseHeader>
       Copyright (C) <alt name="copyright" match=".+">[year] [name of author]</alt>
       This program is free software: you can redistribute it and/or modify it

--- a/src/GFDL-1.1.xml
+++ b/src/GFDL-1.1.xml
@@ -3,13 +3,11 @@
   <license licenseId="GFDL-1.1" isOsiApproved="false"
   name="GNU Free Documentation License v1.1"
   isDeprecated="true" deprecatedVersion="3.0">
+    <obsoletedBy>GFDL-1.1-only</obsoletedBy>
+    <obsoletedBy expression="GFDL-1.1+">GFDL-1.1-or-later</obsoletedBy>
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/old-licenses/fdl-1.1.txt</crossRef>
     </crossRefs>
-    <notes>
-      DEPRECATED: Deprecated in lieu of more
-      explicit license identifier of GFDL-1.1-only
-    </notes>
     <standardLicenseHeader>
       Copyright (c) <alt name="copyright" match=".+">YEAR YOUR NAME</alt>
       . Permission is granted to copy, distribute and/or modify this

--- a/src/GFDL-1.1.xml
+++ b/src/GFDL-1.1.xml
@@ -3,8 +3,10 @@
   <license licenseId="GFDL-1.1" isOsiApproved="false"
   name="GNU Free Documentation License v1.1"
   isDeprecated="true" deprecatedVersion="3.0">
-    <obsoletedBy>GFDL-1.1-only</obsoletedBy>
-    <obsoletedBy expression="GFDL-1.1+">GFDL-1.1-or-later</obsoletedBy>
+    <obsoletedBys>
+      <obsoletedBy>GFDL-1.1-only</obsoletedBy>
+      <obsoletedBy expression="GFDL-1.1+">GFDL-1.1-or-later</obsoletedBy>
+    </obsoletedBys>
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/old-licenses/fdl-1.1.txt</crossRef>
     </crossRefs>

--- a/src/GFDL-1.2.xml
+++ b/src/GFDL-1.2.xml
@@ -3,13 +3,11 @@
   <license licenseId="GFDL-1.2" isOsiApproved="false"
   name="GNU Free Documentation License v1.2"
   isDeprecated="true" deprecatedVersion="3.0">
+    <obsoletedBy>GFDL-1.2-only</obsoletedBy>
+    <obsoletedBy expression="GFDL-1.2+">GFDL-1.2-or-later</obsoletedBy>
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/old-licenses/fdl-1.2.txt</crossRef>
     </crossRefs>
-    <notes>
-      DEPRECATED: Deprecated in lieu of more
-      explicit license identifier of GFDL-1.2-only
-    </notes>
     <standardLicenseHeader>
       Copyright (c) <alt name="copyright" match=".+">YEAR YOUR NAME</alt>
       . Permission is granted to copy, distribute and/or modify this

--- a/src/GFDL-1.2.xml
+++ b/src/GFDL-1.2.xml
@@ -3,8 +3,10 @@
   <license licenseId="GFDL-1.2" isOsiApproved="false"
   name="GNU Free Documentation License v1.2"
   isDeprecated="true" deprecatedVersion="3.0">
-    <obsoletedBy>GFDL-1.2-only</obsoletedBy>
-    <obsoletedBy expression="GFDL-1.2+">GFDL-1.2-or-later</obsoletedBy>
+    <obsoletedBys>
+      <obsoletedBy>GFDL-1.2-only</obsoletedBy>
+      <obsoletedBy expression="GFDL-1.2+">GFDL-1.2-or-later</obsoletedBy>
+    </obsoletedBys>
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/old-licenses/fdl-1.2.txt</crossRef>
     </crossRefs>

--- a/src/GFDL-1.3.xml
+++ b/src/GFDL-1.3.xml
@@ -3,8 +3,10 @@
   <license licenseId="GFDL-1.3" isOsiApproved="false"
   name="GNU Free Documentation License v1.3"
   isDeprecated="true" deprecatedVersion="3.0">
-    <obsoletedBy>GFDL-1.3-only</obsoletedBy>
-    <obsoletedBy expression="GFDL-1.3+">GFDL-1.3-or-later</obsoletedBy>
+    <obsoletedBys>
+      <obsoletedBy>GFDL-1.3-only</obsoletedBy>
+      <obsoletedBy expression="GFDL-1.3+">GFDL-1.3-or-later</obsoletedBy>
+    </obsoletedBys>
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/fdl-1.3.txt</crossRef>
     </crossRefs>

--- a/src/GFDL-1.3.xml
+++ b/src/GFDL-1.3.xml
@@ -3,13 +3,11 @@
   <license licenseId="GFDL-1.3" isOsiApproved="false"
   name="GNU Free Documentation License v1.3"
   isDeprecated="true" deprecatedVersion="3.0">
+    <obsoletedBy>GFDL-1.3-only</obsoletedBy>
+    <obsoletedBy expression="GFDL-1.3+">GFDL-1.3-or-later</obsoletedBy>
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/fdl-1.3.txt</crossRef>
     </crossRefs>
-    <notes>
-      DEPRECATED: Deprecated in lieu of more
-      explicit license identifier of GFDL-1.3-only
-    </notes>
     <standardLicenseHeader>
       Copyright (c) <alt name="copyright" match=".+">YEAR YOUR NAME</alt>
       Permission is granted to copy, distribute and/or modify this

--- a/src/GPL-1.0+.xml
+++ b/src/GPL-1.0+.xml
@@ -2,7 +2,9 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isDeprecated="true" deprecatedVersion="2.0rc2" isOsiApproved="false" licenseId="GPL-1.0+"
             name="GNU General Public License v1.0 or later">
-      <obsoletedBy>GPL-1.0-or-later</obsoletedBy>
+      <obsoletedBys>
+         <obsoletedBy>GPL-1.0-or-later</obsoletedBy>
+      </obsoletedBys>
       <crossRefs>
          <crossRef>http://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html</crossRef>
       </crossRefs>

--- a/src/GPL-1.0+.xml
+++ b/src/GPL-1.0+.xml
@@ -2,10 +2,10 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isDeprecated="true" deprecatedVersion="2.0rc2" isOsiApproved="false" licenseId="GPL-1.0+"
             name="GNU General Public License v1.0 or later">
+      <obsoletedBy>GPL-1.0-or-later</obsoletedBy>
       <crossRefs>
          <crossRef>http://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html</crossRef>
       </crossRefs>
-      <notes>DEPRECATED: Use GPL-1.0-or-later</notes>
     <text>
       <titleText>
          <p>GNU GENERAL PUBLIC LICENSE 

--- a/src/GPL-1.0.xml
+++ b/src/GPL-1.0.xml
@@ -3,8 +3,10 @@
   <license licenseId="GPL-1.0" isOsiApproved="false"
   name="GNU General Public License v1.0 only"
   isDeprecated="true" deprecatedVersion="3.0">
-    <obsoletedBy>GPL-1.0-only</obsoletedBy>
-    <obsoletedBy expression="GPL-1.0+">GPL-1.0-or-later</obsoletedBy>
+    <obsoletedBys>
+      <obsoletedBy>GPL-1.0-only</obsoletedBy>
+      <obsoletedBy expression="GPL-1.0+">GPL-1.0-or-later</obsoletedBy>
+    </obsoletedBys>
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html</crossRef>
     </crossRefs>

--- a/src/GPL-1.0.xml
+++ b/src/GPL-1.0.xml
@@ -3,13 +3,11 @@
   <license licenseId="GPL-1.0" isOsiApproved="false"
   name="GNU General Public License v1.0 only"
   isDeprecated="true" deprecatedVersion="3.0">
+    <obsoletedBy>GPL-1.0-only</obsoletedBy>
+    <obsoletedBy expression="GPL-1.0+">GPL-1.0-or-later</obsoletedBy>
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html</crossRef>
     </crossRefs>
-    <notes>
-      DEPRECATED: Deprecated in lieu of more
-      explicit license identifier of GPL-1.0-only
-    </notes>
     <standardLicenseHeader>
       Copyright (C) <alt name="copyright" match=".+">19xx name of author</alt>
       <p>

--- a/src/GPL-2.0+.xml
+++ b/src/GPL-2.0+.xml
@@ -2,7 +2,9 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="GPL-2.0+" isDeprecated="true" deprecatedVersion="2.0rc2"
             name="GNU General Public License v2.0 or later">
-      <obsoletedBy>GPL-2.0-or-later</obsoletedBy>
+      <obsoletedBys>
+         <obsoletedBy>GPL-2.0-or-later</obsoletedBy>
+      </obsoletedBys>
       <crossRefs>
          <crossRef>http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html</crossRef>
          <crossRef>http://www.opensource.org/licenses/GPL-2.0</crossRef>

--- a/src/GPL-2.0+.xml
+++ b/src/GPL-2.0+.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="GPL-2.0+" isDeprecated="true" deprecatedVersion="2.0rc2"
             name="GNU General Public License v2.0 or later">
-	  <notes>DEPRECATED: Use the license identifier GPL-2.0-or-later</notes>
+      <obsoletedBy>GPL-2.0-or-later</obsoletedBy>
       <crossRefs>
          <crossRef>http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html</crossRef>
          <crossRef>http://www.opensource.org/licenses/GPL-2.0</crossRef>

--- a/src/GPL-2.0-with-GCC-exception.xml
+++ b/src/GPL-2.0-with-GCC-exception.xml
@@ -2,10 +2,11 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isDeprecated="true" deprecatedVersion="2.0rc2" licenseId="GPL-2.0-with-GCC-exception"
             name="GNU General Public License v2.0 w/GCC Runtime Library exception">
+      <obsoletedBy>GPL-2.0 WITH GCC-exception-2.0</obsoletedBy>
+      <obsoletedBy expression="GPL-2.0-with-GCC-exception+">GPL-2.0-or-later WITH GCC-exception-2.0</obsoletedBy>
       <crossRefs>
          <crossRef>https://gcc.gnu.org/git/?p=gcc.git;a=blob;f=gcc/libgcc1.c;h=762f5143fc6eed57b6797c82710f3538aa52b40b;hb=cb143a3ce4fb417c68f5fa2691a1b1b1053dfba9#l10</crossRef>
       </crossRefs>
-      <notes>DEPRECATED: Use License Expression Syntax and Exceptions list to create equivalent license.</notes>
      
     <text>
 	     <p>insert GPL v2 license text here</p>

--- a/src/GPL-2.0-with-GCC-exception.xml
+++ b/src/GPL-2.0-with-GCC-exception.xml
@@ -2,8 +2,10 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isDeprecated="true" deprecatedVersion="2.0rc2" licenseId="GPL-2.0-with-GCC-exception"
             name="GNU General Public License v2.0 w/GCC Runtime Library exception">
-      <obsoletedBy>GPL-2.0 WITH GCC-exception-2.0</obsoletedBy>
-      <obsoletedBy expression="GPL-2.0-with-GCC-exception+">GPL-2.0-or-later WITH GCC-exception-2.0</obsoletedBy>
+      <obsoletedBys>
+         <obsoletedBy>GPL-2.0 WITH GCC-exception-2.0</obsoletedBy>
+         <obsoletedBy expression="GPL-2.0-with-GCC-exception+">GPL-2.0-or-later WITH GCC-exception-2.0</obsoletedBy>
+      </obsoletedBys>
       <crossRefs>
          <crossRef>https://gcc.gnu.org/git/?p=gcc.git;a=blob;f=gcc/libgcc1.c;h=762f5143fc6eed57b6797c82710f3538aa52b40b;hb=cb143a3ce4fb417c68f5fa2691a1b1b1053dfba9#l10</crossRef>
       </crossRefs>

--- a/src/GPL-2.0-with-autoconf-exception.xml
+++ b/src/GPL-2.0-with-autoconf-exception.xml
@@ -2,8 +2,10 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isDeprecated="true" deprecatedVersion="2.0rc2" licenseId="GPL-2.0-with-autoconf-exception"
             name="GNU General Public License v2.0 w/Autoconf exception">
-      <obsoletedBy>GPL-2.0 WITH Autoconf-exception-2.0</obsoletedBy>
-      <obsoletedBy expression="GPL-2.0-with-autoconf-exception+">GPL-2.0-or-later WITH Autoconf-exception-2.0</obsoletedBy>
+      <obsoletedBys>
+         <obsoletedBy>GPL-2.0 WITH Autoconf-exception-2.0</obsoletedBy>
+         <obsoletedBy expression="GPL-2.0-with-autoconf-exception+">GPL-2.0-or-later WITH Autoconf-exception-2.0</obsoletedBy>
+      </obsoletedBys>
       <crossRefs>
          <crossRef>http://ac-archive.sourceforge.net/doc/copyright.html</crossRef>
       </crossRefs>

--- a/src/GPL-2.0-with-autoconf-exception.xml
+++ b/src/GPL-2.0-with-autoconf-exception.xml
@@ -2,10 +2,11 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isDeprecated="true" deprecatedVersion="2.0rc2" licenseId="GPL-2.0-with-autoconf-exception"
             name="GNU General Public License v2.0 w/Autoconf exception">
+      <obsoletedBy>GPL-2.0 WITH Autoconf-exception-2.0</obsoletedBy>
+      <obsoletedBy expression="GPL-2.0-with-autoconf-exception+">GPL-2.0-or-later WITH Autoconf-exception-2.0</obsoletedBy>
       <crossRefs>
          <crossRef>http://ac-archive.sourceforge.net/doc/copyright.html</crossRef>
       </crossRefs>
-      <notes>DEPRECATED: Use License Expression Syntax and Exceptions list to create equivalent license.</notes>
      
     <text>
 	     <p>insert GPL v2 license text here</p>

--- a/src/GPL-2.0-with-bison-exception.xml
+++ b/src/GPL-2.0-with-bison-exception.xml
@@ -2,8 +2,10 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isDeprecated="true" deprecatedVersion="2.0rc2" licenseId="GPL-2.0-with-bison-exception"
             name="GNU General Public License v2.0 w/Bison exception">
-      <obsoletedBy>GPL-2.0 WITH Bison-exception-2.2</obsoletedBy>
-      <obsoletedBy expression="GPL-2.0-with-bison-exception+">GPL-2.0-or-later WITH Bison-exception-2.2</obsoletedBy>
+      <obsoletedBys>
+         <obsoletedBy>GPL-2.0 WITH Bison-exception-2.2</obsoletedBy>
+         <obsoletedBy expression="GPL-2.0-with-bison-exception+">GPL-2.0-or-later WITH Bison-exception-2.2</obsoletedBy>
+      </obsoletedBys>
       <crossRefs>
          <crossRef>http://git.savannah.gnu.org/cgit/bison.git/tree/data/yacc.c?id=193d7c7054ba7197b0789e14965b739162319b5e#n141</crossRef>
       </crossRefs>

--- a/src/GPL-2.0-with-bison-exception.xml
+++ b/src/GPL-2.0-with-bison-exception.xml
@@ -2,10 +2,11 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isDeprecated="true" deprecatedVersion="2.0rc2" licenseId="GPL-2.0-with-bison-exception"
             name="GNU General Public License v2.0 w/Bison exception">
+      <obsoletedBy>GPL-2.0 WITH Bison-exception-2.2</obsoletedBy>
+      <obsoletedBy expression="GPL-2.0-with-bison-exception+">GPL-2.0-or-later WITH Bison-exception-2.2</obsoletedBy>
       <crossRefs>
          <crossRef>http://git.savannah.gnu.org/cgit/bison.git/tree/data/yacc.c?id=193d7c7054ba7197b0789e14965b739162319b5e#n141</crossRef>
       </crossRefs>
-      <notes>DEPRECATED: Use License Expression Syntax and Exceptions list to create equivalent license.</notes>
     <text>
 	     <titleText>Bison Exception</titleText>
      

--- a/src/GPL-2.0-with-classpath-exception.xml
+++ b/src/GPL-2.0-with-classpath-exception.xml
@@ -2,8 +2,10 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isDeprecated="true" deprecatedVersion="2.0rc2" licenseId="GPL-2.0-with-classpath-exception"
             name="GNU General Public License v2.0 w/Classpath exception">
-      <obsoletedBy>GPL-2.0 WITH Classpath-exception-2.0</obsoletedBy>
-      <obsoletedBy expression="GPL-2.0-with-classpath-exception+">GPL-2.0-or-later WITH Classpath-exception-2.0</obsoletedBy>
+      <obsoletedBys>
+         <obsoletedBy>GPL-2.0 WITH Classpath-exception-2.0</obsoletedBy>
+         <obsoletedBy expression="GPL-2.0-with-classpath-exception+">GPL-2.0-or-later WITH Classpath-exception-2.0</obsoletedBy>
+      </obsoletedBys>
       <crossRefs>
          <crossRef>http://www.gnu.org/software/classpath/license.html</crossRef>
       </crossRefs>

--- a/src/GPL-2.0-with-classpath-exception.xml
+++ b/src/GPL-2.0-with-classpath-exception.xml
@@ -2,10 +2,11 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isDeprecated="true" deprecatedVersion="2.0rc2" licenseId="GPL-2.0-with-classpath-exception"
             name="GNU General Public License v2.0 w/Classpath exception">
+      <obsoletedBy>GPL-2.0 WITH Classpath-exception-2.0</obsoletedBy>
+      <obsoletedBy expression="GPL-2.0-with-classpath-exception+">GPL-2.0-or-later WITH Classpath-exception-2.0</obsoletedBy>
       <crossRefs>
          <crossRef>http://www.gnu.org/software/classpath/license.html</crossRef>
       </crossRefs>
-      <notes>DEPRECATED: Use License Expression Syntax and Exceptions list to create equivalent license.</notes>
      
     <text>
 	     <p>insert GPL v2 license text here</p>

--- a/src/GPL-2.0-with-font-exception.xml
+++ b/src/GPL-2.0-with-font-exception.xml
@@ -2,8 +2,10 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isDeprecated="true" deprecatedVersion="2.0rc2" licenseId="GPL-2.0-with-font-exception"
             name="GNU General Public License v2.0 w/Font exception">
-      <obsoletedBy>GPL-2.0 WITH Font-exception-2.0</obsoletedBy>
-      <obsoletedBy expression="GPL-2.0-with-font-exception+">GPL-2.0-or-later+ WITH Font-exception-2.0</obsoletedBy>
+      <obsoletedBys>
+         <obsoletedBy>GPL-2.0 WITH Font-exception-2.0</obsoletedBy>
+         <obsoletedBy expression="GPL-2.0-with-font-exception+">GPL-2.0-or-later+ WITH Font-exception-2.0</obsoletedBy>
+      </obsoletedBys>
       <crossRefs>
          <crossRef>http://www.gnu.org/licenses/gpl-faq.html#FontException</crossRef>
       </crossRefs>

--- a/src/GPL-2.0-with-font-exception.xml
+++ b/src/GPL-2.0-with-font-exception.xml
@@ -2,10 +2,11 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isDeprecated="true" deprecatedVersion="2.0rc2" licenseId="GPL-2.0-with-font-exception"
             name="GNU General Public License v2.0 w/Font exception">
+      <obsoletedBy>GPL-2.0 WITH Font-exception-2.0</obsoletedBy>
+      <obsoletedBy expression="GPL-2.0-with-font-exception+">GPL-2.0-or-later+ WITH Font-exception-2.0</obsoletedBy>
       <crossRefs>
          <crossRef>http://www.gnu.org/licenses/gpl-faq.html#FontException</crossRef>
       </crossRefs>
-      <notes>DEPRECATED: Use License Expression Syntax and Exceptions list to create equivalent license.</notes>
      
     <text>
 	     <p>insert GPL v2 license text here</p>

--- a/src/GPL-2.0.xml
+++ b/src/GPL-2.0.xml
@@ -3,8 +3,10 @@
   <license licenseId="GPL-2.0" isOsiApproved="true"
   name="GNU General Public License v2.0 only"
   isDeprecated="true" deprecatedVersion="3.0">
-    <obsoletedBy>GPL-2.0-only</obsoletedBy>
-    <obsoletedBy expression="GPL-2.0+">GPL-2.0-or-later</obsoletedBy>
+    <obsoletedBys>
+      <obsoletedBy>GPL-2.0-only</obsoletedBy>
+      <obsoletedBy expression="GPL-2.0+">GPL-2.0-or-later</obsoletedBy>
+    </obsoletedBys>
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html</crossRef>
       <crossRef>http://www.opensource.org/licenses/GPL-2.0</crossRef>

--- a/src/GPL-2.0.xml
+++ b/src/GPL-2.0.xml
@@ -3,14 +3,12 @@
   <license licenseId="GPL-2.0" isOsiApproved="true"
   name="GNU General Public License v2.0 only"
   isDeprecated="true" deprecatedVersion="3.0">
+    <obsoletedBy>GPL-2.0-only</obsoletedBy>
+    <obsoletedBy expression="GPL-2.0+">GPL-2.0-or-later</obsoletedBy>
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html</crossRef>
       <crossRef>http://www.opensource.org/licenses/GPL-2.0</crossRef>
     </crossRefs>
-    <notes>
-      DEPRECATED: Deprecated in lieu of more
-      explicit license identifier of GPL-2.0-only
-    </notes>
     <standardLicenseHeader>
       Copyright (C) <alt name="copyright" match=".+">yyyy name of author</alt>
       <p>

--- a/src/GPL-3.0+.xml
+++ b/src/GPL-3.0+.xml
@@ -2,7 +2,9 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="GPL-3.0+" isDeprecated="true" deprecatedVersion="2.0rc2"
             name="GNU General Public License v3.0 or later">
-      <obsoletedBy>GPL-3.0-or-later</obsoletedBy>
+      <obsoletedBys>
+         <obsoletedBy>GPL-3.0-or-later</obsoletedBy>
+      </obsoletedBys>
       <crossRefs>
          <crossRef>http://www.gnu.org/licenses/gpl-3.0-standalone.html</crossRef>
          <crossRef>http://www.opensource.org/licenses/GPL-3.0</crossRef>

--- a/src/GPL-3.0+.xml
+++ b/src/GPL-3.0+.xml
@@ -2,11 +2,11 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="GPL-3.0+" isDeprecated="true" deprecatedVersion="2.0rc2"
             name="GNU General Public License v3.0 or later">
+      <obsoletedBy>GPL-3.0-or-later</obsoletedBy>
       <crossRefs>
          <crossRef>http://www.gnu.org/licenses/gpl-3.0-standalone.html</crossRef>
          <crossRef>http://www.opensource.org/licenses/GPL-3.0</crossRef>
       </crossRefs>
-	  <notes>DEPRECATED: Use the license identifier GPL-3.0-or-later</notes>
     <text>
       <titleText>
          <p>GNU GENERAL PUBLIC LICENSE 

--- a/src/GPL-3.0-with-GCC-exception.xml
+++ b/src/GPL-3.0-with-GCC-exception.xml
@@ -2,7 +2,8 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="GPL-3.0-with-GCC-exception" isDeprecated="true" deprecatedVersion="2.0rc2"
             name="GNU General Public License v3.0 w/GCC Runtime Library exception">
-	  <notes>DEPRECATED: Use License Expression Syntax and Exceptions list to create equivalent license.</notes>
+      <obsoletedBy>GPL-3.0 WITH GCC-exception-3.1</obsoletedBy>
+      <obsoletedBy expression="GPL-3.0-with-GCC-exception+">GPL-3.0-or-later WITH GCC-exception-3.1</obsoletedBy>
       <crossRefs>
          <crossRef>http://www.gnu.org/licenses/gcc-exception-3.1.html</crossRef>
       </crossRefs>

--- a/src/GPL-3.0-with-GCC-exception.xml
+++ b/src/GPL-3.0-with-GCC-exception.xml
@@ -2,8 +2,10 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="GPL-3.0-with-GCC-exception" isDeprecated="true" deprecatedVersion="2.0rc2"
             name="GNU General Public License v3.0 w/GCC Runtime Library exception">
-      <obsoletedBy>GPL-3.0 WITH GCC-exception-3.1</obsoletedBy>
-      <obsoletedBy expression="GPL-3.0-with-GCC-exception+">GPL-3.0-or-later WITH GCC-exception-3.1</obsoletedBy>
+      <obsoletedBys>
+         <obsoletedBy>GPL-3.0 WITH GCC-exception-3.1</obsoletedBy>
+         <obsoletedBy expression="GPL-3.0-with-GCC-exception+">GPL-3.0-or-later WITH GCC-exception-3.1</obsoletedBy>
+      </obsoletedBys>
       <crossRefs>
          <crossRef>http://www.gnu.org/licenses/gcc-exception-3.1.html</crossRef>
       </crossRefs>

--- a/src/GPL-3.0-with-autoconf-exception.xml
+++ b/src/GPL-3.0-with-autoconf-exception.xml
@@ -2,10 +2,11 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isDeprecated="true" deprecatedVersion="2.0rc2" licenseId="GPL-3.0-with-autoconf-exception"
             name="GNU General Public License v3.0 w/Autoconf exception">
+      <obsoletedBy>GPL-3.0 WITH Autoconf-exception-3.0</obsoletedBy>
+      <obsoletedBy expression="GPL-3.0-with-autoconf-exception+">GPL-3.0-or-later WITH Autoconf-exception-3.0</obsoletedBy>
       <crossRefs>
          <crossRef>http://www.gnu.org/licenses/autoconf-exception-3.0.html</crossRef>
       </crossRefs>
-      <notes>DEPRECATED: Use License Expression Syntax and Exceptions list to create equivalent license.</notes>
      
     <text>
 	     <p>insert GPL v3 text here</p>

--- a/src/GPL-3.0-with-autoconf-exception.xml
+++ b/src/GPL-3.0-with-autoconf-exception.xml
@@ -2,8 +2,10 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isDeprecated="true" deprecatedVersion="2.0rc2" licenseId="GPL-3.0-with-autoconf-exception"
             name="GNU General Public License v3.0 w/Autoconf exception">
-      <obsoletedBy>GPL-3.0 WITH Autoconf-exception-3.0</obsoletedBy>
-      <obsoletedBy expression="GPL-3.0-with-autoconf-exception+">GPL-3.0-or-later WITH Autoconf-exception-3.0</obsoletedBy>
+      <obsoletedBys>
+         <obsoletedBy>GPL-3.0 WITH Autoconf-exception-3.0</obsoletedBy>
+         <obsoletedBy expression="GPL-3.0-with-autoconf-exception+">GPL-3.0-or-later WITH Autoconf-exception-3.0</obsoletedBy>
+      </obsoletedBys>
       <crossRefs>
          <crossRef>http://www.gnu.org/licenses/autoconf-exception-3.0.html</crossRef>
       </crossRefs>

--- a/src/GPL-3.0.xml
+++ b/src/GPL-3.0.xml
@@ -3,14 +3,12 @@
   <license licenseId="GPL-3.0" isOsiApproved="true"
   name="GNU General Public License v3.0 only"
   isDeprecated="true" deprecatedVersion="3.0">
+    <obsoletedBy>GPL-3.0-only</obsoletedBy>
+    <obsoletedBy expression="GPL-3.0+">GPL-3.0-or-later</obsoletedBy>
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/gpl-3.0-standalone.html</crossRef>
       <crossRef>http://www.opensource.org/licenses/GPL-3.0</crossRef>
     </crossRefs>
-    <notes>
-      DEPRECATED: Deprecated in lieu of more
-      explicit license identifier of GPL-3.0-only
-    </notes>
     <standardLicenseHeader>
       Copyright (C) <alt name="copyright"
       match=".+">&lt;year&gt; &lt;name of author&gt;</alt>

--- a/src/GPL-3.0.xml
+++ b/src/GPL-3.0.xml
@@ -3,8 +3,10 @@
   <license licenseId="GPL-3.0" isOsiApproved="true"
   name="GNU General Public License v3.0 only"
   isDeprecated="true" deprecatedVersion="3.0">
-    <obsoletedBy>GPL-3.0-only</obsoletedBy>
-    <obsoletedBy expression="GPL-3.0+">GPL-3.0-or-later</obsoletedBy>
+    <obsoletedBys>
+      <obsoletedBy>GPL-3.0-only</obsoletedBy>
+      <obsoletedBy expression="GPL-3.0+">GPL-3.0-or-later</obsoletedBy>
+    </obsoletedBys>
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/gpl-3.0-standalone.html</crossRef>
       <crossRef>http://www.opensource.org/licenses/GPL-3.0</crossRef>

--- a/src/LGPL-2.0+.xml
+++ b/src/LGPL-2.0+.xml
@@ -2,7 +2,9 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="LGPL-2.0+" isDeprecated="true" deprecatedVersion="2.0rc2"
             name="GNU Library General Public License v2 or later">
-      <obsoletedBy>LGPL-2.0-or-later</obsoletedBy>
+      <obsoletedBys>
+         <obsoletedBy>LGPL-2.0-or-later</obsoletedBy>
+      </obsoletedBys>
       <crossRefs>
          <crossRef>http://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html</crossRef>
       </crossRefs>

--- a/src/LGPL-2.0+.xml
+++ b/src/LGPL-2.0+.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="LGPL-2.0+" isDeprecated="true" deprecatedVersion="2.0rc2"
             name="GNU Library General Public License v2 or later">
-	  <notes>DEPRECATED: Use the license identifier LGPL-2.0-or-later</notes>
+      <obsoletedBy>LGPL-2.0-or-later</obsoletedBy>
       <crossRefs>
          <crossRef>http://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html</crossRef>
       </crossRefs>

--- a/src/LGPL-2.0.xml
+++ b/src/LGPL-2.0.xml
@@ -3,13 +3,11 @@
   <license licenseId="LGPL-2.0" isOsiApproved="true"
   name="GNU Library General Public License v2 only"
   isDeprecated="true" deprecatedVersion="3.0">
+    <obsoletedBy>LGPL-2.0-only</obsoletedBy>
+    <obsoletedBy expression="LGPL-2.0+">LGPL-2.0-or-later</obsoletedBy>
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html</crossRef>
     </crossRefs>
-    <notes>
-      DEPRECATED: Deprecated in lieu of more
-      explicit license identifier of LGPL-2.0-only
-    </notes>
     <standardLicenseHeader>
       Copyright (C) <alt name="copyright" match=".+">year name of author</alt>
       This library is free software; you can redistribute it and/or modify it

--- a/src/LGPL-2.0.xml
+++ b/src/LGPL-2.0.xml
@@ -3,8 +3,10 @@
   <license licenseId="LGPL-2.0" isOsiApproved="true"
   name="GNU Library General Public License v2 only"
   isDeprecated="true" deprecatedVersion="3.0">
-    <obsoletedBy>LGPL-2.0-only</obsoletedBy>
-    <obsoletedBy expression="LGPL-2.0+">LGPL-2.0-or-later</obsoletedBy>
+    <obsoletedBys>
+      <obsoletedBy>LGPL-2.0-only</obsoletedBy>
+      <obsoletedBy expression="LGPL-2.0+">LGPL-2.0-or-later</obsoletedBy>
+    </obsoletedBys>
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html</crossRef>
     </crossRefs>

--- a/src/LGPL-2.1+.xml
+++ b/src/LGPL-2.1+.xml
@@ -2,7 +2,9 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="LGPL-2.1+"  isDeprecated="true" deprecatedVersion="2.0rc2"
             name="GNU Library General Public License v2.1 or later">
-      <obsoletedBy>LGPL-2.1-or-later</obsoletedBy>
+      <obsoletedBys>
+         <obsoletedBy>LGPL-2.1-or-later</obsoletedBy>
+      </obsoletedBys>
       <crossRefs>
          <crossRef>http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</crossRef>
          <crossRef>http://www.opensource.org/licenses/LGPL-2.1</crossRef>

--- a/src/LGPL-2.1+.xml
+++ b/src/LGPL-2.1+.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="LGPL-2.1+"  isDeprecated="true" deprecatedVersion="2.0rc2"
             name="GNU Library General Public License v2.1 or later">
-	  <notes>DEPRECATED: Use the license identifier LGPL-2.1-or-later</notes>
+      <obsoletedBy>LGPL-2.1-or-later</obsoletedBy>
       <crossRefs>
          <crossRef>http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</crossRef>
          <crossRef>http://www.opensource.org/licenses/LGPL-2.1</crossRef>

--- a/src/LGPL-2.1.xml
+++ b/src/LGPL-2.1.xml
@@ -3,8 +3,10 @@
   <license licenseId="LGPL-2.1" isOsiApproved="true"
   name="GNU Lesser General Public License v2.1 only"
   isDeprecated="true" deprecatedVersion="3.0">
-    <obsoletedBy>LGPL-2.1-only</obsoletedBy>
-    <obsoletedBy expression="LGPL-2.1+">LGPL-2.1-or-later</obsoletedBy>
+    <obsoletedBys>
+      <obsoletedBy>LGPL-2.1-only</obsoletedBy>
+      <obsoletedBy expression="LGPL-2.1+">LGPL-2.1-or-later</obsoletedBy>
+    </obsoletedBys>
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</crossRef>
       <crossRef>http://www.opensource.org/licenses/LGPL-2.1</crossRef>

--- a/src/LGPL-2.1.xml
+++ b/src/LGPL-2.1.xml
@@ -3,14 +3,12 @@
   <license licenseId="LGPL-2.1" isOsiApproved="true"
   name="GNU Lesser General Public License v2.1 only"
   isDeprecated="true" deprecatedVersion="3.0">
+    <obsoletedBy>LGPL-2.1-only</obsoletedBy>
+    <obsoletedBy expression="LGPL-2.1+">LGPL-2.1-or-later</obsoletedBy>
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</crossRef>
       <crossRef>http://www.opensource.org/licenses/LGPL-2.1</crossRef>
     </crossRefs>
-    <notes>
-      DEPRECATED: Deprecated in lieu of more
-      explicit license identifier of LGPL-2.1-only
-    </notes>
     <standardLicenseHeader>
       Copyright (C) <alt name="copyright" match=".+">year name of author</alt>
       <p>

--- a/src/LGPL-3.0+.xml
+++ b/src/LGPL-3.0+.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="LGPL-3.0+"  isDeprecated="true" deprecatedVersion="2.0rc2"
             name="GNU Lesser General Public License v3.0 or later">
-	  <notes>DEPRECATED: Use the license identifier LGPL-3.0-or-later</notes>
+      <obsoletedBy>LGPL-3.0-or-later</obsoletedBy>
       <crossRefs>
          <crossRef>http://www.gnu.org/licenses/lgpl-3.0-standalone.html</crossRef>
          <crossRef>http://www.opensource.org/licenses/LGPL-3.0</crossRef>

--- a/src/LGPL-3.0+.xml
+++ b/src/LGPL-3.0+.xml
@@ -2,7 +2,9 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="LGPL-3.0+"  isDeprecated="true" deprecatedVersion="2.0rc2"
             name="GNU Lesser General Public License v3.0 or later">
-      <obsoletedBy>LGPL-3.0-or-later</obsoletedBy>
+      <obsoletedBys>
+         <obsoletedBy>LGPL-3.0-or-later</obsoletedBy>
+      </obsoletedBys>
       <crossRefs>
          <crossRef>http://www.gnu.org/licenses/lgpl-3.0-standalone.html</crossRef>
          <crossRef>http://www.opensource.org/licenses/LGPL-3.0</crossRef>

--- a/src/LGPL-3.0.xml
+++ b/src/LGPL-3.0.xml
@@ -3,8 +3,10 @@
   <license licenseId="LGPL-3.0" isOsiApproved="true"
   name="GNU Lesser General Public License v3.0 only"
   isDeprecated="true" deprecatedVersion="3.0">
-    <obsoletedBy>LGPL-3.0-only</obsoletedBy>
-    <obsoletedBy expression="LGPL-3.0+">LGPL-3.0-or-later</obsoletedBy>
+    <obsoletedBys>
+      <obsoletedBy>LGPL-3.0-only</obsoletedBy>
+      <obsoletedBy expression="LGPL-3.0+">LGPL-3.0-or-later</obsoletedBy>
+    </obsoletedBys>
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/lgpl-3.0-standalone.html</crossRef>
       <crossRef>http://www.opensource.org/licenses/LGPL-3.0</crossRef>

--- a/src/LGPL-3.0.xml
+++ b/src/LGPL-3.0.xml
@@ -3,14 +3,12 @@
   <license licenseId="LGPL-3.0" isOsiApproved="true"
   name="GNU Lesser General Public License v3.0 only"
   isDeprecated="true" deprecatedVersion="3.0">
+    <obsoletedBy>LGPL-3.0-only</obsoletedBy>
+    <obsoletedBy expression="LGPL-3.0+">LGPL-3.0-or-later</obsoletedBy>
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/lgpl-3.0-standalone.html</crossRef>
       <crossRef>http://www.opensource.org/licenses/LGPL-3.0</crossRef>
     </crossRefs>
-    <notes>
-      DEPRECATED: Deprecated in lieu of more
-      explicit license identifier of LGPL-3.0-only
-    </notes>
     <text>
     <titleText>
       <p>

--- a/src/Nunit.xml
+++ b/src/Nunit.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isDeprecated="true" deprecatedVersion="3.0" licenseId="Nunit" name="Nunit License">
-      <obsoletedBy>zlib-acknowledgement</obsoletedBy>
+      <obsoletedBys>
+         <obsoletedBy>zlib-acknowledgement</obsoletedBy>
+      </obsoletedBys>
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/Nunit</crossRef>
       </crossRefs>

--- a/src/Nunit.xml
+++ b/src/Nunit.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isDeprecated="true" deprecatedVersion="3.0" licenseId="Nunit" name="Nunit License">
+      <obsoletedBy>zlib-acknowledgement</obsoletedBy>
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/Nunit</crossRef>
       </crossRefs>
-      <notes>DEPRECATED: This license was added twice by accident. Use short identifier: zlib-acknowledgement </notes>
     <text>
       <copyrightText>
          <p>Copyright © 2002-2004 James W. Newkirk, Michael C. Two, Alexei A. Vorontsov, Charlie Poole 

--- a/src/StandardML-NJ.xml
+++ b/src/StandardML-NJ.xml
@@ -2,7 +2,9 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="false" licenseId="StandardML-NJ" isDeprecated="true" deprecatedVersion="2.0rc2"
             name="Standard ML of New Jersey License">
-      <obsoletedBy>SMLNJ</obsoletedBy>
+      <obsoletedBys>
+         <obsoletedBy>SMLNJ</obsoletedBy>
+      </obsoletedBys>
       <crossRefs>
          <crossRef>http://www.smlnj.org//license.html</crossRef>
       </crossRefs>

--- a/src/StandardML-NJ.xml
+++ b/src/StandardML-NJ.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="false" licenseId="StandardML-NJ" isDeprecated="true" deprecatedVersion="2.0rc2"
             name="Standard ML of New Jersey License">
-	  <notes>DEPRECATED: This license was added twice (as of v1.17 and then in v1.20) by accident. Use short identifier: SMLNJ</notes>
+      <obsoletedBy>SMLNJ</obsoletedBy>
       <crossRefs>
          <crossRef>http://www.smlnj.org//license.html</crossRef>
       </crossRefs>

--- a/src/eCos-2.0.xml
+++ b/src/eCos-2.0.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isDeprecated="true" deprecatedVersion="2.0rc2" licenseId="eCos-2.0" name="eCos license version 2.0">
-      <obsoletedBy>GPL-2.0-or-later WITH eCos-exception-2.0</obsoletedBy>
+      <obsoletedBys>
+          <obsoletedBy>GPL-2.0-or-later WITH eCos-exception-2.0</obsoletedBy>
+      </obsoletedBys>
       <crossRefs>
          <crossRef>http://www.gnu.org/licenses/ecos-license.html</crossRef>
       </crossRefs>

--- a/src/eCos-2.0.xml
+++ b/src/eCos-2.0.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isDeprecated="true" deprecatedVersion="2.0rc2" licenseId="eCos-2.0" name="eCos license version 2.0">
+      <obsoletedBy>GPL-2.0-or-later WITH eCos-exception-2.0</obsoletedBy>
       <crossRefs>
          <crossRef>http://www.gnu.org/licenses/ecos-license.html</crossRef>
       </crossRefs>
-      <notes>DEPRECATED: This is really GPL-2.0 or later with an exception. Use License Expression Syntax and Exceptions list to create equivalent license.</notes>
     <text>
       <titleText>The eCos license version 2.0</titleText>
      

--- a/src/wxWindows.xml
+++ b/src/wxWindows.xml
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license licenseId="wxWindows" name="wxWindows Library License"  isDeprecated="true" deprecatedVersion="2.0rc2">
+      <obsoletedBy>GPL-2.0-or-later WITH WxWindows-exception-3.1</obsoletedBy>
       <crossRefs>
          <crossRef>http://www.opensource.org/licenses/WXwindows</crossRef>
       </crossRefs>
-   <notes>
-     <p>DEPRECATED: Use License Expression Syntax and Exceptions list to create equivalent license.</p>
-     <p>Typically used with GPL-2.0+.</p>
-  </notes>
     <text>
       <p>EXCEPTION NOTICE</p>
       <list>

--- a/src/wxWindows.xml
+++ b/src/wxWindows.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license licenseId="wxWindows" name="wxWindows Library License"  isDeprecated="true" deprecatedVersion="2.0rc2">
-      <obsoletedBy>GPL-2.0-or-later WITH WxWindows-exception-3.1</obsoletedBy>
+      <obsoletedBys>
+         <obsoletedBy>GPL-2.0-or-later WITH WxWindows-exception-3.1</obsoletedBy>
+      </obsoletedBys>
       <crossRefs>
          <crossRef>http://www.opensource.org/licenses/WXwindows</crossRef>
       </crossRefs>


### PR DESCRIPTION
From [here][1] (whose source I could not find):

> As a result, a number of licenses formerly included in the SPDX License List have been deprecated as licenses, and correct usage employs the License Expression Syntax as of v2.0.

So the sole reason for the deprecations seems to be “there's a better way to say that now”.

Telling people “use an expression instead” is less useful than saying “use this expression instead: `$SOME_EXPRESSION`”.  This commit updates the eCos license (the only deprecated license currently in this repository) to do that, using the [`WITH` exception syntax][2] and the [eCos exception label][3] defined in SPDX 2.1 (and possibly in earlier versions).

This is related to spdx/tools#73, although discussion there seemed to be doubling down on a deprecated boolean.

[1]: https://spdx.org/licenses/
[2]: https://spdx.org/spdx-specification-21-web-version#h.jxpfx0ykyb60
[3]: https://spdx.org/spdx-specification-21-web-version#h.ruv3yl8g6czd