### PR TITLE
RPL-1.5: Add <alt> for "royalty- free"

### DIFF
--- a/src/RPL-1.5.xml
+++ b/src/RPL-1.5.xml
@@ -199,7 +199,7 @@
         <li>
           <b>4.0</b>
           <p>Grant of License From Contributor. By application of the provisions in Section 6 below, each
-             Contributor hereby grants You a world-wide, royalty- free, non-exclusive license, subject to
+             Contributor hereby grants You a world-wide, royalty-<alt name="extraSpace" match=" ?"></alt>free, non-exclusive license, subject to
              said Contributor's intellectual property rights, and any third party intellectual property
              claims derived from the Licensed Software under this License, to do the following:</p>
       <list>


### PR DESCRIPTION
I have been unable to find an upstream URL for this license on technicalpursuit.com, even after [searching the Internet Archives][1].  But the [version submitted to the OSI by William J. Edney (using a technicalpursuit.com email address)][2] contains the [presumably canonical text in an attachment][3].  That attachment is using the hyphen to wrap lines:

```
$ curl -s https://lists.opensource.org/pipermail/license-discuss/attachments/20070724/6944e582/attachment.txt | dos2unix | grep -A1 'royalty-$'
Section 6 below, each Contributor hereby grants You a world-wide, royalty-
free, non-exclusive license, subject to said Contributor's intellectual
```

But when we unwrap those lines, we should not have injected a space.  I've used an `<alt>` entry to allow both the appropriately space-less version (which I've set as canonical) and our old typo'ed version.

[1]: https://web.archive.org/web/*/technicalpursuit.com/*
[2]: https://lists.opensource.org/pipermail/license-discuss/2007-July/013075.html
[3]: https://lists.opensource.org/pipermail/license-discuss/attachments/20070724/6944e582/attachment.txt