### PR TITLE
format-xml: Add a script for pretty-printing our XML source

### DIFF
--- a/bin/format-xml.py
+++ b/bin/format-xml.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+#
+# Pretty-print JSON, ordering attributes, stripping trailing
+# whitespace, nesting tags, etc.  This does not adjust the indenting
+# *within* text sections; you get to do that on your own.
+#
+# usage: ./bin/format-xml.py PATH...
+#
+# You can pass multiple PATHs to a single invocation, in which case
+# the script will format each PATH.  When PATH is a directory, the
+# script will recurse through its contents, formating every file which
+# ends in '.xml'.
+#
+# This script depends on LXML (http://lxml.de/)
+#
+# Script licensed under SPDX-License-Identifier: MIT
+
+import os
+import re
+import sys
+from lxml import etree
+
+
+_PARSER = etree.XMLParser(
+    ns_clean=True,
+    remove_blank_text=True,
+    remove_comments=True,
+    remove_pis=True,
+)
+
+
+def format_xml(path):
+    if os.path.isdir(path):
+        for dirpath, _, filenames in os.walk(path):
+            for filename in filenames:
+                if filename.endswith('.xml'):
+                    format_xml(path=os.path.join(dirpath, filename))
+        return
+    with open(path, 'r') as f:
+        original_content = f.read()
+    content = original_content.replace('\t', ' ')
+    tree = etree.fromstring(content, parser=_PARSER)
+    content = etree.tostring(tree, encoding='unicode', pretty_print=True)
+    content = re.sub(r'\s+$', '', content, flags=re.MULTILINE)
+    if content != original_content:
+        with open(path, 'wb') as f:
+            f.write(content.encode('UTF-8'))
+            f.write('\n'.encode('UTF-8'))
+
+
+if __name__ == '__main__':
+    for path in sys.argv[1:]:
+        format_xml(path=path)


### PR DESCRIPTION
Using [Python][1], because I'm familiar with it, and I've floated a Python script for spdx-spec in spdx/spdx-spec#10.  I'm not sure which tools/languages other license-list maintainers are familiar with.

Also using [LXML][2], since it's popular for XML editing within Python.

If you run this script on our current master, you get a lot of changes:

```
$ ./bin/format-xml.py src
$ git --no-pager diff --shortstat
 270 files changed, 16593 insertions(+), 16945 deletions(-)
```

I've left those changes off this PR for now while we discuss the feasability of this approach, but I can push them up publically somewhere else if folks want to browse them without running the script locally.

This is laying the ground-work for automatically manipulating our XML, e.g. converting to `<bullet>` (#414).

[1]: https://www.python.org/
[2]: http://lxml.de/