### PR TITLE
FTL: Replace dead freetype.fis.uniroma2.it and remove <copyright>

### DIFF
--- a/src/FTL.xml
+++ b/src/FTL.xml
@@ -1,6 +1,7 @@
 <SPDX name="Freetype Project License" identifier="FTL" osi-approved="false">
   <urls>
     <url>http://freetype.fis.uniroma2.it/FTL.TXT</url>
+    <url>http://git.savannah.gnu.org/cgit/freetype/freetype2.git/tree/docs/FTL.TXT</url>
   </urls>
   <notes>This license was released 27 Jan 2006</notes>
   <license>

--- a/src/FTL.xml
+++ b/src/FTL.xml
@@ -9,10 +9,8 @@
       <p>The FreeType Project LICENSE</p>
       <p>2006-Jan-27</p>
     </title>
-    <copyright>
-      <p>Copyright 1996-2002, 2006 by David Turner, Robert Wilhelm, and Werner Lemberg</p>
-    </copyright>
     <optional>
+      <p>Copyright 1996-2002, 2006 by David Turner, Robert Wilhelm, and Werner Lemberg</p>
       <p>Introduction</p>
       <p>The FreeType Project is distributed in several archive packages; some of them may contain, in addition to
          the FreeType font engine, various tools and contributions which rely on, or relate to, the FreeType


### PR DESCRIPTION
Cleanups for the just-landed #78.

That host no longer exists:

    $ ping freetype.fis.uniroma2.it
    ping: unknown host freetype.fis.uniroma2.it

The Savannah link I'm using comes from [here][1], so it's probably a good choice for a canonical URL, despite being a floating link into a Git archive.

I've removed the `<copyright>` tag, shifting the copyright line into the `<optional>` section, because the line seems to [apply to the license itself][1.5].  For example, see [here][2], where the bumped `FTL.TXT` copyright does not include 2004 but the bumped `README` copyright does.  Regardless of the author intentions, the remainder of the FTL "license" is clearly FreeType-specific, including a contact section.  So it seems very unlikely that another project would use the same license and only replace the line formerly contained within `<copyright>`.

[1]: https://www.freetype.org/license.html
[1.5]: https://wiki.spdx.org/view/Legal_Team/Templatizing/tags-matching
[2]: http://git.savannah.gnu.org/cgit/freetype/freetype2.git/commit/?id=68a15ebbe4f61999368a72a2953e257513a3cbba