### PR TITLE
Adobe-Glyph: Use <alt> instead of <optional> for Ê

### DIFF
--- a/src/Adobe-Glyph.xml
+++ b/src/Adobe-Glyph.xml
@@ -28,8 +28,8 @@
       <p>Adobe shall not be liable to any party for any loss of revenue or profit or for indirect, incidental,
          special, consequential, or other similar damages, whether based on tort (including without limitation
          negligence or strict liability), contract or other legal or equitable grounds even if Adobe has been
-         advised or had reason to know of the possibility of such damages.<optional>Ê</optional> The Adobe 
-         materials are provided on an "AS IS" basis.<optional>Ê</optional> Adobe specifically disclaims all 
+         advised or had reason to know of the possibility of such damages.<alt name="eCircumflex1" match="Ê?"></alt> The Adobe
+         materials are provided on an "AS IS" basis.<alt name="eCircumflex2" match="Ê?"></alt> Adobe specifically disclaims all
          express, statutory, or implied warranties relating to the Adobe materials, including but not limited 
          to those concerning merchantability or fitness for a particular purpose or non-infringement of any
          third party rights regarding the Adobe materials.</p>


### PR DESCRIPTION
The SPDX legal team [decided to make these optional on 2016-05-12][1].  The [Fedora wiki][1.1] ([linked from `urls.url`][1.2]) has them, although the provenance of that content is [unclear to me][2].  But the characters are not in [the agl-specification repo][3] which is presumably canonical because [Adobe links to it][4] and [an Adobe employee is the only contributor][5].

The `<alt>` approach lets us make the non-Ê form canonical, while still matching licenses that include Ês.

Spun off from [here][6].

[1]: https://github.com/spdx/license-list-XML/pull/265#issuecomment-218835260
[1.1]: https://fedoraproject.org/wiki/Licensing/MIT#AdobeGlyph
[1.2]: https://github.com/spdx/license-list-XML/blob/0447528f2b835addd4c5ca38d319f44131887416/src/Adobe-Glyph.xml#L3
[2]: https://fedoraproject.org/w/index.php?title=Licensing%3AMIT&diff=47840&oldid=40703
[3]: https://github.com/adobe-type-tools/agl-specification/blame/b3e00bd2b2e65c70be034043a5fe7942a3f2b126/README.md#L13
[4]: https://www.adobe.com/devnet/font.html
[5]: https://github.com/adobe-type-tools/agl-specification/graphs/contributors
[6]: https://github.com/spdx/license-list-XML/pull/265#issuecomment-319144524