### PR TITLE
CC-BY-SA-3.0: Add <alt> for “Ssection” typo

### DIFF
--- a/src/CC-BY-SA-3.0.xml
+++ b/src/CC-BY-SA-3.0.xml
@@ -258,7 +258,7 @@
                name of such party or parties; (ii) the title of the Work if supplied; (iii) to the extent
                reasonably practicable, the URI, if any, that Licensor specifies to be associated with the
                Work, unless such URI does not refer to the copyright notice or licensing information for
-               the Work; and (iv) , consistent with Ssection 3(b), in the case of an Adaptation, a credit
+               the Work; and (iv) , consistent with <alt name="sectionTypo" match="Ss?ection">Section</alt> 3(b), in the case of an Adaptation, a credit
                identifying the use of the Work in the Adaptation (e.g., &quot;French translation of the
                Work by Original Author,&quot; or &quot;Screenplay based on original Work by Original
                Author&quot;). The credit required by this Section 4(c) may be implemented in any


### PR DESCRIPTION
The typo exists in [the original][1], so instead of just fixing it, I'm using an `<alt>` entry.  That allows us to match both the original and the fixed version.

[1]: https://creativecommons.org/licenses/by-sa/3.0/legalcode