### PR TITLE
Artistic-2.0: Remove <copyright>

### DIFF
--- a/src/Artistic-2.0.xml
+++ b/src/Artistic-2.0.xml
@@ -8,10 +8,9 @@
     <title>
       <p>The Artistic License 2.0</p>
     </title>
-    <copyright>
-      <p>Copyright (c) 2000-2006, The Perl Foundation.</p>
-    </copyright>
     <optional>
+      <p>Copyright (c) 2000-2006, The Perl Foundation.</p>
+
       <p>Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is
          not allowed.</p>
       <p>Preamble</p>


### PR DESCRIPTION
From [the wiki][1]:

> Copyright tag: denotes an optional (as per Matching Guideline 9) section of the license content, with the implication that it contains copyright notices *that apply to the code under license*; this is explicitly *not* intended to include copyright notices that apply to the license itself

The following line makes it fairly clear that this was intended to be a copyright for the license itself, so this commit removes the `<copyright>` tag.  See also @mlinksva on this point [here][2] and discussion in spdx/license-list#7 and #404.

[1]: https://wiki.spdx.org/view/Legal_Team/Templatizing/tags-matching
[2]: https://github.com/github/choosealicense.com/issues/310#issuecomment-159096032