### PR TITLE
EUDatagrid: Remove/replace curly quotes

### DIFF
--- a/src/EUDatagrid.xml
+++ b/src/EUDatagrid.xml
@@ -26,14 +26,14 @@
         <li>
           <b>2.</b>
           <p>The user documentation, if any, included with a redistribution, must include the following notice: 
-            <br/>“"This product includes software developed by the EU DataGrid (http://www.eu-datagrid.org/)." 
+            <br/>"This product includes software developed by the EU DataGrid (http://www.eu-datagrid.org/)." 
           </p>
           <p>Alternatively, if that is where third-party acknowledgments normally appear, this acknowledgment
              must be reproduced in the software itself.</p>
         </li>
         <li>
           <b>3.</b>
-          <p>The names "EDG", "EDG Toolkit", “EU DataGrid” and "EU DataGrid Project" may not be used to
+          <p>The names "EDG", "EDG Toolkit", "EU DataGrid" and "EU DataGrid Project" may not be used to
              endorse or promote software, or products derived therefrom, except with prior written
              permission by hep-project-grid-edg-license@cern.ch.</p>
         </li>


### PR DESCRIPTION
The straight quotes were part of [early drafts][1], but when the “EU DataGrid” entry was added (between [2002-06-25][1] and [2002-08-17][2]) it came in with curly quotes, which remained through the [first non-draft version archived by the Internet Archive][3].  Our [matching guidelines][4] suggest that all quotes are equivalent, so I've changed
to straight quotes for internal consistency.

The (duplicated) curly quotes opening the notice are in neither the [first archived non-draft version][3] nor the [earlier][1] [drafts][2], so I've just dropped them.

[1]: http://wayback.archive.org/web/20020625131338/http://eu-datagrid.web.cern.ch/eu-datagrid/license.html
[2]: http://wayback.archive.org/web/20020817002230/http://eu-datagrid.web.cern.ch/eu-datagrid/license.html
[3]: http://wayback.archive.org/web/20021229214435/http://eu-datagrid.web.cern.ch:80/eu-datagrid/license.html
[4]: https://spdx.org/spdx-license-list/matching-guidelines