### PR TITLE
src/GPL-2.0-with-*: Remove internal byte-order-mark

### DIFF
--- a/src/GPL-2.0-with-GCC-exception.xml
+++ b/src/GPL-2.0-with-GCC-exception.xml
@@ -2,7 +2,7 @@
   <notes>DEPRECATED: Use License Expression Syntax and Exceptions list to create equivalent license.</notes>
   <license>
     <body> 
-	<p>﻿insert GPL v2 license text here</p>
+	<p>insert GPL v2 license text here</p>
 	<p>GCC Linking Exception </p>
 	<p>In addition to the permissions in the GNU General Public License, the Free Software Foundation gives you unlimited permission to link the compiled version of this file into combinations with other programs, and to distribute those combinations without any restriction coming from the use of this file. (The General Public License restrictions do apply in other respects; for example, they cover modification of the file, and distribution when not linked into a combine executable.</p>
 	</body>

--- a/src/GPL-2.0-with-autoconf-exception.xml
+++ b/src/GPL-2.0-with-autoconf-exception.xml
@@ -5,7 +5,7 @@
   <notes>DEPRECATED: Use License Expression Syntax and Exceptions list to create equivalent license.</notes>
   <license>
     <body> 
-	<p>﻿insert GPL v2 license text here</p>
+	<p>insert GPL v2 license text here</p>
 	<p>Autoconf Exception</p>
 	<p>As a special exception, the Free Software Foundation gives unlimited permission to copy, distribute and modify the configure scripts that are the output of Autoconf. You need not follow the terms of the GNU General Public License when using or distributing such scripts, even though portions of the text of Autoconf appear in them. The GNU General Public License (GPL) does govern all other use of the material that constitutes the Autoconf program.</p>
 	<p>Certain portions of the Autoconf source text are designed to be copied (in certain cases, depending on the input) into the output of Autoconf. We call these the "data" portions. The rest of the Autoconf source text consists of comments plus executable code that decides which of the data portions to output in any given case. We call these comments and executable code the "non-data" portions. Autoconf never copies any of the non-data portions into its output.</p>

--- a/src/GPL-2.0-with-classpath-exception.xml
+++ b/src/GPL-2.0-with-classpath-exception.xml
@@ -5,7 +5,7 @@
   <notes>DEPRECATED: Use License Expression Syntax and Exceptions list to create equivalent license.</notes>
   <license>
     <body> 
-	<p>﻿insert GPL v2 license text here</p>
+	<p>insert GPL v2 license text here</p>
 	<p>Class Path Exception</p>
 	<p>Linking this library statically or dynamically with other modules is making a combined work based on this library. Thus, the terms and conditions of the GNU General Public License cover the whole combination.</p>
 	<p>As a special exception, the copyright holders of this library give you permission to link this library with independent modules to produce an executable, regardless of the license terms of these independent modules, and to copy and distribute the resulting executable under terms of your choice, provided that you also meet, for each linked independent module, the terms and conditions of the license of that module. An independent module is a module which is not derived from or based on this library. If you modify this library, you may extend this exception to your version of the library, but you are not obligated to do so. If you do not wish to do so, delete this exception statement from your version.</p>

--- a/src/GPL-2.0-with-font-exception.xml
+++ b/src/GPL-2.0-with-font-exception.xml
@@ -5,7 +5,7 @@
   <notes>DEPRECATED: Use License Expression Syntax and Exceptions list to create equivalent license.</notes>
   <license>
     <body> 
-	<p>﻿insert GPL v2 license text here</p>
+	<p>insert GPL v2 license text here</p>
 	<p>Font Exception</p>
 	<p>As a special exception, if you create a document which uses this font, and embed this font or unaltered portions of this font into the document, this font does not by itself cause the resulting document to be covered by the GNU General Public License. This exception does not however invalidate any other reasons why the document might be covered by the GNU General Public License. If you modify this font, you may extend this exception to your version of the font, but you are not obligated to do so. If you do not wish to do so, delete this exception statement from your version.</p>
 	</body>


### PR DESCRIPTION
Generated with:

    $ sed -i 's/\xef\xbb\xbf//' $(git ls-tree -r --name-only HEAD)

because we [don't a BOM for UTF-8][1].  And even if we did need a BOM, it would be at the beginning of the file, and not in the middle after a `<p>` tag.

[1]: http://www.unicode.org/faq/utf_bom.html#utf8-2