### PR TITLE
src/*: Fix whitespace around commas (e.g. “,provided” -> “, provided”)

### DIFF
--- a/src/APSL-1.1.xml
+++ b/src/APSL-1.1.xml
@@ -6,7 +6,7 @@
   <license>
     <title>
       <p>APPLE PUBLIC SOURCE LICENSE 
-        <br/>Version 1.1 - April 19,1999 
+        <br/>Version 1.1 - April 19, 1999
       </p>
     </title>
     <optional>

--- a/src/Afmparse.xml
+++ b/src/Afmparse.xml
@@ -18,7 +18,7 @@
           <p>If the file has been modified in any way, a notice of such modification is conspicuously indicated.</p>
         </li>
       </list>
-      <p>PostScript, Display PostScript,and Adobe are registered trademarks of Adobe Systems Incorporated.</p>
+      <p>PostScript, Display PostScript, and Adobe are registered trademarks of Adobe Systems Incorporated.</p>
       <p>THE INFORMATION BELOW IS FURNISHED AS IS, IS SUBJECT TO CHANGE WITHOUT NOTICE, AND SHOULD NOT BE
          CONSTRUED AS A COMMITMENT BY ADOBE SYSTEMS INCORPORATED. ADOBE SYSTEMS INCORPORATED ASSUMES NO
          RESPONSIBILITY OR LIABILITY FOR ANY ERRORS OR INACCURACIES, MAKES NO WARRANTY OF ANY KIND (EXPRESS,

--- a/src/CC-BY-3.0.xml
+++ b/src/CC-BY-3.0.xml
@@ -218,7 +218,7 @@
                name of such party or parties; (ii) the title of the Work if supplied; (iii) to the extent
                reasonably practicable, the URI, if any, that Licensor specifies to be associated with the
                Work, unless such URI does not refer to the copyright notice or licensing information for
-               the Work; and (iv) , consistent with Section 3(b), in the case of an Adaptation, a credit
+               the Work; and (iv), consistent with Section 3(b), in the case of an Adaptation, a credit
                identifying the use of the Work in the Adaptation (e.g., &quot;French translation of the
                Work by Original Author,&quot; or &quot;Screenplay based on original Work by Original
                Author&quot;). The credit required by this Section 4 (b) may be implemented in any

--- a/src/CC-BY-SA-3.0.xml
+++ b/src/CC-BY-SA-3.0.xml
@@ -258,7 +258,7 @@
                name of such party or parties; (ii) the title of the Work if supplied; (iii) to the extent
                reasonably practicable, the URI, if any, that Licensor specifies to be associated with the
                Work, unless such URI does not refer to the copyright notice or licensing information for
-               the Work; and (iv) , consistent with <alt name="sectionTypo" match="Ss?ection">Section</alt>
+               the Work; and (iv), consistent with <alt name="sectionTypo" match="Ss?ection">Section</alt>
                3(b), in the case of an Adaptation, a credit
                identifying the use of the Work in the Adaptation (e.g., "French translation of the
                Work by Original Author," or "Screenplay based on original Work by Original

--- a/src/EPL-1.0.xml
+++ b/src/EPL-1.0.xml
@@ -195,7 +195,7 @@
                  NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each Recipient
                  is solely responsible for determining the appropriateness of using and distributing
                  the Program and assumes all risks associated with its exercise of rights under this
-                 Agreement , including but not limited to the risks and costs of program errors,
+                 Agreement, including but not limited to the risks and costs of program errors,
                  compliance with applicable laws, damage to or loss of data, programs or equipment, and
                  unavailability or interruption of operations. 
           </p>

--- a/src/EUDatagrid.xml
+++ b/src/EUDatagrid.xml
@@ -40,7 +40,7 @@
         <li>
           <b>4.</b>
           <p>You are under no obligation to provide anyone with any bug fixes, patches, upgrades or other
-             modifications, enhancements or derivatives of the features,functionality or performance of
+             modifications, enhancements or derivatives of the features, functionality or performance of
              this software that you may develop. However, if you publish or distribute your modifications,
              enhancements or derivative works without contemporaneously requiring users to enter into a
              separate written license agreement, then you are deemed to have granted participants in the EU

--- a/src/ErlPL-1.1.xml
+++ b/src/ErlPL-1.1.xml
@@ -88,7 +88,7 @@
             <li>
               <b>1.12.</b>
               <p>``You&apos;&apos; means an individual or a legal entity exercising rights under, and complying
-                 with all of the terms of, this License. For legal entities,``You&apos;&apos; includes any
+                 with all of the terms of, this License. For legal entities, ``You&apos;&apos; includes any
                  entity which controls, is controlled by, or is under common control with You. For purposes of
                  this definition, ``control&apos;&apos; means (a) the power, direct or indirect, to cause the
                  direction or management of such entity, whether by contract or otherwise, or (b) ownership of

--- a/src/FreeImage.xml
+++ b/src/FreeImage.xml
@@ -257,7 +257,7 @@
                      notice in an Executable version, related documentation or collateral in which You
                      descr ibe recipients&apos; rights relating to the Covered Code. You may distribute
                      the Executable version of Covered Code under a license of Your choice, which may
-                     contain terms different from this License,provided that You are in compliance with
+                     contain terms different from this License, provided that You are in compliance with
                      the terms of this License and that the license for the Executable version does not
                      attempt to limit or alter the recipient&apos;s rights in the Source Code version
                      from the rights set forth in this License. If You distribute the Executable

--- a/src/Multics.xml
+++ b/src/Multics.xml
@@ -22,12 +22,12 @@
          in the mid 1970s, under the leadership of Professor Fernando Jose Corbato. Users consider that Multics
          provided the best software architecture for managing computer hardware properly and for executing
          programs. Many subsequent operating systems incorporated Multics principles. Multics was distributed
-         in 1975 to 2000 by Group Bull in Europe , and in the U.S. by Bull HN Information Systems Inc., as
+         in 1975 to 2000 by Group Bull in Europe, and in the U.S. by Bull HN Information Systems Inc., as
          successor in interest by change in name only to Honeywell Bull Inc. and Honeywell Information Systems
          Inc.</p>
       </optional>
       <p>Permission to use, copy, modify, and distribute these programs and their documentation for any purpose
-         and without fee is hereby granted,provided that the below copyright notice and historical background
+         and without fee is hereby granted, provided that the below copyright notice and historical background
          appear in all copies and that both the copyright notice and historical background and this permission
          notice appear in supporting documentation, and that the names of MIT, HIS, BULL or BULL HN not be used
          in advertising or publicity pertaining to distribution of the programs without specific prior written


### PR DESCRIPTION
Changes which catch us up with the orginal:

* Afmparse's missing whitespace is not in [the original][1], which [has not changed since 2012-10-30][2].
* FreeImage's missing whitespace is not in [the original][3], which has a newline there.
* The original source for Multics is not clear, but its missing whitespace (“,provided”) is not [here][4].

Changes which diverge from the original (we may want to keep the broken version for consistency):

* APSL-1.1's missing whitespace is [also in the original][5].
* CC-BY-3.0's extra whitespace is [also in the original][6].
* CC-BY-SA-3.0's extra whitespace is [also in the original][7].
* EPL-1.0's extra whitespace is [also in the original][8].  
* EUDatagrid's missing whitespace was [not in the 2002-08-17 version of their license][10] but was [added by 2002-12-29][11].
* ErlPL-1.1 missing whitespace is also in [the original][12].
* The original source for Multics is not clear, but its extra whitespace (“Europe , ”) is also [here][4].

We have [a guideline to collapse whitespace][13], but it does not include adding whitespace where there none in the template or completely removing whitespace that is in the template.

[1]: https://fedoraproject.org/wiki/Licensing/Afmparse
[2]: https://fedoraproject.org/w/index.php?title=Licensing/Afmparse&oldid=309240
[3]: http://freeimage.sourceforge.net/freeimage-license.txt
[4]: http://web.mit.edu/multics-history/source/Multics_Internet_Server/Multics_sources.html
[5]: https://opensource.apple.com/source/IOSerialFamily/IOSerialFamily-7/APPLE_LICENSE
[6]: https://creativecommons.org/licenses/by/3.0/legalcode
[7]: https://creativecommons.org/licenses/by-sa/3.0/legalcode
[8]: http://www.eclipse.org/legal/epl-v10.html
[9]: https://opensource.org/licenses/EPL-1.0
[10]: http://wayback.archive.org/web/20020817002230/http://eu-datagrid.web.cern.ch:80/eu-datagrid/license.html
[11]: http://wayback.archive.org/web/20021229214435/http://eu-datagrid.web.cern.ch:80/eu-datagrid/license.html
[12]: http://www.erlang.org/EPLICENSE
[13]: https://spdx.org/spdx-license-list/matching-guidelines