### PR TITLE
src/AFL-*: Replace dead opensource.linux-mirror.org links

### DIFF
--- a/src/AFL-1.1.xml
+++ b/src/AFL-1.1.xml
@@ -1,6 +1,7 @@
 <spdx name="Academic Free License v1.1" identifier="AFL-1.1" osi-approved="true">
   <urls>
     <url>http://opensource.linux-mirror.org/licenses/afl-1.1.txt</url>
+    <url>http://wayback.archive.org/web/20021004124254/http://www.opensource.org/licenses/academic.php</url>
   </urls>
   <notes>This license has been superseded by later versions.</notes>
   <license>

--- a/src/AFL-1.2.xml
+++ b/src/AFL-1.2.xml
@@ -1,9 +1,9 @@
 <SPDX name="Academic Free License v1.2" identifier="AFL-1.2" osi-approved="true">
   <urls>
     <url>http://opensource.linux-mirror.org/licenses/afl-1.2.txt</url>
+    <url>http://wayback.archive.org/web/20021204204652/http://www.opensource.org/licenses/academic.php</url>
   </urls>
   <notes>This license has been superseded by later versions.
-  
   
     We found these notes here: https://web.archive.org/web/20100828113909/http://opensource.linux-mirror.org/licenses/afl-1.2.txt
     

--- a/src/AFL-2.0.xml
+++ b/src/AFL-2.0.xml
@@ -1,6 +1,7 @@
 <SPDX name="Academic Free License v2.0" identifier="AFL-2.0" osi-approved="true">
   <urls>
     <url>http://opensource.linux-mirror.org/licenses/afl-2.0.txt</url>
+    <url>http://wayback.archive.org/web/20060924134533/http://www.opensource.org/licenses/afl-2.0.txt</url>
   </urls>
   <license>
     <header>


### PR DESCRIPTION
That host no longer exists:

    $ ping opensource.linux-mirror.org
    ping: unknown host opensource.linux-mirror.org

It would be better to link to opensource.org, because we're claiming that these are all OSI-approved licenses.  But the OSI is not listing them on its current page ([probably an oversight][1]).  So instead I'm linking to Internet Archive pages showing the old licenses on the OSI site.

The OSI had also [approved the AFL-1.0][2], but we don't have XML for that yet (and we may never have assigned an SPDX identifier to it).

I only have the `.txt` link for the AFL-2.0, because opensource.org was [still listing AFL-1.2 on 2006-09-24][3] and had [switched to the AFL-3.0 by the next-archived academic.php in 2007-07-14][4].

[1]: https://lists.opensource.org/pipermail/license-discuss/2017-July/019922.html
[2]: http://wayback.archive.org/web/20020805135807/http://www.opensource.org/licenses/academic.php
[3]: http://wayback.archive.org/web/20060924132044/http://www.opensource.org/licenses/academic.php
[4]: http://wayback.archive.org/web/20070714181427/http://www.opensource.org/licenses/academic.php