### PR TITLE
ISC: Add <alt> tags

### DIFF
--- a/src/ISC.xml
+++ b/src/ISC.xml
@@ -8,16 +8,17 @@
       <p>ISC License:</p>
     </title>
     <copyright>
-      <p>Copyright (c) 2004-2010 by Internet Systems Consortium, Inc. ("ISC") 
-        <br/>Copyright (c) 1995-2003 by Internet Software Consortium 
+      <p>Copyright (c) <alt name="copyright" match=".+">2004-2010 by Internet Systems Consortium, Inc. ("ISC")
+        <br/>Copyright (c) 1995-2003 by Internet Software Consortium</alt>
       </p>
     </copyright>
     <body>
       <p>Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is
          hereby granted, provided that the above copyright notice and this permission notice appear in all
          copies.</p>
-      <p>THE SOFTWARE IS PROVIDED "AS IS" AND ISC DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING
-         ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL ISC BE LIABLE FOR ANY
+      <p>THE SOFTWARE IS PROVIDED "AS IS" AND <alt name="copyrightHolder" match=".+">ISC</alt> DISCLAIMS ALL
+         WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+         FITNESS. IN NO EVENT SHALL <alt name="copyrightHolderLiability" match=".+">ISC</alt> BE LIABLE FOR ANY
          SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF
          USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING
          OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.</p>

--- a/src/ISC.xml
+++ b/src/ISC.xml
@@ -13,7 +13,7 @@
       </p>
     </copyright>
     <body>
-      <p>Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is
+      <p>Permission to use, copy, modify, and<optional>/or</optional> distribute this software for any purpose with or without fee is
          hereby granted, provided that the above copyright notice and this permission notice appear in all
          copies.</p>
       <p>THE SOFTWARE IS PROVIDED "AS IS" AND <alt name="copyrightHolder" match=".+">ISC</alt> DISCLAIMS ALL


### PR DESCRIPTION
Following the [example][1] [set][2] by BSD-2-Clause, because users who are not the ISC are going to want to put their own name (or something generic like the BSD's “the copyright holders and contributors”) in those slots.  The OSI has [replaced the original “ISC” occurrences with “THE AUTHOR”][2.1] and not marked them for replacement.

I'm not sure about the naming.  I expect the values to be the same or similar for the two `copyrightHolder*` entries.  But the BSD's seem to use [different][2] [names][3] while other licenses like the MPL-1.1 seem to [reuse][4] [the][5] [same][6] [name][7].

Addresses part of spdx/license-list#7 (see also #404).

Also interesting, but probably unrelated, is that the ISC has [bumped their terminal copyright year from 2010 to 2013][8].  Presumably they're showing how the replacable text would change and are not claiming an extended copyright on the license content, because I see no changes in the license text.  I've left the terminal year alone for this commit.

[1]: https://github.com/spdx/license-list-XML/blob/2b7dd5d067561b8e27c1efbc35fc88851356edd7/src/BSD-2-Clause.xml#L10
[2]: https://github.com/spdx/license-list-XML/blob/2b7dd5d067561b8e27c1efbc35fc88851356edd7/src/BSD-2-Clause.xml#L30
[2.1]: https://opensource.org/licenses/ISC
[3]: https://github.com/spdx/license-list-XML/blob/2b7dd5d067561b8e27c1efbc35fc88851356edd7/src/BSD-2-Clause.xml#L33
[4]: https://github.com/spdx/license-list-XML/blob/2b7dd5d067561b8e27c1efbc35fc88851356edd7/src/MPL-1.1.xml#L20
[5]: https://github.com/spdx/license-list-XML/blob/2b7dd5d067561b8e27c1efbc35fc88851356edd7/src/MPL-1.1.xml#L21
[6]: https://github.com/spdx/license-list-XML/blob/2b7dd5d067561b8e27c1efbc35fc88851356edd7/src/MPL-1.1.xml#L23
[7]: https://github.com/spdx/license-list-XML/blob/2b7dd5d067561b8e27c1efbc35fc88851356edd7/src/MPL-1.1.xml#L26
[8]: https://www.isc.org/downloads/software-support-policy/isc-license/