### PR TITLE
Sendmail: Add an Internet Archive link

### DIFF
--- a/src/Sendmail.xml
+++ b/src/Sendmail.xml
@@ -1,6 +1,7 @@
 <SPDX name="Sendmail License" identifier="Sendmail" osi-approved="false">
   <urls>
     <url>http://www.sendmail.com/pdfs/open_source/sendmail_license.pdf</url>
+    <url>https://web.archive.org/web/20160322142305/https://www.sendmail.com/pdfs/open_source/sendmail_license.pdf</url>
   </urls>
   <license>
     <title>


### PR DESCRIPTION
The old URL currently redirects to a page that no longer contains the license text:

    $ curl -sIL http://www.sendmail.com/pdfs/open_source/sendmail_license.pdf | grep -i '^HTTP\|^location'
    HTTP/1.1 301 Moved Permanently
    Location: https://www.sendmail.com/pdfs/open_source/sendmail_license.pdf
    HTTP/2 302
    location: https://www.proofpoint.com/us/products/sendmail-sentrion/
    HTTP/2 301
    location: https://www.proofpoint.com/us/products/sendmail-sentrion
    HTTP/2 301
    location: https://www.proofpoint.com/us/products/mail-routing-agent
    HTTP/2 200

It's possible that the license text is somewhere on www.proofpoint.com, but if so neither Google nor I could find it.  The link I've used is the most recent to include the license text.  The Internet Archive's next access [on 2017-07-07 20:23:32 UTC resulted in a 302 redirect to the sendmail-sentrion/ URL][1].

I'd prefer to remove the old URL, but while we still don't have an official policy on that (#433), my previous attempts to replace dead links were [met with suggestions to add Internet Archive links while keeping the the known-dead links without special markup][3].

[1]: https://web.archive.org/web/20170707202332/https://www.sendmail.com/pdfs/open_source/sendmail_license.pdf
[3]: https://github.com/spdx/license-list-XML/issues/433#issuecomment-329582571