### PR TITLE
OSET-PL-2.1: Add <alt> for "cross- claims" and missing "does not grant any rights in the trademarks" line

### DIFF
--- a/src/OSET-PL-2.1.xml
+++ b/src/OSET-PL-2.1.xml
@@ -222,7 +222,8 @@
 		      <b>c.</b> <p>under Patent Claims infringed by Covered
 		Software in the absence of its Contributions.</p>
               </li>
-            </list>  
+            </list>
+            <p>This License does not grant any rights in the trademarks, service marks, or logos of any Contributor (except as may be necessary to comply with the notice requirements in Section 3.4).</p>
         </li>
         <li>
 		  <b>2.4</b> <p>Subsequent Licenses<br/>

--- a/src/OSET-PL-2.1.xml
+++ b/src/OSET-PL-2.1.xml
@@ -390,7 +390,7 @@
 		  <b>5.2</b> <p>Patent Infringement Claims<br/>
 			  If You initiate litigation against any entity by asserting
 			  a patent infringement claim (excluding declaratory judgment actions,
-			  counter-claims, and cross- claims) alleging that a Contributor Version
+			  counter-claims, and cross-<alt name="extraSpace" match=" ?"></alt>claims) alleging that a Contributor Version
 			  directly or indirectly infringes any patent,
 			  then the rights granted to You by any and all Contributors
 			  for the Covered Software under Section 2.1 of this License


### PR DESCRIPTION
The extra space is part of the [upstream HTML][1]:

    $ curl -s http://www.osetfoundation.org/public-license | sed -n 's/.*\([^ ]* cross- claims[^ ]*\).*/\1/p'
    and cross- claims</i>)

although they also have an appropriately space-less version in section 8:

    $ curl -s http://www.osetfoundation.org/public-license | sed -n 's/.*\([^ ]* cross-claims[^ ]*\).*/\1/p'
    bring cross-claims

Their [text version][2] uses the appropriately space-less version in both places:

    $ curl -sL http://www.osetfoundation.org/s/OPL_v21-plain.txt | grep 'cross- *claims'
    … counter-claims, and cross-claims) alleging…
    … bring cross-claims or counter-claims.

I've used an `<alt>` entry to allow both the appropriately space-less version (which I've set as canonical) and the upstream HTML typo'ed version.

The missing “…does not grant any rights in the trademarks …” line is in both the upstream [HTML][1] and [text][2] versions.

Follow-ups to #378.

[1]: http://www.osetfoundation.org/public-license
[2]: http://www.osetfoundation.org/s/OPL_v21-plain.txt
