### PR TITLE
update location of license-list repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 This is a workspace for developing and implementing a new XML format for the SPDX License List.
 
 # NOT STABLE OR AUTHORITATIVE
-The files in this repo are not stable in XML structure or in substance (license text). Although they are being worked on publicly and transparently here on github, they are currently only suitable for internal use by the SPDX Legal Team and the SPDX Technical Team. Please do _not_ rely on these files just yet, and please continue to use the resources on [spdx.org](https://spdx.org/) and [git.spdx.org](http://git.spdx.org/?p=license-list.git;a=tree) instead when developing tools or ingesting license text.
+The files in this repo are not stable in XML structure or in substance (license text). Although they are being worked on publicly and transparently here on github, they are currently only suitable for internal use by the SPDX Legal Team and the SPDX Technical Team. Please do _not_ rely on these files just yet, and please continue to use the resources on [spdx.org](https://spdx.org/) and [plain license-list repo](https://github.com/spdx/license-list) instead when developing tools or ingesting license text.


### PR DESCRIPTION
Existing location no longer exists, spdx/license-list probably now current per https://spdx.org/news/news/2017/01/move-github-complete-tools (which could use a link perhaps to https://github.com/spdx but I'm not sure how the website is maintained).