### PR TITLE
src/*: Add <urls> to licenses that were missing them

### DIFF
--- a/src/GPL-2.0-with-GCC-exception.xml
+++ b/src/GPL-2.0-with-GCC-exception.xml
@@ -1,4 +1,7 @@
 <SPDX name="GNU General Public License v2.0 w/GCC Runtime Library exception" identifier="GPL-2.0-with-GCC-exception" deprecated="true">
+  <urls>
+    <url>https://gcc.gnu.org/git/?p=gcc.git;a=blob;f=gcc/libgcc1.c;h=762f5143fc6eed57b6797c82710f3538aa52b40b;hb=cb143a3ce4fb417c68f5fa2691a1b1b1053dfba9#l10</url>
+  </urls>
   <notes>DEPRECATED: Use License Expression Syntax and Exceptions list to create equivalent license.</notes>
   <license>
     <body> 

--- a/src/GPL-2.0-with-bison-exception.xml
+++ b/src/GPL-2.0-with-bison-exception.xml
@@ -1,4 +1,7 @@
 <SPDX name="GNU General Public License v2.0 w/Bison exception" identifier="GPL-2.0-with-bison-exception" deprecated="true">
+  <urls>
+    <url>http://git.savannah.gnu.org/cgit/bison.git/tree/data/yacc.c?id=193d7c7054ba7197b0789e14965b739162319b5e#n141</url>
+  </urls>
   <notes>DEPRECATED: Use License Expression Syntax and Exceptions list to create equivalent license.</notes>
   <license>
 	<title>Bison Exception</title>

--- a/src/GPL-3.0-with-autoconf-exception.xml
+++ b/src/GPL-3.0-with-autoconf-exception.xml
@@ -1,5 +1,7 @@
 <SPDX name="GNU General Public License v3.0 w/Autoconf exception" identifier="GPL-3.0-with-autoconf-exception" deprecated="true">
-http://www.gnu.org/licenses/autoconf-exception-3.0.html
+  <urls>
+    <url>http://www.gnu.org/licenses/autoconf-exception-3.0.html</url>
+  </urls>
   <notes>DEPRECATED: Use License Expression Syntax and Exceptions list to create equivalent license.</notes>
   <license>
     <body> 

--- a/src/Zimbra-1.3.xml
+++ b/src/Zimbra-1.3.xml
@@ -1,5 +1,4 @@
 <spdx name="Zimbra Public License v1.3" identifier="Zimbra-1.3" osi-approved="false">
-  <urls></urls>
   <license>
     <title>
       <p>Zimbra Public License, Version 1.3 (ZPL)</p>

--- a/src/exceptions/Bison-exception-2.2.xml
+++ b/src/exceptions/Bison-exception-2.2.xml
@@ -1,5 +1,7 @@
 <SPDX name="Bison exception 2.2" identifier="Bison-exception-2.2">
-  <urls></urls>
+  <urls>
+    <url>http://git.savannah.gnu.org/cgit/bison.git/tree/data/yacc.c?id=193d7c7054ba7197b0789e14965b739162319b5e#n141</url>
+  </urls>
   <notes>Typically used with GPL-2.0 or GPL-3.0
   </notes>
   <exception>

--- a/src/exceptions/GCC-exception-2.0.xml
+++ b/src/exceptions/GCC-exception-2.0.xml
@@ -1,5 +1,7 @@
 <SPDX name="GCC Runtime Library exception 2.0" identifier="GCC-exception-2.0">
-
+  <urls>
+    <url>https://gcc.gnu.org/git/?p=gcc.git;a=blob;f=gcc/libgcc1.c;h=762f5143fc6eed57b6797c82710f3538aa52b40b;hb=cb143a3ce4fb417c68f5fa2691a1b1b1053dfba9#l10</url>
+  </urls>
   <notes>Typically used with GPL-2.0+.  Sometimes also referred to a
          "linking exception."  
   </notes>


### PR DESCRIPTION
In the GPL-3.0-with-autoconf-exception case, this is just fixing the XML markup for an existing URL.

For the other licenses and exceptions, I've found URLs for an early occurence in the original project.  Ideally these URLs are for a page about the license/exception by the license/exception author, but where that doesn't exist a link to the first known consumer seems better than nothing.

This fixes everything turned up by:

    $ grep -L '<url>' $(git ls-tree -r --name-only HEAD | grep .xml)

except for Zimbra-1.3.  The FSF has [an entry for that license][1], but they link [here][2], which Zimbra redirects to the 1.4 version:

    $ curl -I http://www.zimbra.com/license/zimbra-public-license-1-3.html
    HTTP/1.1 301 Moved Permanently
    Content-Type: text/html; charset=iso-8859-1
    Date: Fri, 09 Jun 2017 16:20:15 GMT
    Location: http://www.zimbra.com/license/zimbra-public-license-1-4.html
    …

[Zimbra's legal page only lists the 1.4 version][3], and their `robots.txt` [did not allow the Internet Archive to archive their site when they had a 1.3 version][4].

[1]: https://www.gnu.org/licenses/license-list.html#Zimbra
[2]: http://www.zimbra.com/license/zimbra-public-license-1-3.html
[3]: http://www.zimbra.com/legal/licensing/
[4]: https://web.archive.org/web/*/http://zimbra.com