### PR TITLE
Condor-1.1:  Add <alt> for "royalty- free" and use wayback URL

### DIFF
--- a/src/Condor-1.1.xml
+++ b/src/Condor-1.1.xml
@@ -56,7 +56,7 @@
           <b>5.</b>
           <p>To the extent that patent claims licensable by the University of Wisconsin-Madison are
              necessarily infringed by the use or sale of the Software, you are granted a non-exclusive,
-             worldwide, royalty- free perpetual license under such patent claims, with the rights for you
+             worldwide, royalty-<alt name="extraSpace" match=" ?"></alt>free perpetual license under such patent claims, with the rights for you
              to make, use, sell, offer to sell, import and otherwise transfer the Software in source code
              and object code form and derivative works. This patent license shall apply to the combination
              of the Software with other software if, at the time the Software is added by you, such

--- a/src/Condor-1.1.xml
+++ b/src/Condor-1.1.xml
@@ -1,6 +1,7 @@
 <SPDX name="Condor Public License v1.1" identifier="Condor-1.1" osi-approved="false">
   <urls>
     <url>http://research.cs.wisc.edu/condor/license.html#condor</url>
+    <url>http://web.archive.org/web/20111123062036/http://research.cs.wisc.edu/condor/license.html#condor</url>
   </urls>
   <notes>This license was released 30 October 2003</notes>
   <license>


### PR DESCRIPTION
The extra space is part of the upstream HTML:

```
$ curl -s http://web.archive.org/web/20121029030238/http://research.cs.wisc.edu/condor/license.html | grep -A1 'royalty-$'
   the Software, you are granted a non-exclusive, worldwide, royalty-
   free perpetual license under such patent claims, with the rights
```

I've used an `<alt>` entry to allow both the appropriately space-less version (which I've set as canonical) and the upstream typo'ed version.

The new URL is because the old link redirects to the HTCondor license page:

```
$ curl -sI http://research.cs.wisc.edu/condor/license.html
HTTP/1.1 301 Moved Permanently
Date: Thu, 03 Aug 2017 17:54:54 GMT
Server: Apache
Location: http://research.cs.wisc.edu/htcondor/license.html
Content-Type: text/html; charset=iso-8859-1
```

which does not contain the old Condor 1.1 license.  Walking the archives for the non-HT page, the Condor 1.1 license is [still listed in 2012-10-29][1] but the [next archived result for that page on 2016-05-14 is the 301 redirect][2].

[1]: http://web.archive.org/web/20121029030238/http://research.cs.wisc.edu/condor/license.html
[2]: http://web.archive.org/web/20160514123949/http://research.cs.wisc.edu/condor/license.html