### PR TITLE
all CECILL licenses in English! 

### DIFF
--- a/src/CECILL-2.0.xml
+++ b/src/CECILL-2.0.xml
@@ -1,0 +1,644 @@
+<SPDX name="CeCILL Free Software License Agreement v2.0" identifier="CECILL-2.0" osi-approved="false">
+  <urls>
+    <url>http://www.cecill.info/licences/Licence_CeCILL_V2-en.html</url>
+  </urls>
+  <notes>
+French translation can be found here: http://www.cecill.info/licences/Licence_CeCILL_V2-fr.html
+  </notes>
+  <license>
+    <title>
+      <p>
+CeCILL FREE SOFTWARE LICENSE AGREEMENT
+      </p>
+    </title>
+    <optional>
+      <p>
+Notice
+      </p>
+      <p>
+This Agreement is a Free Software license agreement that is the result of discussions between its authors in order to ensure compliance with the two main principles guiding its drafting:
+      </p>
+      <list>
+        <li>
+          <b>*</b>
+          <p>
+firstly, compliance with the principles governing the distribution of Free Software: access to source code, broad rights granted to users,
+          </p>
+        </li>
+        <li>
+          <b>*</b>
+          <p>
+secondly, the election of a governing law, French law, with which it is conformant, both as regards the law of torts and intellectual property law, and the protection that it offers to both authors and holders of the economic rights over software.
+          </p>
+        </li>
+      </list>
+      <p>
+The authors of the CeCILL (for Ce[a] C[nrs] I[nria] L[ogiciel] L[ibre]) license are:
+      </p>
+      <list>
+        <li>
+          <p>
+Commissariat à l'Energie Atomique - CEA, a public scientific, technical and industrial research establishment, having its principal place of business at 25 rue Leblanc, immeuble Le Ponant D, 75015 Paris, France.
+          </p>
+        </li>
+        <li>
+          <p>
+Centre National de la Recherche Scientifique - CNRS, a public scientific and technological establishment, having its principal place of business at 3 rue Michel-Ange, 75794 Paris cedex 16, France.
+          </p>
+        </li>
+        <li>
+          <p>
+Institut National de Recherche en Informatique et en Automatique - INRIA, a public scientific and technological establishment, having its principal place of business at Domaine de Voluceau, Rocquencourt, BP 105, 78153 Le Chesnay cedex, France.
+          </p>
+        </li>
+      </list>
+    </optional>
+    <list>
+      <li>
+        <b>Preamble</b>
+          <p>
+The purpose of this Free Software license agreement is to grant users the right to modify and redistribute the software governed by this license within the framework of an open source distribution model.
+          </p>
+          <p>
+The exercising of these rights is conditional upon certain obligations for users so as to preserve this status for all subsequent redistributions.
+          </p>
+          <p>
+In consideration of access to the source code and the rights to copy, modify and redistribute granted by the license, users are provided only with a limited warranty and the software's author, the holder of the economic rights, and the successive licensors only have limited liability.
+          </p>
+          <p>
+In this respect, the risks associated with loading, using, modifying and/or developing or reproducing the software by the user are brought to the user's attention, given its Free Software status, which may make it complicated to use, with the result that its use is reserved for developers and experienced professionals having in-depth computer knowledge. Users are therefore encouraged to load and test the suitability of the software as regards their requirements in conditions enabling the security of their systems and/or data to be ensured and, more generally, to use and operate it in the same conditions of security. This Agreement may be freely reproduced and published, provided it is not altered, and that no provisions are either added or removed herefrom.
+          </p>
+          <p>
+This Agreement may apply to any or all software for which the holder of the economic rights decides to submit the use thereof to its provisions.
+          </p>
+      </li>
+      <li>
+        <b>Article 1 -</b>
+      <p>
+        DEFINITIONS
+      </p>
+      <p>
+For the purpose of this Agreement, when the following expressions commence with a capital letter, they shall have the following meaning:
+      </p>
+      <list>
+        <li>
+          <p>
+Agreement: means this license agreement, and its possible subsequent versions and annexes.
+          </p>
+        </li>
+        <li>
+          <p>
+Software: means the software in its Object Code and/or Source Code form and, where applicable, its documentation, "as is" when the Licensee accepts the Agreement.
+          </p>
+        </li>
+        <li>
+          <p>
+Initial Software: means the Software in its Source Code and possibly its Object Code form and, where applicable, its documentation, "as is" when it is first distributed under the terms and conditions of the Agreement.
+          </p>
+        </li>
+        <li>
+          <p>
+Modified Software: means the Software modified by at least one Contribution.
+          </p>
+        </li>
+        <li>
+          <p>
+Source Code: means all the Software's instructions and program lines to which access is required so as to modify the Software.
+          </p>
+        </li>
+        <li>
+          <p>
+Object Code: means the binary files originating from the compilation of the Source Code.
+          </p>
+        </li>
+        <li>
+          <p>
+Holder: means the holder(s) of the economic rights over the Initial Software.
+          </p>
+        </li>
+        <li>
+          <p>
+Licensee: means the Software user(s) having accepted the Agreement.
+          </p>
+        </li>
+        <li>
+          <p>
+Contributor: means a Licensee having made at least one Contribution.
+          </p>
+        </li>
+        <li>
+          <p>
+Licensor: means the Holder, or any other individual or legal entity, who distributes the Software under the Agreement.
+          </p>
+        </li>
+        <li>
+          <p>
+Contribution: means any or all modifications, corrections, translations, adaptations and/or new functions integrated into the Software by any or all Contributors, as well as any or all Internal Modules.
+          </p>
+        </li>
+        <li>
+          <p>
+Module: means a set of sources files including their documentation that enables supplementary functions or services in addition to those offered by the Software.
+          </p>
+        </li>
+        <li>
+          <p>
+External Module: means any or all Modules, not derived from the Software, so that this Module and the Software run in separate address spaces, with one calling the other when they are run.
+          </p>
+        </li>
+        <li>
+          <p>
+Internal Module: means any or all Module, connected to the Software so that they both execute in the same address space.
+          </p>
+        </li>
+        <li>
+          <p>
+GNU GPL: means the GNU General Public License version 2 or any subsequent version, as published by the Free Software Foundation Inc.
+          </p>
+        </li>
+        <li>
+          <p>
+Parties: mean both the Licensee and the Licensor.
+          </p>
+        </li>
+      </list>
+      <p>
+These expressions may be used both in singular and plural form.
+      </p>
+      </li>
+      <li>
+        <b>Article 2 -</b>
+      <p>
+PURPOSE
+      </p>
+      <p>
+The purpose of the Agreement is the grant by the Licensor to the Licensee of a non-exclusive, transferable and worldwide license for the Software as set forth in Article 5 hereinafter for the whole term of the protection granted by the rights over said Software. 
+      </p>
+      </li>
+      <li>
+        <b>Article 3 -</b>
+      <p>
+ACCEPTANCE
+      </p>
+      <list>
+        <li>
+          <b>3.1</b>
+          <p>
+The Licensee shall be deemed as having accepted the terms and conditions of this Agreement upon the occurrence of the first of the following events:
+          </p>
+          <list>
+            <li>
+              <b>(i)</b>
+              <p>
+loading the Software by any or all means, notably, by downloading from a remote server, or by loading from a physical medium;
+              </p>
+            </li>
+            <li>
+              <b>(ii)</b>
+              <p>
+the first time the Licensee exercises any of the rights granted hereunder.
+              </p>
+            </li>
+          </list>
+        </li>
+        <li>
+          <b>3.2</b>
+          <p>
+One copy of the Agreement, containing a notice relating to the characteristics of the Software, to the limited warranty, and to the fact that its use is restricted to experienced users has been provided to the Licensee prior to its acceptance as set forth in Article 3.1 hereinabove, and the Licensee hereby acknowledges that it has read and understood it.
+          </p>
+        </li>
+      </list>
+      </li>
+      <li>
+        <b>Article 4 -</b>
+      <p>
+EFFECTIVE DATE AND TERM
+      </p>
+      <list>
+        <li>
+          <b>4.1</b>
+          <p>
+EFFECTIVE DATE
+          </p>
+          <p>
+The Agreement shall become effective on the date when it is accepted by the Licensee as set forth in Article 3.1.
+          </p>
+        </li>
+        <li>
+          <b>4.2</b>
+          <p>
+TERM
+          </p>
+          <p>
+The Agreement shall remain in force for the entire legal term of protection of the economic rights over the Software.
+          </p>
+        </li>
+      </list>
+      </li>
+      <li>
+        <b>Article 5 -</b>
+      <p>
+SCOPE OF RIGHTS GRANTED
+      </p>
+      <p>
+The Licensor hereby grants to the Licensee, who accepts, the following rights over the Software for any or all use, and for the term of the Agreement, on the basis of the terms and conditions set forth hereinafter.
+      </p>
+      <p>
+Besides, if the Licensor owns or comes to own one or more patents protecting all or part of the functions of the Software or of its components, the Licensor undertakes not to enforce the rights granted by these patents against successive Licensees using, exploiting or modifying the Software. If these patents are transferred, the Licensor undertakes to have the transferees subscribe to the obligations set forth in this paragraph.
+      </p>
+      <list>
+        <li>
+          <b>5.1</b>
+          <p>
+RIGHT OF USE
+          </p>
+          <p>
+The Licensee is authorized to use the Software, without any limitation as to its fields of application, with it being hereinafter specified that this comprises:
+          </p>
+          <list>
+            <li>
+              <b>1.</b>
+              <p>
+permanent or temporary reproduction of all or part of the Software by any or all means and in any or all form.
+              </p>
+            </li>
+            <li>
+              <b>2.</b>
+              <p>
+loading, displaying, running, or storing the Software on any or all medium.
+              </p>
+            </li>
+            <li>
+              <b>3.</b>
+              <p>
+entitlement to observe, study or test its operation so as to determine the ideas and principles behind any or all constituent elements of said Software. This shall apply when the Licensee carries out any or all loading, displaying, running, transmission or storage operation as regards the Software, that it is entitled to carry out hereunder.
+              </p>
+            </li>
+          </list>
+        </li>
+        <li>
+          <b>5.2</b>
+          <p>
+ENTITLEMENT TO MAKE CONTRIBUTIONS
+          </p>
+          <p>
+The right to make Contributions includes the right to translate, adapt, arrange, or make any or all modifications to the Software, and the right to reproduce the resulting software.
+          </p>
+          <p>
+The Licensee is authorized to make any or all Contributions to the Software provided that it includes an explicit notice that it is the author of said Contribution and indicates the date of the creation thereof.
+          </p>
+        </li>
+        <li>
+          <b>5.3</b>
+          <p>
+RIGHT OF DISTRIBUTION
+          </p>
+          <p>
+In particular, the right of distribution includes the right to publish, transmit and communicate the Software to the general public on any or all medium, and by any or all means, and the right to market, either in consideration of a fee, or free of charge, one or more copies of the Software by any means.
+          </p>
+          <p>
+The Licensee is further authorized to distribute copies of the modified or unmodified Software to third parties according to the terms and conditions set forth hereinafter.
+          </p>
+          <list>
+            <li>
+              <b>5.3.1.</b>
+              <p>
+DISTRIBUTION OF SOFTWARE WITHOUT MODIFICATION
+              </p>
+              <p>
+The Licensee is authorized to distribute true copies of the Software in Source Code or Object Code form, provided that said distribution complies with all the provisions of the Agreement and is accompanied by:
+              </p>
+              <list>
+                <li>
+                <b>1.</b>
+                <p>
+a copy of the Agreement,
+                </p>
+              </li>
+              <li>
+                <b>2.</b>
+                <p>
+a notice relating to the limitation of both the Licensor's warranty and liability as set forth in Articles 8 and 9,
+                </p>
+              </li>
+            </list>
+            <p>
+and that, in the event that only the Object Code of the Software is redistributed, the Licensee allows future Licensees unhindered access to the full Source Code of the Software by indicating how to access it, it being understood that the additional cost of acquiring the Source Code shall not exceed the cost of transferring the data.
+            </p>
+          </li>
+          <li>
+            <b>5.3.2.</b>
+            <p>
+DISTRIBUTION OF MODIFIED SOFTWARE
+            </p>
+            <p>
+When the Licensee makes a Contribution to the Software, the terms and conditions for the distribution of the resulting Modified Software become subject to all the provisions of this Agreement.
+            </p>
+            <p>
+The Licensee is authorized to distribute the Modified Software, in source code or object code form, provided that said distribution complies with all the provisions of the Agreement and is accompanied by:
+            </p>
+            <list>
+              <li>
+              <b>1.</b>
+              <p>
+a copy of the Agreement,
+              </p>
+            </li>
+            <li>
+              <b>2.</b>
+              <p>
+a notice relating to the limitation of both the Licensor's warranty and liability as set forth in Articles 8 and 9,
+              </p>
+            </li>
+            </list>
+            <p>
+and that, in the event that only the object code of the Modified Software is redistributed, the Licensee allows future Licensees unhindered access to the full source code of the Modified Software by indicating how to access it, it being understood that the additional cost of acquiring the source code shall not exceed the cost of transferring the data.
+          </p>
+        </li>
+        <li>
+          <b>5.3.3.</b>
+          <p>
+DISTRIBUTION OF EXTERNAL MODULES
+          </p>
+          <p>
+When the Licensee has developed an External Module, the terms and conditions of this Agreement do not apply to said External Module, that may be distributed under a separate license agreement.
+          </p>
+          </li>
+          <li>
+            <b>5.3.4.</b>
+            <p>
+COMPATIBILITY WITH THE GNU GPL
+            </p>
+            <p>
+The Licensee can include a code that is subject to the provisions of one of the versions of the GNU GPL in the Modified or unmodified Software, and distribute that entire code under the terms of the same version of the GNU GPL.
+            </p>
+            <p>
+The Licensee can include the Modified or unmodified Software in a code that is subject to the provisions of one of the versions of the GNU GPL, and distribute that entire code under the terms of the same version of the GNU GPL.  
+            </p>
+          </li>
+        </list>
+      </li>
+      </list>
+    </li>
+      <li>
+        <b>Article 6 -</b>
+      <p>
+INTELLECTUAL PROPERTY
+      </p>
+      <list>
+        <li>
+          <b>6.1</b>
+          <p>
+OVER THE INITIAL SOFTWARE
+          </p>
+          <p>
+The Holder owns the economic rights over the Initial Software. Any or all use of the Initial Software is subject to compliance with the terms and conditions under which the Holder has elected to distribute its work and no one shall be entitled to modify the terms and conditions for the distribution of said Initial Software.
+          </p>
+          <p>
+The Holder undertakes that the Initial Software will remain ruled at least by this Agreement, for the duration set forth in Article 4.2.
+          </p>
+        </li>
+        <li>
+          <b>6.2</b>
+          <p>
+OVER THE CONTRIBUTIONS
+          </p>
+          <p>
+The Licensee who develops a Contribution is the owner of the intellectual property rights over this Contribution as defined by applicable law.
+          </p>
+        </li>
+        <li>
+          <b>6.3</b>
+          <p>
+OVER THE EXTERNAL MODULES
+          </p>
+          <p>
+The Licensee who develops an External Module is the owner of the intellectual property rights over this External Module as defined by applicable law and is free to choose the type of agreement that shall govern its distribution.
+          </p>
+        </li>
+        <li>
+          <b>6.4</b>
+          <p>
+JOINT PROVISIONS
+          </p>
+          <p>
+The Licensee expressly undertakes:
+          </p>
+            <list>
+              <li>
+              <b>1.</b>
+              <p>
+not to remove, or modify, in any manner, the intellectual property notices attached to the Software;
+              </p>
+            </li>
+            <li>
+              <b>2.</b>
+              <p>
+to reproduce said notices, in an identical manner, in the copies of the Software modified or not.
+              </p>
+            </li>
+          </list>
+          <p>
+The Licensee undertakes not to directly or indirectly infringe the intellectual property rights of the Holder and/or Contributors on the Software and to take, where applicable, vis-à-vis its staff, any and all measures required to ensure respect of said intellectual property rights of the Holder and/or Contributors.
+          </p>
+        </li>
+      </list>
+    </li>
+      <li>
+        <b>Article 7 -</b>
+      <p>
+RELATED SERVICES
+      </p>
+      <list>
+        <li>
+          <b>7.1</b>
+          <p>
+Under no circumstances shall the Agreement oblige the Licensor to provide technical assistance or maintenance services for the Software.
+          </p>
+          <p>
+However, the Licensor is entitled to offer this type of services. The terms and conditions of such technical assistance, and/or such maintenance, shall be set forth in a separate instrument. Only the Licensor offering said maintenance and/or technical assistance services shall incur liability therefor.
+          </p>
+        </li>
+        <li>
+          <b>7.2</b>
+          <p>
+Similarly, any Licensor is entitled to offer to its licensees, under its sole responsibility, a warranty, that shall only be binding upon itself, for the redistribution of the Software and/or the Modified Software, under terms and conditions that it is free to decide. Said warranty, and the financial terms and conditions of its application, shall be subject of a separate instrument executed between the Licensor and the Licensee.
+          </p>
+        </li>
+      </list>
+    </li>
+      <li>
+        <b>Article 8 -</b>
+      <p>
+LIABILITY
+      </p>
+      <list>
+        <li>
+          <b>8.1</b>
+          <p>
+Subject to the provisions of Article 8.2, the Licensee shall be entitled to claim compensation for any direct loss it may have suffered from the Software as a result of a fault on the part of the relevant Licensor, subject to providing evidence thereof.
+          </p>
+        </li>
+        <li>
+          <b>8.2</b>
+          <p>
+The Licensor's liability is limited to the commitments made under this Agreement and shall not be incurred as a result of in particular: (i) loss due the Licensee's total or partial failure to fulfill its obligations, (ii) direct or consequential loss that is suffered by the Licensee due to the use or performance of the Software, and (iii) more generally, any consequential loss. In particular the Parties expressly agree that any or all pecuniary or business loss (i.e. loss of data, loss of profits, operating loss, loss of customers or orders, opportunity cost, any disturbance to business activities) or any or all legal proceedings instituted against the Licensee by a third party, shall constitute consequential loss and shall not provide entitlement to any or all compensation from the Licensor.
+          </p>
+        </li>
+      </list>
+    </li>
+      <li>
+        <b>Article 9 -</b>
+      <p>
+WARRANTY
+      </p>
+      <list>
+        <li>
+          <b>9.1</b>
+          <p>
+The Licensee acknowledges that the scientific and technical state-of-the-art when the Software was distributed did not enable all possible uses to be tested and verified, nor for the presence of possible defects to be detected. In this respect, the Licensee's attention has been drawn to the risks associated with loading, using, modifying and/or developing and reproducing the Software which are reserved for experienced users.
+          </p>
+          <p>
+The Licensee shall be responsible for verifying, by any or all means, the suitability of the product for its requirements, its good working order, and for ensuring that it shall not cause damage to either persons or properties.
+          </p>
+        </li>
+        <li>
+          <b>9.2</b>
+          <p>
+The Licensor hereby represents, in good faith, that it is entitled to grant all the rights over the Software (including in particular the rights set forth in Article 5).
+          </p>
+        </li>
+        <li>
+          <b>9.3</b>
+          <p>
+The Licensee acknowledges that the Software is supplied "as is" by the Licensor without any other express or tacit warranty, other than that provided for in Article 9.2 and, in particular, without any warranty as to its commercial value, its secured, safe, innovative or relevant nature.
+
+          </p>
+          <p>
+Specifically, the Licensor does not warrant that the Software is free from any error, that it will operate without interruption, that it will be compatible with the Licensee's own equipment and software configuration, nor that it will meet the Licensee's requirements.
+          </p>
+        </li>
+        <li>
+          <b>9.4</b>
+          <p>
+The Licensor does not either expressly or tacitly warrant that the Software does not infringe any third party intellectual property right relating to a patent, software or any other property right. Therefore, the Licensor disclaims any and all liability towards the Licensee arising out of any or all proceedings for infringement that may be instituted in respect of the use, modification and redistribution of the Software. Nevertheless, should such proceedings be instituted against the Licensee, the Licensor shall provide it with technical and legal assistance for its defense. Such technical and legal assistance shall be decided on a case-by-case basis between the relevant Licensor and the Licensee pursuant to a memorandum of understanding. The Licensor disclaims any and all liability as regards the Licensee's use of the name of the Software. No warranty is given as regards the existence of prior rights over the name of the Software or as regards the existence of a trademark.
+          </p>
+        </li>
+      </list>
+    </li>
+      <li>
+        <b>Article 10 -</b>
+      <p>
+TERMINATION
+      </p>
+      <list>
+        <li>
+          <b>10.1</b>
+          <p>
+In the event of a breach by the Licensee of its obligations hereunder, the Licensor may automatically terminate this Agreement thirty (30) days after notice has been sent to the Licensee and has remained ineffective.
+          </p>
+        </li>
+        <li>
+          <b>10.2</b>
+          <p>
+A Licensee whose Agreement is terminated shall no longer be authorized to use, modify or distribute the Software. However, any licenses that it may have granted prior to termination of the Agreement shall remain valid subject to their having been granted in compliance with the terms and conditions hereof.
+          </p>
+        </li>
+      </list>
+    </li>
+      <li>
+        <b>Article 11 -</b>
+      <p>
+MISCELLANEOUS
+      </p>
+      <list>
+        <li>
+          <b>11.1</b>
+          <p>
+EXCUSABLE EVENTS
+          </p>
+          <p>
+Neither Party shall be liable for any or all delay, or failure to perform the Agreement, that may be attributable to an event of force majeure, an act of God or an outside cause, such as defective functioning or interruptions of the electricity or telecommunications networks, network paralysis following a virus attack, intervention by government authorities, natural disasters, water damage, earthquakes, fire, explosions, strikes and labor unrest, war, etc.
+          </p>
+        </li>
+        <li>
+          <b>11.2</b>
+          <p>
+Any failure by either Party, on one or more occasions, to invoke one or more of the provisions hereof, shall under no circumstances be interpreted as being a waiver by the interested Party of its right to invoke said provision(s) subsequently.
+          </p>
+        </li>
+        <li>
+          <b>11.3</b>
+          <p>
+The Agreement cancels and replaces any or all previous agreements, whether written or oral, between the Parties and having the same purpose, and constitutes the entirety of the agreement between said Parties concerning said purpose. No supplement or modification to the terms and conditions hereof shall be effective as between the Parties unless it is made in writing and signed by their duly authorized representatives.
+          </p>
+        </li>
+        <li>
+          <b>11.4</b>
+          <p>
+In the event that one or more of the provisions hereof were to conflict with a current or future applicable act or legislative text, said act or legislative text shall prevail, and the Parties shall make the necessary amendments so as to comply with said act or legislative text. All other provisions shall remain effective. Similarly, invalidity of a provision of the Agreement, for any reason whatsoever, shall not cause the Agreement as a whole to be invalid.
+          </p>
+        </li>
+        <li>
+          <b>11.5</b>
+          <p>
+LANGUAGE
+          </p>
+          <p>
+The Agreement is drafted in both French and English and both versions are deemed authentic.
+          </p>
+        </li>
+      </list>
+    </li>
+      <li>
+        <b>Article 12 -</b>
+      <p>
+NEW VERSIONS OF THE AGREEMENT
+      </p>
+      <list>
+        <li>
+          <b>12.1</b>
+          <p>
+Any person is authorized to duplicate and distribute copies of this Agreement.
+          </p>
+        </li>
+        <li>
+          <b>12.2</b>
+          <p>
+So as to ensure coherence, the wording of this Agreement is protected and may only be modified by the authors of the License, who reserve the right to periodically publish updates or new versions of the Agreement, each with a separate number. These subsequent versions may address new issues encountered by Free Software.
+          </p>
+        </li>
+        <li>
+          <b>12.3</b>
+          <p>
+Any Software distributed under a given version of the Agreement may only be subsequently distributed under the same version of the Agreement or a subsequent version, subject to the provisions of Article 5.3.4.
+          </p>
+        </li>
+      </list>
+    </li>
+      <li>
+        <b>Article 13 -</b>
+      <p>
+GOVERNING LAW AND JURISDICTION
+      </p>
+      <list>
+        <li>
+          <b>13.1</b>
+          <p>
+The Agreement is governed by French law. The Parties agree to endeavor to seek an amicable solution to any disagreements or disputes that may arise during the performance of the Agreement.
+          </p>
+        </li>
+        <li>
+          <b>13.2</b>
+          <p>
+Failing an amicable solution within two (2) months as from their occurrence, and unless emergency proceedings are necessary, the disagreements or disputes shall be referred to the Paris Courts having jurisdiction, by the more diligent Party.
+          </p>
+        </li>
+      </list>
+    </li>
+  </list>
+  <p>
+Version 2.0 dated 2006-09-05.
+  </p>
+</license>
+</SPDX>

--- a/src/CECILL-2.0.xml
+++ b/src/CECILL-2.0.xml
@@ -3,7 +3,7 @@
     <url>http://www.cecill.info/licences/Licence_CeCILL_V2-en.html</url>
   </urls>
   <notes>
-French translation can be found here: http://www.cecill.info/licences/Licence_CeCILL_V2-fr.html
+French version can be found here: http://www.cecill.info/licences/Licence_CeCILL_V2-fr.html
   </notes>
   <license>
     <title>

--- a/src/CECILL-2.1.xml
+++ b/src/CECILL-2.1.xml
@@ -1,4 +1,4 @@
-<SPDX name="CeCILL Free Software License Agreement v2.1" identifier="CECILL-2.1" osi-approved="false">
+<SPDX name="CeCILL Free Software License Agreement v2.1" identifier="CECILL-2.1" osi-approved="true">
   <urls>
     <url>http://www.cecill.info/licences/Licence_CeCILL_V2.1-en.html</url>
   </urls>

--- a/src/CECILL-2.1.xml
+++ b/src/CECILL-2.1.xml
@@ -1,0 +1,664 @@
+<SPDX name="CeCILL Free Software License Agreement v2.1" identifier="CECILL-2.1" osi-approved="false">
+  <urls>
+    <url>http://www.cecill.info/licences/Licence_CeCILL_V2.1-en.html</url>
+  </urls>
+  <notes>
+French version can be found here: http://www.cecill.info/licences/Licence_CeCILL_V2.1-fr.html
+  </notes>
+  <license>
+    <title>
+      <p>
+CeCILL FREE SOFTWARE LICENSE AGREEMENT
+      </p>
+    </title>
+  <p>
+Version 2.1 dated 2013-06-21
+  </p>
+    <optional>
+      <p>
+Notice
+      </p>
+      <p>
+This Agreement is a Free Software license agreement that is the result of discussions between its authors in order to ensure compliance with the two main principles guiding its drafting:
+      </p>
+      <list>
+        <li>
+          <b>*</b>
+          <p>
+firstly, compliance with the principles governing the distribution of Free Software: access to source code, broad rights granted to users,
+          </p>
+        </li>
+        <li>
+          <b>*</b>
+          <p>
+secondly, the election of a governing law, French law, with which it is conformant, both as regards the law of torts and intellectual property law, and the protection that it offers to both authors and holders of the economic rights over software.
+          </p>
+        </li>
+      </list>
+      <p>
+The authors of the CeCILL (for Ce[a] C[nrs] I[nria] L[ogiciel] L[ibre]) license are:
+      </p>
+      <list>
+        <li>
+          <p>
+Commissariat à l'énergie atomique et aux énergies alternatives - CEA, a public scientific, technical and industrial research establishment, having its principal place of business at 25 rue Leblanc, immeuble Le Ponant D, 75015 Paris, France.
+          </p>
+        </li>
+        <li>
+          <p>
+Centre National de la Recherche Scientifique - CNRS, a public scientific and technological establishment, having its principal place of business at 3 rue Michel-Ange, 75794 Paris cedex 16, France.
+          </p>
+        </li>
+        <li>
+          <p>
+Institut National de Recherche en Informatique et en Automatique - Inria, a public scientific and technological establishment, having its principal place of business at Domaine de Voluceau, Rocquencourt, BP 105, 78153 Le Chesnay cedex, France.
+          </p>
+        </li>
+      </list>
+    </optional>
+    <list>
+      <li>
+        <b>Preamble</b>
+          <p>
+The purpose of this Free Software license agreement is to grant users the right to modify and redistribute the software governed by this license within the framework of an open source distribution model.
+          </p>
+          <p>
+The exercising of this right is conditional upon certain obligations for users so as to preserve this status for all subsequent redistributions.
+          </p>
+          <p>
+In consideration of access to the source code and the rights to copy, modify and redistribute granted by the license, users are provided only with a limited warranty and the software's author, the holder of the economic rights, and the successive licensors only have limited liability.
+          </p>
+          <p>
+In this respect, the risks associated with loading, using, modifying and/or developing or reproducing the software by the user are brought to the user's attention, given its Free Software status, which may make it complicated to use, with the result that its use is reserved for developers and experienced professionals having in-depth computer knowledge. Users are therefore encouraged to load and test the suitability of the software as regards their requirements in conditions enabling the security of their systems and/or data to be ensured and, more generally, to use and operate it in the same conditions of security. This Agreement may be freely reproduced and published, provided it is not altered, and that no provisions are either added or removed herefrom.
+          </p>
+          <p>
+This Agreement may apply to any or all software for which the holder of the economic rights decides to submit the use thereof to its provisions.
+          </p>
+          <p>
+Frequently asked questions can be found on the official website of the CeCILL licenses family (http://www.cecill.info/index.en.html) for any necessary clarification.
+          </p>
+      </li>
+      <li>
+        <b>Article 1 -</b>
+      <p>
+        DEFINITIONS
+      </p>
+      <p>
+For the purpose of this Agreement, when the following expressions commence with a capital letter, they shall have the following meaning:
+      </p>
+      <list>
+        <li>
+          <p>
+Agreement: means this license agreement, and its possible subsequent versions and annexes.
+          </p>
+        </li>
+        <li>
+          <p>
+Software: means the software in its Object Code and/or Source Code form and, where applicable, its documentation, "as is" when the Licensee accepts the Agreement.
+          </p>
+        </li>
+        <li>
+          <p>
+Initial Software: means the Software in its Source Code and possibly its Object Code form and, where applicable, its documentation, "as is" when it is first distributed under the terms and conditions of the Agreement.
+          </p>
+        </li>
+        <li>
+          <p>
+Modified Software: means the Software modified by at least one Contribution.
+          </p>
+        </li>
+        <li>
+          <p>
+Source Code: means all the Software's instructions and program lines to which access is required so as to modify the Software.
+          </p>
+        </li>
+        <li>
+          <p>
+Object Code: means the binary files originating from the compilation of the Source Code.
+          </p>
+        </li>
+        <li>
+          <p>
+Holder: means the holder(s) of the economic rights over the Initial Software.
+          </p>
+        </li>
+        <li>
+          <p>
+Licensee: means the Software user(s) having accepted the Agreement.
+          </p>
+        </li>
+        <li>
+          <p>
+Contributor: means a Licensee having made at least one Contribution.
+          </p>
+        </li>
+        <li>
+          <p>
+Licensor: means the Holder, or any other individual or legal entity, who distributes the Software under the Agreement.
+          </p>
+        </li>
+        <li>
+          <p>
+Contribution: means any or all modifications, corrections, translations, adaptations and/or new functions integrated into the Software by any or all Contributors, as well as any or all Internal Modules.
+          </p>
+        </li>
+        <li>
+          <p>
+Module: means a set of sources files including their documentation that enables supplementary functions or services in addition to those offered by the Software.
+          </p>
+        </li>
+        <li>
+          <p>
+External Module: means any or all Modules, not derived from the Software, so that this Module and the Software run in separate address spaces, with one calling the other when they are run.
+          </p>
+        </li>
+        <li>
+          <p>
+Internal Module: means any or all Module, connected to the Software so that they both execute in the same address space.
+          </p>
+        </li>
+        <li>
+          <p>
+GNU GPL: means the GNU General Public License version 2 or any subsequent version, as published by the Free Software Foundation Inc.
+          </p>
+        </li>
+        <li>
+          <p>
+GNU Affero GPL: means the GNU Affero General Public License version 3 or any subsequent version, as published by the Free Software Foundation Inc.
+          </p>
+        </li>
+        <li>
+          <p>
+EUPL: means the European Union Public License version 1.1 or any subsequent version, as published by the European Commission.
+          </p>
+        </li>
+        <li>
+          <p>
+Parties: mean both the Licensee and the Licensor.
+          </p>
+        </li>
+      </list>
+      <p>
+These expressions may be used both in singular and plural form.
+      </p>
+      </li>
+      <li>
+        <b>Article 2 -</b>
+      <p>
+PURPOSE
+      </p>
+      <p>
+The purpose of the Agreement is the grant by the Licensor to the Licensee of a non-exclusive, transferable and worldwide license for the Software as set forth in Article 5 hereinafter for the whole term of the protection granted by the rights over said Software.
+      </p>
+      </li>
+      <li>
+        <b>Article 3 -</b>
+      <p>
+ACCEPTANCE
+      </p>
+      <list>
+        <li>
+          <b>3.1</b>
+          <p>
+The Licensee shall be deemed as having accepted the terms and conditions of this Agreement upon the occurrence of the first of the following events:
+          </p>
+          <list>
+            <li>
+              <b>(i)</b>
+              <p>
+loading the Software by any or all means, notably, by downloading from a remote server, or by loading from a physical medium;
+              </p>
+            </li>
+            <li>
+              <b>(ii)</b>
+              <p>
+the first time the Licensee exercises any of the rights granted hereunder.
+              </p>
+            </li>
+          </list>
+        </li>
+        <li>
+          <b>3.2</b>
+          <p>
+One copy of the Agreement, containing a notice relating to the characteristics of the Software, to the limited warranty, and to the fact that its use is restricted to experienced users has been provided to the Licensee prior to its acceptance as set forth in Article 3.1 hereinabove, and the Licensee hereby acknowledges that it has read and understood it.
+          </p>
+        </li>
+      </list>
+      </li>
+      <li>
+        <b>Article 4 -</b>
+      <p>
+EFFECTIVE DATE AND TERM
+      </p>
+      <list>
+        <li>
+          <b>4.1</b>
+          <p>
+EFFECTIVE DATE
+          </p>
+          <p>
+The Agreement shall become effective on the date when it is accepted by the Licensee as set forth in Article 3.1.
+          </p>
+        </li>
+        <li>
+          <b>4.2</b>
+          <p>
+TERM
+          </p>
+          <p>
+The Agreement shall remain in force for the entire legal term of protection of the economic rights over the Software.
+          </p>
+        </li>
+      </list>
+      </li>
+      <li>
+        <b>Article 5 -</b>
+      <p>
+SCOPE OF RIGHTS GRANTED
+      </p>
+      <p>
+The Licensor hereby grants to the Licensee, who accepts, the following rights over the Software for any or all use, and for the term of the Agreement, on the basis of the terms and conditions set forth hereinafter.
+      </p>
+      <p>
+Besides, if the Licensor owns or comes to own one or more patents protecting all or part of the functions of the Software or of its components, the Licensor undertakes not to enforce the rights granted by these patents against successive Licensees using, exploiting or modifying the Software. If these patents are transferred, the Licensor undertakes to have the transferees subscribe to the obligations set forth in this paragraph.
+      </p>
+      <list>
+        <li>
+          <b>5.1</b>
+          <p>
+RIGHT OF USE
+          </p>
+          <p>
+The Licensee is authorized to use the Software, without any limitation as to its fields of application, with it being hereinafter specified that this comprises:
+          </p>
+          <list>
+            <li>
+              <b>1.</b>
+              <p>
+permanent or temporary reproduction of all or part of the Software by any or all means and in any or all form.
+              </p>
+            </li>
+            <li>
+              <b>2.</b>
+              <p>
+loading, displaying, running, or storing the Software on any or all medium.
+              </p>
+            </li>
+            <li>
+              <b>3.</b>
+              <p>
+entitlement to observe, study or test its operation so as to determine the ideas and principles behind any or all constituent elements of said Software. This shall apply when the Licensee carries out any or all loading, displaying, running, transmission or storage operation as regards the Software, that it is entitled to carry out hereunder.
+              </p>
+            </li>
+          </list>
+        </li>
+        <li>
+          <b>5.2</b>
+          <p>
+ENTITLEMENT TO MAKE CONTRIBUTIONS
+          </p>
+          <p>
+The right to make Contributions includes the right to translate, adapt, arrange, or make any or all modifications to the Software, and the right to reproduce the resulting software.
+          </p>
+          <p>
+The Licensee is authorized to make any or all Contributions to the Software provided that it includes an explicit notice that it is the author of said Contribution and indicates the date of the creation thereof.
+          </p>
+        </li>
+        <li>
+          <b>5.3</b>
+          <p>
+RIGHT OF DISTRIBUTION
+          </p>
+          <p>
+In particular, the right of distribution includes the right to publish, transmit and communicate the Software to the general public on any or all medium, and by any or all means, and the right to market, either in consideration of a fee, or free of charge, one or more copies of the Software by any means.
+          </p>
+          <p>
+The Licensee is further authorized to distribute copies of the modified or unmodified Software to third parties according to the terms and conditions set forth hereinafter.
+          </p>
+          <list>
+            <li>
+              <b>5.3.1.</b>
+              <p>
+DISTRIBUTION OF SOFTWARE WITHOUT MODIFICATION
+              </p>
+              <p>
+The Licensee is authorized to distribute true copies of the Software in Source Code or Object Code form, provided that said distribution complies with all the provisions of the Agreement and is accompanied by:
+              </p>
+              <list>
+                <li>
+                <b>1.</b>
+                <p>
+a copy of the Agreement,
+                </p>
+              </li>
+              <li>
+                <b>2.</b>
+                <p>
+a notice relating to the limitation of both the Licensor's warranty and liability as set forth in Articles 8 and 9,
+                </p>
+              </li>
+            </list>
+            <p>
+and that, in the event that only the Object Code of the Software is redistributed, the Licensee allows effective access to the full Source Code of the Software for a period of at least three years from the distribution of the Software, it being understood that the additional acquisition cost of the Source Code shall not exceed the cost of the data transfer.
+            </p>
+          </li>
+          <li>
+            <b>5.3.2.</b>
+            <p>
+DISTRIBUTION OF MODIFIED SOFTWARE
+            </p>
+            <p>
+When the Licensee makes a Contribution to the Software, the terms and conditions for the distribution of the resulting Modified Software become subject to all the provisions of this Agreement.
+            </p>
+            <p>
+The Licensee is authorized to distribute the Modified Software, in source code or object code form, provided that said distribution complies with all the provisions of the Agreement and is accompanied by:
+            </p>
+            <list>
+              <li>
+              <b>1.</b>
+              <p>
+a copy of the Agreement,
+              </p>
+            </li>
+            <li>
+              <b>2.</b>
+              <p>
+a notice relating to the limitation of both the Licensor's warranty and liability as set forth in Articles 8 and 9,
+              </p>
+            </li>
+            </list>
+            <p>
+and, in the event that only the object code of the Modified Software is redistributed,
+          </p>
+            <list>
+              <li>
+              <b>3.</b>
+              <p>
+a note stating the conditions of effective access to the full source code of the Modified Software for a period of at least three years from the distribution of the Modified Software, it being understood that the additional acquisition cost of the source code shall not exceed the cost of the data transfer.
+	      </p>
+	    </li>
+	  </list>
+        </li>
+        <li>
+          <b>5.3.3.</b>
+          <p>
+DISTRIBUTION OF EXTERNAL MODULES
+          </p>
+          <p>
+When the Licensee has developed an External Module, the terms and conditions of this Agreement do not apply to said External Module, that may be distributed under a separate license agreement.
+          </p>
+          </li>
+          <li>
+            <b>5.3.4.</b>
+            <p>
+COMPATIBILITY WITH OTHER LICENSES
+            </p>
+            <p>
+The Licensee can include a code that is subject to the provisions of one of the versions of the GNU GPL, GNU Affero GPL and/or EUPL in the Modified or unmodified Software, and distribute that entire code under the terms of the same version of the GNU GPL, GNU Affero GPL and/or EUPL.
+            </p>
+            <p>
+The Licensee can include the Modified or unmodified Software in a code that is subject to the provisions of one of the versions of the GNU GPL, GNU Affero GPL and/or EUPL and distribute that entire code under the terms of the same version of the GNU GPL, GNU Affero GPL and/or EUPL.
+            </p>
+          </li>
+        </list>
+      </li>
+      </list>
+    </li>
+      <li>
+        <b>Article 6 -</b>
+      <p>
+INTELLECTUAL PROPERTY
+      </p>
+      <list>
+        <li>
+          <b>6.1</b>
+          <p>
+OVER THE INITIAL SOFTWARE
+          </p>
+          <p>
+The Holder owns the economic rights over the Initial Software. Any or all use of the Initial Software is subject to compliance with the terms and conditions under which the Holder has elected to distribute its work and no one shall be entitled to modify the terms and conditions for the distribution of said Initial Software.
+          </p>
+          <p>
+The Holder undertakes that the Initial Software will remain ruled at least by this Agreement, for the duration set forth in Article 4.2.
+          </p>
+        </li>
+        <li>
+          <b>6.2</b>
+          <p>
+OVER THE CONTRIBUTIONS
+          </p>
+          <p>
+The Licensee who develops a Contribution is the owner of the intellectual property rights over this Contribution as defined by applicable law.
+          </p>
+        </li>
+        <li>
+          <b>6.3</b>
+          <p>
+OVER THE EXTERNAL MODULES
+          </p>
+          <p>
+The Licensee who develops an External Module is the owner of the intellectual property rights over this External Module as defined by applicable law and is free to choose the type of agreement that shall govern its distribution.
+          </p>
+        </li>
+        <li>
+          <b>6.4</b>
+          <p>
+JOINT PROVISIONS
+          </p>
+          <p>
+The Licensee expressly undertakes:
+          </p>
+            <list>
+              <li>
+              <b>1.</b>
+              <p>
+not to remove, or modify, in any manner, the intellectual property notices attached to the Software;
+              </p>
+            </li>
+            <li>
+              <b>2.</b>
+              <p>
+to reproduce said notices, in an identical manner, in the copies of the Software modified or not.
+              </p>
+            </li>
+          </list>
+          <p>
+The Licensee undertakes not to directly or indirectly infringe the intellectual property rights on the Software of the Holder and/or Contributors, and to take, where applicable, vis-à-vis its staff, any and all measures required to ensure respect of said intellectual property rights of the Holder and/or Contributors.
+          </p>
+        </li>
+      </list>
+    </li>
+      <li>
+        <b>Article 7 -</b>
+      <p>
+RELATED SERVICES
+      </p>
+      <list>
+        <li>
+          <b>7.1</b>
+          <p>
+Under no circumstances shall the Agreement oblige the Licensor to provide technical assistance or maintenance services for the Software.
+          </p>
+          <p>
+However, the Licensor is entitled to offer this type of services. The terms and conditions of such technical assistance, and/or such maintenance, shall be set forth in a separate instrument. Only the Licensor offering said maintenance and/or technical assistance services shall incur liability therefor.
+          </p>
+        </li>
+        <li>
+          <b>7.2</b>
+          <p>
+Similarly, any Licensor is entitled to offer to its licensees, under its sole responsibility, a warranty, that shall only be binding upon itself, for the redistribution of the Software and/or the Modified Software, under terms and conditions that it is free to decide. Said warranty, and the financial terms and conditions of its application, shall be subject of a separate instrument executed between the Licensor and the Licensee.
+          </p>
+        </li>
+      </list>
+    </li>
+      <li>
+        <b>Article 8 -</b>
+      <p>
+LIABILITY
+      </p>
+      <list>
+        <li>
+          <b>8.1</b>
+          <p>
+Subject to the provisions of Article 8.2, the Licensee shall be entitled to claim compensation for any direct loss it may have suffered from the Software as a result of a fault on the part of the relevant Licensor, subject to providing evidence thereof.
+          </p>
+        </li>
+        <li>
+          <b>8.2</b>
+          <p>
+The Licensor's liability is limited to the commitments made under this Agreement and shall not be incurred as a result of in particular: (i) loss due the Licensee's total or partial failure to fulfill its obligations, (ii) direct or consequential loss that is suffered by the Licensee due to the use or performance of the Software, and (iii) more generally, any consequential loss. In particular the Parties expressly agree that any or all pecuniary or business loss (i.e. loss of data, loss of profits, operating loss, loss of customers or orders, opportunity cost, any disturbance to business activities) or any or all legal proceedings instituted against the Licensee by a third party, shall constitute consequential loss and shall not provide entitlement to any or all compensation from the Licensor.
+          </p>
+        </li>
+      </list>
+    </li>
+      <li>
+        <b>Article 9 -</b>
+      <p>
+WARRANTY
+      </p>
+      <list>
+        <li>
+          <b>9.1</b>
+          <p>
+The Licensee acknowledges that the scientific and technical state-of-the-art when the Software was distributed did not enable all possible uses to be tested and verified, nor for the presence of possible defects to be detected. In this respect, the Licensee's attention has been drawn to the risks associated with loading, using, modifying and/or developing and reproducing the Software which are reserved for experienced users.
+          </p>
+          <p>
+The Licensee shall be responsible for verifying, by any or all means, the suitability of the product for its requirements, its good working order, and for ensuring that it shall not cause damage to either persons or properties.
+          </p>
+        </li>
+        <li>
+          <b>9.2</b>
+          <p>
+The Licensor hereby represents, in good faith, that it is entitled to grant all the rights over the Software (including in particular the rights set forth in Article 5).
+          </p>
+        </li>
+        <li>
+          <b>9.3</b>
+          <p>
+The Licensee acknowledges that the Software is supplied "as is" by the Licensor without any other express or tacit warranty, other than that provided for in Article 9.2 and, in particular, without any warranty as to its commercial value, its secured, safe, innovative or relevant nature.
+          </p>
+          <p>
+Specifically, the Licensor does not warrant that the Software is free from any error, that it will operate without interruption, that it will be compatible with the Licensee's own equipment and software configuration, nor that it will meet the Licensee's requirements.
+          </p>
+        </li>
+        <li>
+          <b>9.4</b>
+          <p>
+The Licensor does not either expressly or tacitly warrant that the Software does not infringe any third party intellectual property right relating to a patent, software or any other property right. Therefore, the Licensor disclaims any and all liability towards the Licensee arising out of any or all proceedings for infringement that may be instituted in respect of the use, modification and redistribution of the Software. Nevertheless, should such proceedings be instituted against the Licensee, the Licensor shall provide it with technical and legal expertise for its defense. Such technical and legal expertise shall be decided on a case-by-case basis between the relevant Licensor and the Licensee pursuant to a memorandum of understanding. The Licensor disclaims any and all liability as regards the Licensee's use of the name of the Software. No warranty is given as regards the existence of prior rights over the name of the Software or as regards the existence of a trademark.
+          </p>
+        </li>
+      </list>
+    </li>
+      <li>
+        <b>Article 10 -</b>
+      <p>
+TERMINATION
+      </p>
+      <list>
+        <li>
+          <b>10.1</b>
+          <p>
+In the event of a breach by the Licensee of its obligations hereunder, the Licensor may automatically terminate this Agreement thirty (30) days after notice has been sent to the Licensee and has remained ineffective.
+          </p>
+        </li>
+        <li>
+          <b>10.2</b>
+          <p>
+A Licensee whose Agreement is terminated shall no longer be authorized to use, modify or distribute the Software. However, any licenses that it may have granted prior to termination of the Agreement shall remain valid subject to their having been granted in compliance with the terms and conditions hereof.
+          </p>
+        </li>
+      </list>
+    </li>
+      <li>
+        <b>Article 11 -</b>
+      <p>
+MISCELLANEOUS
+      </p>
+      <list>
+        <li>
+          <b>11.1</b>
+          <p>
+EXCUSABLE EVENTS
+          </p>
+          <p>
+Neither Party shall be liable for any or all delay, or failure to perform the Agreement, that may be attributable to an event of force majeure, an act of God or an outside cause, such as defective functioning or interruptions of the electricity or telecommunications networks, network paralysis following a virus attack, intervention by government authorities, natural disasters, water damage, earthquakes, fire, explosions, strikes and labor unrest, war, etc.
+          </p>
+        </li>
+        <li>
+          <b>11.2</b>
+          <p>
+Any failure by either Party, on one or more occasions, to invoke one or more of the provisions hereof, shall under no circumstances be interpreted as being a waiver by the interested Party of its right to invoke said provision(s) subsequently.
+          </p>
+        </li>
+        <li>
+          <b>11.3</b>
+          <p>
+The Agreement cancels and replaces any or all previous agreements, whether written or oral, between the Parties and having the same purpose, and constitutes the entirety of the agreement between said Parties concerning said purpose. No supplement or modification to the terms and conditions hereof shall be effective as between the Parties unless it is made in writing and signed by their duly authorized representatives.
+          </p>
+        </li>
+        <li>
+          <b>11.4</b>
+          <p>
+In the event that one or more of the provisions hereof were to conflict with a current or future applicable act or legislative text, said act or legislative text shall prevail, and the Parties shall make the necessary amendments so as to comply with said act or legislative text. All other provisions shall remain effective. Similarly, invalidity of a provision of the Agreement, for any reason whatsoever, shall not cause the Agreement as a whole to be invalid.
+          </p>
+        </li>
+        <li>
+          <b>11.5</b>
+          <p>
+LANGUAGE
+          </p>
+          <p>
+The Agreement is drafted in both French and English and both versions are deemed authentic.
+          </p>
+        </li>
+      </list>
+    </li>
+      <li>
+        <b>Article 12 -</b>
+      <p>
+NEW VERSIONS OF THE AGREEMENT
+      </p>
+      <list>
+        <li>
+          <b>12.1</b>
+          <p>
+Any person is authorized to duplicate and distribute copies of this Agreement.
+          </p>
+        </li>
+        <li>
+          <b>12.2</b>
+          <p>
+So as to ensure coherence, the wording of this Agreement is protected and may only be modified by the authors of the License, who reserve the right to periodically publish updates or new versions of the Agreement, each with a separate number. These subsequent versions may address new issues encountered by Free Software.
+          </p>
+        </li>
+        <li>
+          <b>12.3</b>
+          <p>
+Any Software distributed under a given version of the Agreement may only be subsequently distributed under the same version of the Agreement or a subsequent version, subject to the provisions of Article 5.3.4.
+          </p>
+        </li>
+      </list>
+    </li>
+      <li>
+        <b>Article 13 -</b>
+      <p>
+GOVERNING LAW AND JURISDICTION
+      </p>
+      <list>
+        <li>
+          <b>13.1</b>
+          <p>
+The Agreement is governed by French law. The Parties agree to endeavor to seek an amicable solution to any disagreements or disputes that may arise during the performance of the Agreement.
+          </p>
+        </li>
+        <li>
+          <b>13.2</b>
+          <p>
+Failing an amicable solution within two (2) months as from their occurrence, and unless emergency proceedings are necessary, the disagreements or disputes shall be referred to the Paris Courts having jurisdiction, by the more diligent Party.
+          </p>
+        </li>
+      </list>
+    </li>
+  </list>
+</license>
+</SPDX>

--- a/src/CECILL-B.xml
+++ b/src/CECILL-B.xml
@@ -1,0 +1,657 @@
+<SPDX name="CeCILL-B Free Software License Agreement" identifier="CECILL-B" osi-approved="false">
+  <urls>
+	  <url>http://www.cecill.info/licences/Licence_CeCILL-B_V1-en.html</url>
+  </urls>
+  <notes>
+French version can be found here: http://www.cecill.info/licences/Licence_CeCILL-B_V1-fr.html
+  </notes>
+  <license>
+    <title>
+      <p>
+CeCILL FREE SOFTWARE LICENSE AGREEMENT
+      </p>
+    </title>
+    <optional>
+      <p>
+Notice
+      </p>
+      <p>
+This Agreement is a Free Software license agreement that is the result of discussions between its authors in order to ensure compliance with the two main principles guiding its drafting:
+      </p>
+      <list>
+        <li>
+          <b>*</b>
+          <p>
+firstly, compliance with the principles governing the distribution of Free Software: access to source code, broad rights granted to users,
+          </p>
+        </li>
+        <li>
+          <b>*</b>
+          <p>
+secondly, the election of a governing law, French law, with which it is conformant, both as regards the law of torts and intellectual property law, and the protection that it offers to both authors and holders of the economic rights over software.
+          </p>
+        </li>
+      </list>
+      <p>
+The authors of the CeCILL-B (for Ce[a] C[nrs] I[nria] L[ogiciel] L[ibre]) license are:
+      </p>
+      <list>
+        <li>
+          <p>
+Commissariat à l'Energie Atomique - CEA, a public scientific, technical and industrial research establishment, having its principal place of business at 25 rue Leblanc, immeuble Le Ponant D, 75015 Paris, France.
+          </p>
+        </li>
+        <li>
+          <p>
+Centre National de la Recherche Scientifique - CNRS, a public scientific and technological establishment, having its principal place of business at 3 rue Michel-Ange, 75794 Paris cedex 16, France.
+          </p>
+        </li>
+        <li>
+          <p>
+Institut National de Recherche en Informatique et en Automatique - INRIA, a public scientific and technological establishment, having its principal place of business at Domaine de Voluceau, Rocquencourt, BP 105, 78153 Le Chesnay cedex, France.
+          </p>
+        </li>
+      </list>
+    </optional>
+    <list>
+      <li>
+        <b>Preamble</b>
+          <p>
+This Agreement is an open source software license intended to give users significant freedom to modify and redistribute the software licensed hereunder.
+          </p>
+          <p>
+The exercising of this freedom is conditional upon a strong obligation of giving credits for everybody that distributes a software incorporating a software ruled by the current license so as all contributions to be properly identified and acknowledged.
+          </p>
+          <p>
+In consideration of access to the source code and the rights to copy, modify and redistribute granted by the license, users are provided only with a limited warranty and the software's author, the holder of the economic rights, and the successive licensors only have limited liability.
+          </p>
+          <p>
+In this respect, the risks associated with loading, using, modifying and/or developing or reproducing the software by the user are brought to the user's attention, given its Free Software status, which may make it complicated to use, with the result that its use is reserved for developers and experienced professionals having in-depth computer knowledge. Users are therefore encouraged to load and test the suitability of the software as regards their requirements in conditions enabling the security of their systems and/or data to be ensured and, more generally, to use and operate it in the same conditions of security. This Agreement may be freely reproduced and published, provided it is not altered, and that no provisions are either added or removed herefrom.
+          </p>
+          <p>
+This Agreement may apply to any or all software for which the holder of the economic rights decides to submit the use thereof to its provisions.
+          </p>
+      </li>
+      <li>
+        <b>Article 1 -</b>
+      <p>
+        DEFINITIONS
+      </p>
+      <p>
+For the purpose of this Agreement, when the following expressions commence with a capital letter, they shall have the following meaning:
+      </p>
+      <list>
+        <li>
+          <p>
+Agreement: means this license agreement, and its possible subsequent versions and annexes.
+          </p>
+        </li>
+        <li>
+          <p>
+Software: means the software in its Object Code and/or Source Code form and, where applicable, its documentation, "as is" when the Licensee accepts the Agreement.
+          </p>
+        </li>
+        <li>
+          <p>
+Initial Software: means the Software in its Source Code and possibly its Object Code form and, where applicable, its documentation, "as is" when it is first distributed under the terms and conditions of the Agreement.
+          </p>
+        </li>
+        <li>
+          <p>
+Modified Software: means the Software modified by at least one Contribution.
+          </p>
+        </li>
+        <li>
+          <p>
+Source Code: means all the Software's instructions and program lines to which access is required so as to modify the Software.
+          </p>
+        </li>
+        <li>
+          <p>
+Object Code: means the binary files originating from the compilation of the Source Code.
+          </p>
+        </li>
+        <li>
+          <p>
+Holder: means the holder(s) of the economic rights over the Initial Software.
+          </p>
+        </li>
+        <li>
+          <p>
+Licensee: means the Software user(s) having accepted the Agreement.
+          </p>
+        </li>
+        <li>
+          <p>
+Contributor: means a Licensee having made at least one Contribution.
+          </p>
+        </li>
+        <li>
+          <p>
+Licensor: means the Holder, or any other individual or legal entity, who distributes the Software under the Agreement.
+          </p>
+        </li>
+        <li>
+          <p>
+Contribution: means any or all modifications, corrections, translations, adaptations and/or new functions integrated into the Software by any or all Contributors, as well as any or all Internal Modules.
+          </p>
+        </li>
+        <li>
+          <p>
+Module: means a set of sources files including their documentation that enables supplementary functions or services in addition to those offered by the Software.
+          </p>
+        </li>
+        <li>
+          <p>
+External Module: means any or all Modules, not derived from the Software, so that this Module and the Software run in separate address spaces, with one calling the other when they are run.
+          </p>
+        </li>
+        <li>
+          <p>
+Internal Module: means any or all Module, connected to the Software so that they both execute in the same address space.
+          </p>
+        </li>
+        <li>
+          <p>
+Parties: mean both the Licensee and the Licensor.
+          </p>
+        </li>
+      </list>
+      <p>
+These expressions may be used both in singular and plural form.
+      </p>
+      </li>
+      <li>
+        <b>Article 2 -</b>
+      <p>
+PURPOSE
+      </p>
+      <p>
+The purpose of the Agreement is the grant by the Licensor to the Licensee of a non-exclusive, transferable and worldwide license for the Software as set forth in Article 5 hereinafter for the whole term of the protection granted by the rights over said Software. 
+      </p>
+      </li>
+      <li>
+        <b>Article 3 -</b>
+      <p>
+ACCEPTANCE
+      </p>
+      <list>
+        <li>
+          <b>3.1</b>
+          <p>
+The Licensee shall be deemed as having accepted the terms and conditions of this Agreement upon the occurrence of the first of the following events:
+          </p>
+          <list>
+            <li>
+              <b>(i)</b>
+              <p>
+loading the Software by any or all means, notably, by downloading from a remote server, or by loading from a physical medium;
+              </p>
+            </li>
+            <li>
+              <b>(ii)</b>
+              <p>
+the first time the Licensee exercises any of the rights granted hereunder.
+              </p>
+            </li>
+          </list>
+        </li>
+        <li>
+          <b>3.2</b>
+          <p>
+One copy of the Agreement, containing a notice relating to the characteristics of the Software, to the limited warranty, and to the fact that its use is restricted to experienced users has been provided to the Licensee prior to its acceptance as set forth in Article 3.1 hereinabove, and the Licensee hereby acknowledges that it has read and understood it.
+          </p>
+        </li>
+      </list>
+      </li>
+      <li>
+        <b>Article 4 -</b>
+      <p>
+EFFECTIVE DATE AND TERM
+      </p>
+      <list>
+        <li>
+          <b>4.1</b>
+          <p>
+EFFECTIVE DATE
+          </p>
+          <p>
+The Agreement shall become effective on the date when it is accepted by the Licensee as set forth in Article 3.1.
+          </p>
+        </li>
+        <li>
+          <b>4.2</b>
+          <p>
+TERM
+          </p>
+          <p>
+The Agreement shall remain in force for the entire legal term of protection of the economic rights over the Software.
+          </p>
+        </li>
+      </list>
+      </li>
+      <li>
+        <b>Article 5 -</b>
+      <p>
+SCOPE OF RIGHTS GRANTED
+      </p>
+      <p>
+The Licensor hereby grants to the Licensee, who accepts, the following rights over the Software for any or all use, and for the term of the Agreement, on the basis of the terms and conditions set forth hereinafter.
+      </p>
+      <p>
+Besides, if the Licensor owns or comes to own one or more patents protecting all or part of the functions of the Software or of its components, the Licensor undertakes not to enforce the rights granted by these patents against successive Licensees using, exploiting or modifying the Software. If these patents are transferred, the Licensor undertakes to have the transferees subscribe to the obligations set forth in this paragraph.
+      </p>
+      <list>
+        <li>
+          <b>5.1</b>
+          <p>
+RIGHT OF USE
+          </p>
+          <p>
+The Licensee is authorized to use the Software, without any limitation as to its fields of application, with it being hereinafter specified that this comprises:
+          </p>
+          <list>
+            <li>
+              <b>1.</b>
+              <p>
+permanent or temporary reproduction of all or part of the Software by any or all means and in any or all form.
+              </p>
+            </li>
+            <li>
+              <b>2.</b>
+              <p>
+loading, displaying, running, or storing the Software on any or all medium.
+              </p>
+            </li>
+            <li>
+              <b>3.</b>
+              <p>
+entitlement to observe, study or test its operation so as to determine the ideas and principles behind any or all constituent elements of said Software. This shall apply when the Licensee carries out any or all loading, displaying, running, transmission or storage operation as regards the Software, that it is entitled to carry out hereunder.
+              </p>
+            </li>
+          </list>
+        </li>
+        <li>
+          <b>5.2</b>
+          <p>
+ENTITLEMENT TO MAKE CONTRIBUTIONS
+          </p>
+          <p>
+The right to make Contributions includes the right to translate, adapt, arrange, or make any or all modifications to the Software, and the right to reproduce the resulting software.
+          </p>
+          <p>
+The Licensee is authorized to make any or all Contributions to the Software provided that it includes an explicit notice that it is the author of said Contribution and indicates the date of the creation thereof.
+          </p>
+        </li>
+        <li>
+          <b>5.3</b>
+          <p>
+RIGHT OF DISTRIBUTION
+          </p>
+          <p>
+In particular, the right of distribution includes the right to publish, transmit and communicate the Software to the general public on any or all medium, and by any or all means, and the right to market, either in consideration of a fee, or free of charge, one or more copies of the Software by any means.
+          </p>
+          <p>
+The Licensee is further authorized to distribute copies of the modified or unmodified Software to third parties according to the terms and conditions set forth hereinafter.
+          </p>
+          <list>
+            <li>
+              <b>5.3.1.</b>
+              <p>
+DISTRIBUTION OF SOFTWARE WITHOUT MODIFICATION
+              </p>
+              <p>
+The Licensee is authorized to distribute true copies of the Software in Source Code or Object Code form, provided that said distribution complies with all the provisions of the Agreement and is accompanied by:
+              </p>
+              <list>
+                <li>
+                <b>1.</b>
+                <p>
+a copy of the Agreement,
+                </p>
+              </li>
+              <li>
+                <b>2.</b>
+                <p>
+a notice relating to the limitation of both the Licensor's warranty and liability as set forth in Articles 8 and 9,
+                </p>
+              </li>
+            </list>
+            <p>
+and that, in the event that only the Object Code of the Software is redistributed, the Licensee allows effective access to the full Source Code of the Software at a minimum during the entire period of its distribution of the Software, it being understood that the additional cost of acquiring the Source Code shall not exceed the cost of transferring the data.
+            </p>
+          </li>
+          <li>
+            <b>5.3.2.</b>
+            <p>
+DISTRIBUTION OF MODIFIED SOFTWARE
+            </p>
+            <p>
+If the Licensee makes any Contribution to the Software, the resulting Modified Software may be distributed under a license agreement other than this Agreement subject to compliance with the provisions of Article 5.3.4.
+            </p>
+        </li>
+        <li>
+          <b>5.3.3.</b>
+          <p>
+DISTRIBUTION OF EXTERNAL MODULES
+          </p>
+          <p>
+When the Licensee has developed an External Module, the terms and conditions of this Agreement do not apply to said External Module, that may be distributed under a separate license agreement.
+          </p>
+          </li>
+          <li>
+            <b>5.3.4.</b>
+          <p>
+CREDITS
+          </p>
+          <p>
+Any Licensee who may distribute a Modified Software hereby expressly agrees to:
+          </p>
+	  <list>
+                <li>
+                <b>1.</b>
+                <p>
+indicate in the related documentation that it is based on the Software licensed hereunder, and reproduce the intellectual property notice for the Software,
+                </p>
+              </li>
+              <li>
+                <b>2.</b>
+                <p>
+ensure that written indications of the Software intended use, intellectual property notice and license hereunder are included in easily accessible format from the Modified Software interface,
+                </p>
+              </li>
+              <li>
+                <b>3.</b>
+                <p>
+mention, on a freely accessible website describing the Modified Software, at least throughout the distribution term thereof, that it is based on the Software licensed hereunder, and reproduce the Software intellectual property notice,
+                </p>
+              </li>
+              <li>
+                <b>4.</b>
+                <p>
+where it is distributed to a third party that may distribute a Modified Software without having to make its source code available, make its best efforts to ensure that said third party agrees to comply with the obligations set forth in this Article .
+                </p>
+              </li>
+	    </list>
+	    <p>
+If the Software, whether or not modified, is distributed with an External Module designed for use in connection with the Software, the Licensee shall submit said External Module to the foregoing obligations.
+	    </p>
+          </li>
+          <li>
+            <b>5.3.5.</b>
+            <p>
+COMPATIBILITY WITH THE CeCILL AND CeCILL-C LICENSES
+            </p>
+            <p>
+Where a Modified Software contains a Contribution subject to the CeCILL license, the provisions set forth in Article 5.3.4 shall be optional.
+            </p>
+            <p>
+A Modified Software may be distributed under the CeCILL-C license. In such a case the provisions set forth in Article 5.3.4 shall be optional.
+            </p>
+	  </li>
+	</list>
+      </li>
+      </list>
+    </li>
+      <li>
+        <b>Article 6 -</b>
+      <p>
+INTELLECTUAL PROPERTY
+      </p>
+      <list>
+        <li>
+          <b>6.1</b>
+          <p>
+OVER THE INITIAL SOFTWARE
+          </p>
+          <p>
+The Holder owns the economic rights over the Initial Software. Any or all use of the Initial Software is subject to compliance with the terms and conditions under which the Holder has elected to distribute its work and no one shall be entitled to modify the terms and conditions for the distribution of said Initial Software.
+          </p>
+          <p>
+The Holder undertakes that the Initial Software will remain ruled at least by this Agreement, for the duration set forth in Article 4.2.
+          </p>
+        </li>
+        <li>
+          <b>6.2</b>
+          <p>
+OVER THE CONTRIBUTIONS
+          </p>
+          <p>
+The Licensee who develops a Contribution is the owner of the intellectual property rights over this Contribution as defined by applicable law.
+          </p>
+        </li>
+        <li>
+          <b>6.3</b>
+          <p>
+OVER THE EXTERNAL MODULES
+          </p>
+          <p>
+The Licensee who develops an External Module is the owner of the intellectual property rights over this External Module as defined by applicable law and is free to choose the type of agreement that shall govern its distribution.
+          </p>
+        </li>
+        <li>
+          <b>6.4</b>
+          <p>
+JOINT PROVISIONS
+          </p>
+          <p>
+The Licensee expressly undertakes:
+          </p>
+            <list>
+              <li>
+              <b>1.</b>
+              <p>
+not to remove, or modify, in any manner, the intellectual property notices attached to the Software;
+              </p>
+            </li>
+            <li>
+              <b>2.</b>
+              <p>
+to reproduce said notices, in an identical manner, in the copies of the Software modified or not.
+              </p>
+            </li>
+          </list>
+          <p>
+The Licensee undertakes not to directly or indirectly infringe the intellectual property rights of the Holder and/or Contributors on the Software and to take, where applicable, vis-à-vis its staff, any and all measures required to ensure respect of said intellectual property rights of the Holder and/or Contributors.
+          </p>
+        </li>
+      </list>
+    </li>
+      <li>
+        <b>Article 7 -</b>
+      <p>
+RELATED SERVICES
+      </p>
+      <list>
+        <li>
+          <b>7.1</b>
+          <p>
+Under no circumstances shall the Agreement oblige the Licensor to provide technical assistance or maintenance services for the Software.
+          </p>
+          <p>
+However, the Licensor is entitled to offer this type of services. The terms and conditions of such technical assistance, and/or such maintenance, shall be set forth in a separate instrument. Only the Licensor offering said maintenance and/or technical assistance services shall incur liability therefor.
+          </p>
+        </li>
+        <li>
+          <b>7.2</b>
+          <p>
+Similarly, any Licensor is entitled to offer to its licensees, under its sole responsibility, a warranty, that shall only be binding upon itself, for the redistribution of the Software and/or the Modified Software, under terms and conditions that it is free to decide. Said warranty, and the financial terms and conditions of its application, shall be subject of a separate instrument executed between the Licensor and the Licensee.
+          </p>
+        </li>
+      </list>
+    </li>
+      <li>
+        <b>Article 8 -</b>
+      <p>
+LIABILITY
+      </p>
+      <list>
+        <li>
+          <b>8.1</b>
+          <p>
+Subject to the provisions of Article 8.2, the Licensee shall be entitled to claim compensation for any direct loss it may have suffered from the Software as a result of a fault on the part of the relevant Licensor, subject to providing evidence thereof.
+          </p>
+        </li>
+        <li>
+          <b>8.2</b>
+          <p>
+The Licensor's liability is limited to the commitments made under this Agreement and shall not be incurred as a result of in particular: (i) loss due the Licensee's total or partial failure to fulfill its obligations, (ii) direct or consequential loss that is suffered by the Licensee due to the use or performance of the Software, and (iii) more generally, any consequential loss. In particular the Parties expressly agree that any or all pecuniary or business loss (i.e. loss of data, loss of profits, operating loss, loss of customers or orders, opportunity cost, any disturbance to business activities) or any or all legal proceedings instituted against the Licensee by a third party, shall constitute consequential loss and shall not provide entitlement to any or all compensation from the Licensor.
+          </p>
+        </li>
+      </list>
+    </li>
+      <li>
+        <b>Article 9 -</b>
+      <p>
+WARRANTY
+      </p>
+      <list>
+        <li>
+          <b>9.1</b>
+          <p>
+The Licensee acknowledges that the scientific and technical state-of-the-art when the Software was distributed did not enable all possible uses to be tested and verified, nor for the presence of possible defects to be detected. In this respect, the Licensee's attention has been drawn to the risks associated with loading, using, modifying and/or developing and reproducing the Software which are reserved for experienced users.
+          </p>
+          <p>
+The Licensee shall be responsible for verifying, by any or all means, the suitability of the product for its requirements, its good working order, and for ensuring that it shall not cause damage to either persons or properties.
+          </p>
+        </li>
+        <li>
+          <b>9.2</b>
+          <p>
+The Licensor hereby represents, in good faith, that it is entitled to grant all the rights over the Software (including in particular the rights set forth in Article 5).
+          </p>
+        </li>
+        <li>
+          <b>9.3</b>
+          <p>
+The Licensee acknowledges that the Software is supplied "as is" by the Licensor without any other express or tacit warranty, other than that provided for in Article 9.2 and, in particular, without any warranty as to its commercial value, its secured, safe, innovative or relevant nature.
+
+          </p>
+          <p>
+Specifically, the Licensor does not warrant that the Software is free from any error, that it will operate without interruption, that it will be compatible with the Licensee's own equipment and software configuration, nor that it will meet the Licensee's requirements.
+          </p>
+        </li>
+        <li>
+          <b>9.4</b>
+          <p>
+The Licensor does not either expressly or tacitly warrant that the Software does not infringe any third party intellectual property right relating to a patent, software or any other property right. Therefore, the Licensor disclaims any and all liability towards the Licensee arising out of any or all proceedings for infringement that may be instituted in respect of the use, modification and redistribution of the Software. Nevertheless, should such proceedings be instituted against the Licensee, the Licensor shall provide it with technical and legal assistance for its defense. Such technical and legal assistance shall be decided on a case-by-case basis between the relevant Licensor and the Licensee pursuant to a memorandum of understanding. The Licensor disclaims any and all liability as regards the Licensee's use of the name of the Software. No warranty is given as regards the existence of prior rights over the name of the Software or as regards the existence of a trademark.
+          </p>
+        </li>
+      </list>
+    </li>
+      <li>
+        <b>Article 10 -</b>
+      <p>
+TERMINATION
+      </p>
+      <list>
+        <li>
+          <b>10.1</b>
+          <p>
+In the event of a breach by the Licensee of its obligations hereunder, the Licensor may automatically terminate this Agreement thirty (30) days after notice has been sent to the Licensee and has remained ineffective.
+          </p>
+        </li>
+        <li>
+          <b>10.2</b>
+          <p>
+A Licensee whose Agreement is terminated shall no longer be authorized to use, modify or distribute the Software. However, any licenses that it may have granted prior to termination of the Agreement shall remain valid subject to their having been granted in compliance with the terms and conditions hereof.
+          </p>
+        </li>
+      </list>
+    </li>
+      <li>
+        <b>Article 11 -</b>
+      <p>
+MISCELLANEOUS
+      </p>
+      <list>
+        <li>
+          <b>11.1</b>
+          <p>
+EXCUSABLE EVENTS
+          </p>
+          <p>
+Neither Party shall be liable for any or all delay, or failure to perform the Agreement, that may be attributable to an event of force majeure, an act of God or an outside cause, such as defective functioning or interruptions of the electricity or telecommunications networks, network paralysis following a virus attack, intervention by government authorities, natural disasters, water damage, earthquakes, fire, explosions, strikes and labor unrest, war, etc.
+          </p>
+        </li>
+        <li>
+          <b>11.2</b>
+          <p>
+Any failure by either Party, on one or more occasions, to invoke one or more of the provisions hereof, shall under no circumstances be interpreted as being a waiver by the interested Party of its right to invoke said provision(s) subsequently.
+          </p>
+        </li>
+        <li>
+          <b>11.3</b>
+          <p>
+The Agreement cancels and replaces any or all previous agreements, whether written or oral, between the Parties and having the same purpose, and constitutes the entirety of the agreement between said Parties concerning said purpose. No supplement or modification to the terms and conditions hereof shall be effective as between the Parties unless it is made in writing and signed by their duly authorized representatives.
+          </p>
+        </li>
+        <li>
+          <b>11.4</b>
+          <p>
+In the event that one or more of the provisions hereof were to conflict with a current or future applicable act or legislative text, said act or legislative text shall prevail, and the Parties shall make the necessary amendments so as to comply with said act or legislative text. All other provisions shall remain effective. Similarly, invalidity of a provision of the Agreement, for any reason whatsoever, shall not cause the Agreement as a whole to be invalid.
+          </p>
+        </li>
+        <li>
+          <b>11.5</b>
+          <p>
+LANGUAGE
+          </p>
+          <p>
+The Agreement is drafted in both French and English and both versions are deemed authentic.
+          </p>
+        </li>
+      </list>
+    </li>
+      <li>
+        <b>Article 12 -</b>
+      <p>
+NEW VERSIONS OF THE AGREEMENT
+      </p>
+      <list>
+        <li>
+          <b>12.1</b>
+          <p>
+Any person is authorized to duplicate and distribute copies of this Agreement.
+          </p>
+        </li>
+        <li>
+          <b>12.2</b>
+          <p>
+So as to ensure coherence, the wording of this Agreement is protected and may only be modified by the authors of the License, who reserve the right to periodically publish updates or new versions of the Agreement, each with a separate number. These subsequent versions may address new issues encountered by Free Software.
+          </p>
+        </li>
+        <li>
+          <b>12.3</b>
+          <p>
+Any Software distributed under a given version of the Agreement may only be subsequently distributed under the same version of the Agreement or a subsequent version.
+          </p>
+        </li>
+      </list>
+    </li>
+      <li>
+        <b>Article 13 -</b>
+      <p>
+GOVERNING LAW AND JURISDICTION
+      </p>
+      <list>
+        <li>
+          <b>13.1</b>
+          <p>
+The Agreement is governed by French law. The Parties agree to endeavor to seek an amicable solution to any disagreements or disputes that may arise during the performance of the Agreement.
+          </p>
+        </li>
+        <li>
+          <b>13.2</b>
+          <p>
+Failing an amicable solution within two (2) months as from their occurrence, and unless emergency proceedings are necessary, the disagreements or disputes shall be referred to the Paris Courts having jurisdiction, by the more diligent Party.
+          </p>
+        </li>
+      </list>
+    </li>
+  </list>
+  <p>
+Version 1.0 dated 2006-09-05.
+  </p>
+</license>
+</SPDX>

--- a/src/CECILL-C-fr.xml
+++ b/src/CECILL-C-fr.xml
@@ -1,0 +1,500 @@
+<SPDX name="CeCILL-C Free Software License Agreement" identifier="CECILL-C" osi-approved="false">
+  <urls>
+    <url>http://www.cecill.info/licences/Licence_CeCILL-C_V1-fr.html</url>
+  </urls>
+  <notes>English translation can be found here: http://www.cecill.info/licences/Licence_CeCILL-C_V1-en.html</notes>
+  <license>
+    <title>
+      <p>CONTRAT DE LICENCE DE LOGICIEL LIBRE CeCILL-C</p>
+    </title>
+    <optional>
+      <p>Avertissement</p>
+      <p>Ce contrat est une licence de logiciel libre issue d'une concertation entre ses auteurs afin que le
+         respect de deux grands principes préside à sa rédaction:</p>
+      <list>
+        <li>
+          <p>d'une part, le respect des principes de diffusion des logiciels libres: accès au code source, droits
+            étendus conférés aux utilisateurs,</p>
+        </li>
+        <li>
+            <p>d'autre part, la désignation d'un droit applicable, le droit français, auquel elle est conforme,
+             tant au regard du droit de la responsabilité civile que du droit de la propriété
+             intellectuelle et de la protection qu'il offre aux auteurs et titulaires des droits
+             patrimoniaux sur un logiciel.</p>
+        </li>
+      </list>
+      <p>Les auteurs de la licence CeCILL-C1 sont:</p>
+        <list>
+          <li>
+            <p>Commissariat à l'Energie Atomique - CEA, établissement public de recherche à caractère scientifique,
+             technique et industriel, dont le siège est situé 25 rue Leblanc, immeuble Le Ponant D, 75015
+             Paris.</p>
+          </li>
+          <li>
+            <p>Centre National de la Recherche Scientifique - CNRS, établissement public à caractère scientifique et
+             technologique, dont le siège est situé 3 rue Michel-Ange, 75794 Paris cedex 16.</p>
+          </li>
+          <li>
+            <p>Institut National de Recherche en Informatique et en Automatique - INRIA, établissement public à
+             caractère scientifique et technologique, dont le siège est situé Domaine de Voluceau, Rocquencourt, BP
+             105, 78153 Le Chesnay cedex.</p>
+          </li>
+        </list>
+        </optional>
+        <p>Préambule</p>
+        <p>Ce contrat est une licence de logiciel libre dont l'objectif est de conférer aux utilisateurs la liberté
+         de modifier et de réutiliser le logiciel régi par cette licence.</p>
+        <p>L'exercice de cette liberté est assorti d'une obligation de remettre à la disposition de la communauté
+         les modifications apportées au code source du logiciel afin de contribuer à son évolution.</p>
+        <p>L'accessibilité au code source et les droits de copie, de modification et de redistribution qui découlent
+         de ce contrat ont pour contrepartie de n'offrir aux utilisateurs qu'une garantie limitée et de ne
+         faire peser sur l'auteur du logiciel, le titulaire des droits patrimoniaux et les concédants
+         successifs qu'une responsabilité restreinte.</p>
+        <p>A cet égard l'attention de l'utilisateur est attirée sur les risques associés au chargement, à
+         l'utilisation, à la modification et/ou au développement et à la reproduction du logiciel par
+         l'utilisateur étant donné sa spécificité de logiciel libre, qui peut le rendre complexe à manipuler et
+         qui le réserve donc à des développeurs ou des professionnels avertis possédant des connaissances
+         informatiques approfondies. Les utilisateurs sont donc invités à charger et tester l'adéquation du
+         logiciel à leurs besoins dans des conditions permettant d'assurer la sécurité de leurs systèmes et/ou
+         de leurs données et, plus généralement, à l'utiliser et l'exploiter dans les mêmes conditions de
+         sécurité. Ce contrat peut être reproduit et diffusé librement, sous réserve de le conserver en l'état,
+         sans ajout ni suppression de clauses.</p>
+        <p>Ce contrat est susceptible de s'appliquer à tout logiciel dont le titulaire des droits patrimoniaux
+         décide de soumettre l'exploitation aux dispositions qu'il contient.</p>
+        <list>
+            <li>
+                <p>Article 1 - DEFINITIONS</p>
+                <p>Dans ce contrat, les termes suivants, lorsqu'ils seront écrits avec une lettre capitale, auront la
+                 signification suivante:</p>
+                <p>Contrat: désigne le présent contrat de licence, ses éventuelles versions postérieures et annexes.</p>
+                <p>Logiciel: désigne le logiciel sous sa forme de Code Objet et/ou de Code Source et le cas échéant sa
+                 documentation, dans leur état au moment de l'acceptation du Contrat par le Licencié.</p>
+                <p>Logiciel Initial: désigne le Logiciel sous sa forme de Code Source et éventuellement de Code Objet et le
+                 cas échéant sa documentation, dans leur état au moment de leur première diffusion sous les termes du
+                 Contrat.</p>
+                <p>Logiciel Modifié: désigne le Logiciel modifié par au moins une Contribution Intégrée.</p>
+                <p>Code Source: désigne l'ensemble des instructions et des lignes de programme du Logiciel et auquel l'accès
+                 est nécessaire en vue de modifier le Logiciel.</p>
+                <p>Code Objet: désigne les fichiers binaires issus de la compilation du Code Source.</p>
+                <p>Titulaire: désigne le ou les détenteurs des droits patrimoniaux d'auteur sur le Logiciel Initial.</p>
+                <p>Licencié: désigne le ou les utilisateurs du Logiciel ayant accepté le Contrat.</p>
+                <p>Contributeur: désigne le Licencié auteur d'au moins une Contribution Intégrée.</p>
+                <p>Concédant: désigne le Titulaire ou toute personne physique ou morale distribuant le Logiciel sous le
+                 Contrat.</p>
+                <p>Contribution Intégrée: désigne l'ensemble des modifications, corrections, traductions, adaptations et/ou
+                 nouvelles fonctionnalités intégrées dans le Code Source par tout Contributeur.</p>
+                <p>Module Lié: désigne un ensemble de fichiers sources y compris leur documentation qui, sans modification
+                 du Code Source, permet de réaliser des fonctionnalités ou services supplémentaires à ceux fournis par
+                 le Logiciel.</p>
+                <p>Logiciel Dérivé: désigne toute combinaison du Logiciel, modifié ou non, et d'un Module Lié.</p>
+                <p>Parties: désigne collectivement le Licencié et le Concédant.</p>
+                <p>Ces termes s'entendent au singulier comme au pluriel.</p>
+            </li>
+            <li>
+                <p>Article 2 - OBJET</p>
+                <p>Le Contrat a pour objet la concession par le Concédant au Licencié d'une licence non exclusive, cessible
+                 et mondiale du Logiciel telle que définie ci-après à l'article 5 pour toute la durée de protection des
+                 droits portant sur ce Logiciel.</p>
+            </li>
+            <li>
+                <p>Article 3 - ACCEPTATION</p>
+                <list>
+                    <li>
+                        <b>3.1</b>
+                        <p>L'acceptation par le Licencié des termes du Contrat est réputée acquise du fait du premier des
+                         faits suivants:</p>
+                        <list>
+                            <li>
+                                <b>(i)</b>
+                                <p>le chargement du Logiciel par tout moyen notamment par téléchargement à partir d'un serveur
+                                 distant ou par chargement à partir d'un support physique;</p>
+                            </li>
+                            <li>
+                                <b>(ii)</b>
+                                <p>le premier exercice par le Licencié de l'un quelconque des droits concédés par le Contrat.</p>
+                            </li>
+                        </list>
+                    </li>
+                    <li>
+                        <b>3.2</b>
+                        <p>Un exemplaire du Contrat, contenant notamment un avertissement relatif aux spécificités du
+                         Logiciel, à la restriction de garantie et à la limitation à un usage par des utilisateurs
+                         expérimentés a été mis à disposition du Licencié préalablement à son acceptation telle que
+                         définie à l'article 3.1 ci dessus et le Licencié reconnaît en avoir pris connaissance.</p>
+                    </li>
+                </list>
+            </li>
+            <li>
+                <p>Article 4 - ENTREE EN VIGUEUR ET DUREE</p>
+                <list>
+                    <li>
+                      <b>4.1</b>
+                      <p>ENTREE EN VIGUEUR</p>
+                      <p>Le Contrat entre en vigueur à la date de son acceptation par le Licencié telle que définie en 3.1.</p>
+                    </li>
+                    <li>
+                      <b>4.2</b>
+                      <p>DUREE</p>
+                      <p>Le Contrat produira ses effets pendant toute la durée légale de protection des droits
+                         patrimoniaux portant sur le Logiciel.</p>
+                      
+                    </li>
+                </list>
+            </li>
+            <li>
+                <p>Article 5 - ETENDUE DES DROITS CONCEDES</p>
+                <p>Le Concédant concède au Licencié, qui accepte, les droits suivants sur le Logiciel pour toutes
+                 destinations et pour la durée du Contrat dans les conditions ci-après détaillées.</p>
+                <p>Par ailleurs, si le Concédant détient ou venait à détenir un ou plusieurs brevets d'invention
+                 protégeant tout ou partie des fonctionnalités du Logiciel ou de ses composants, il s'engage à
+                 ne pas opposer les éventuels droits conférés par ces brevets aux Licenciés successifs qui
+                 utiliseraient, exploiteraient ou modifieraient le Logiciel. En cas de cession de ces brevets,
+                 le Concédant s'engage à faire reprendre les obligations du présent alinéa aux
+                 cessionnaires.</p>
+                <list>
+                    <li>
+                      <b>5.1</b>
+                      <p>DROIT D'UTILISATION</p>
+                      <p>Le Licencié est autorisé à utiliser le Logiciel, sans restriction quant aux domaines
+                         d'application, étant ci-après précisé que cela comporte:</p>
+                      <p>la reproduction permanente ou provisoire du Logiciel en tout ou partie par tout moyen et sous
+                         toute forme.</p>
+                      <p>le chargement, l'affichage, l'exécution, ou le stockage du Logiciel sur tout support.</p>
+                      <p>la possibilité d'en observer, d'en étudier, ou d'en tester le fonctionnement afin de déterminer
+                         les idées et principes qui sont à la base de n'importe quel élément de ce Logiciel; et ceci,
+                         lorsque le Licencié effectue toute opération de chargement, d'affichage, d'exécution, de
+                         transmission ou de stockage du Logiciel qu'il est en droit d'effectuer en vertu du
+                         Contrat.</p>
+                    </li>
+                    <li>
+                      <b>5.2</b>
+                      <p>DROIT DE MODIFICATION</p>
+                      <p>Le droit de modification comporte le droit de traduire, d'adapter, d'arranger ou d'apporter toute
+                         autre modification au Logiciel et le droit de reproduire le logiciel en résultant. Il comprend
+                         en particulier le droit de créer un Logiciel Dérivé.</p>
+                      <p>Le Licencié est autorisé à apporter toute modification au Logiciel sous réserve de mentionner, de
+                         façon explicite, son nom en tant qu'auteur de cette modification et la date de création de
+                         celle-ci.</p>
+                    </li>
+                    <li>
+                      <b>5.3</b>
+                      <p>DROIT DE DISTRIBUTION</p>
+                      <p>Le droit de distribution comporte notamment le droit de diffuser, de transmettre et de
+                         communiquer le Logiciel au public sur tout support et par tout moyen ainsi que le droit de
+                         mettre sur le marché à titre onéreux ou gratuit, un ou des exemplaires du Logiciel par tout
+                         procédé.</p>
+                      <p>Le Licencié est autorisé à distribuer des copies du Logiciel, modifié ou non, à des tiers dans
+                         les conditions ci-après détaillées.</p>
+                    </li>
+                    <li>
+                      <p>5.3.1 DISTRIBUTION DU LOGICIEL SANS MODIFICATION</p>
+                      <p>Le Licencié est autorisé à distribuer des copies conformes du Logiciel, sous forme de Code Source
+                         ou de Code Objet, à condition que cette distribution respecte les dispositions du Contrat dans
+                         leur totalité et soit accompagnée:</p>
+                        <list>
+                            <li>
+                                <p>d'un exemplaire du Contrat,</p>
+                            </li>
+                            <li>
+                                <p>d'un avertissement relatif à la restriction de garantie et de responsabilité du Concédant telle
+                                 que prévue aux articles 8 et 9,</p>
+                            </li>
+                        </list>
+                      <p>et que, dans le cas où seul le Code Objet du Logiciel est redistribué, le Licencié permette un
+                         accès effectif au Code Source complet du Logiciel pendant au moins toute la durée de sa
+                         distribution du Logiciel, étant entendu que le coût additionnel d'acquisition du Code Source
+                         ne devra pas excéder le simple coût de transfert des données.</p>
+                    </li>
+                    <li>
+                        <p>5.3.2 DISTRIBUTION DU LOGICIEL MODIFIE</p>
+                        <p>Lorsque le Licencié apporte une Contribution Intégrée au Logiciel, les conditions de distribution
+                         du Logiciel Modifié en résultant sont alors soumises à l'intégralité des dispositions du
+                         Contrat.</p>
+                        <p>Le Licencié est autorisé à distribuer le Logiciel Modifié sous forme de code source ou de code
+                         objet, à condition que cette distribution respecte les dispositions du Contrat dans leur
+                         totalité et soit accompagnée:</p>
+                        <list>
+                          <li><p>d'un exemplaire du Contrat,</p></li>
+                          <li><p>d'un avertissement relatif à la restriction de garantie et de responsabilité du Concédant telle
+                          que prévue aux articles 8 et 9,</p></li>
+                        </list>
+                        <p>et que, dans le cas où seul le code objet du Logiciel Modifié est redistribué, le Licencié
+                         permette un accès effectif à son code source complet pendant au moins toute la durée de sa
+                         distribution du Logiciel Modifié, étant entendu que le coût additionnel d'acquisition du code
+                         source ne devra pas excéder le simple coût de transfert des données.</p>
+                    </li>
+                    <li>
+                        <p>5.3.3 DISTRIBUTION DU LOGICIEL DERIVE</p>
+                        <p>Lorsque le Licencié crée un Logiciel Dérivé, ce Logiciel Dérivé peut être distribué sous un
+                         contrat de licence autre que le présent Contrat à condition de respecter les obligations de
+                         mention des droits sur le Logiciel telles que définies à l'article 6.4. Dans le cas où la
+                         création du Logiciel Dérivé a nécessité une modification du Code Source le licencié s'engage à
+                         ce que:</p>
+                        <list>
+                            <li>
+                                <p>le Logiciel Modifié correspondant à cette modification soit régi par le présent Contrat,</p>
+                            </li>
+                            <li>
+                                <p>les Contributions Intégrées dont le Logiciel Modifié résulte soient clairement identifiées
+                                 et documentées,</p>
+                            </li>
+                            <li>
+                                <p>le Licencié permette un accès effectif au code source du Logiciel Modifié, pendant au moins
+                                 toute la durée de la distribution du Logiciel Dérivé, de telle sorte que ces
+                                 modifications puissent être reprises dans une version ultérieure du Logiciel, étant
+                                 entendu que le coût additionnel d'acquisition du code source du Logiciel Modifié ne
+                                 devra pas excéder le simple coût du transfert des données.</p>
+                            </li>
+                        </list>
+                    </li>
+                    <li>
+                        <p>5.3.4 COMPATIBILITE AVEC LA LICENCE CeCILL</p>
+                        <p>Lorsqu'un Logiciel Modifié contient une Contribution Intégrée soumise au contrat de licence
+                         CeCILL, ou lorsqu'un Logiciel Dérivé contient un Module Lié soumis au contrat de licence
+                         CeCILL, les stipulations prévues au troisième item de l'article 6.4 sont facultatives.</p>
+                    </li>
+                </list>
+            </li>
+            <li>
+                <p>Article 6 - PROPRIETE INTELLECTUELLE</p>
+                <list>
+                    <li>
+                      <b>6.1</b>
+                      <p>SUR LE LOGICIEL INITIAL</p>
+                      <p>Le Titulaire est détenteur des droits patrimoniaux sur le Logiciel Initial. Toute utilisation du
+                         Logiciel Initial est soumise au respect des conditions dans lesquelles le Titulaire a choisi
+                         de diffuser son oeuvre et nul autre n'a la faculté de modifier les conditions de diffusion de
+                         ce Logiciel Initial.</p>
+                      <p>Le Titulaire s'engage à ce que le Logiciel Initial reste au moins régi par le Contrat et ce, pour
+                         la durée visée à l'article 4.2.</p>
+                    </li>
+                    <li>
+                      <b>6.2</b>
+                      <p>SUR LES CONTRIBUTIONS INTEGREES</p>
+                      <p>Le Licencié qui a développé une Contribution Intégrée est titulaire sur celle-ci des droits de
+                         propriété intellectuelle dans les conditions définies par la législation applicable.</p>
+                    </li>
+                    <li>
+                      <b>6.3</b>
+                      <p>SUR LES MODULES LIES</p>
+                      <p>Le Licencié qui a développé un Module Lié est titulaire sur celui-ci des droits de propriété
+                         intellectuelle dans les conditions définies par la législation applicable et reste libre du
+                         choix du contrat régissant sa diffusion dans les conditions définies à l'article 5.3.3.</p>
+                    </li>
+                     <li>
+                      <b>6.4</b>
+                      <p>MENTIONS DES DROITS</p>
+                      <p>Le Licencié s'engage expressément:</p>
+                      <list>
+                            <p>à ne pas supprimer ou modifier de quelque manière que ce soit les mentions de propriété
+                             intellectuelle apposées sur le Logiciel;</p>
+                            <p>à reproduire à l'identique lesdites mentions de propriété intellectuelle sur les copies du
+                             Logiciel modifié ou non;</p>
+                            <p>à faire en sorte que l'utilisation du Logiciel, ses mentions de propriété intellectuelle et le
+                             fait qu'il est régi par le Contrat soient indiqués dans un texte facilement accessible
+                             notamment depuis l'interface de tout Logiciel Dérivé.</p> 
+                      </list>
+                      <p>Le Licencié s'engage à ne pas porter atteinte, directement ou indirectement, aux droits de
+                        propriété intellectuelle du Titulaire et/ou des Contributeurs sur le Logiciel et à
+                        prendre, le cas échéant, à l'égard de son personnel toutes les mesures nécessaires
+                        pour assurer le respect des dits droits de propriété intellectuelle du Titulaire et/ou
+                        des Contributeurs.</p>
+                    </li> 
+                </list>
+            </li>
+            <li>
+                <p>Article 7 - SERVICES ASSOCIES</p>
+                <list>
+                    <li>
+                        <b>7.1</b>
+                        <p>Le Contrat n'oblige en aucun cas le Concédant à la réalisation de prestations d'assistance
+                         technique ou de maintenance du Logiciel.</p>
+                        <p>Cependant le Concédant reste libre de proposer ce type de services. Les termes et conditions
+                         d'une telle assistance technique et/ou d'une telle maintenance seront alors déterminés dans un
+                         acte séparé. Ces actes de maintenance et/ou assistance technique n'engageront que la seule
+                         responsabilité du Concédant qui les propose.</p>
+                    </li>
+                    <li>
+                        <b>7.2</b>
+                        <p>De même, tout Concédant est libre de proposer, sous sa seule responsabilité, à ses licenciés une
+                         garantie, qui n'engagera que lui, lors de la redistribution du Logiciel et/ou du Logiciel
+                         Modifié et ce, dans les conditions qu'il souhaite. Cette garantie et les modalités financières
+                         de son application feront l'objet d'un acte séparé entre le Concédant et le Licencié.</p>
+                    </li>
+                </list>
+            </li>
+            <li>
+                <p>Article 8 - RESPONSABILITE</p>
+                <list>
+                    <li>
+                        <b>8.1</b>
+                        <p>Sous réserve des dispositions de l'article 8.2, le Licencié a la faculté, sous réserve de prouver
+                         la faute du Concédant concerné, de solliciter la réparation du préjudice direct qu'il subirait
+                         du fait du Logiciel et dont il apportera la preuve.</p>
+                    </li>
+                    <li>
+                        <b>8.2</b>
+                        <p>La responsabilité du Concédant est limitée aux engagements pris en application du Contrat et ne
+                         saurait être engagée en raison notamment: (i) des dommages dus à l'inexécution, totale ou
+                         partielle, de ses obligations par le Licencié, (ii) des dommages directs ou indirects
+                         découlant de l'utilisation ou des performances du Logiciel subis par le Licencié et (iii) plus
+                         généralement d'un quelconque dommage indirect. En particulier, les Parties conviennent
+                         expressément que tout préjudice financier ou commercial (par exemple perte de données, perte
+                         de bénéfices, perte d'exploitation, perte de clientèle ou de commandes, manque à gagner,
+                         trouble commercial quelconque) ou toute action dirigée contre le Licencié par un tiers,
+                         constitue un dommage indirect et n'ouvre pas droit à réparation par le Concédant.</p>
+                    </li>
+                </list>
+            </li>
+            <li>
+                <p>Article 9 - GARANTIE</p>
+                <list>
+                    <li>
+                        <b>9.1</b>
+                        <p>Le Licencié reconnaît que l'état actuel des connaissances scientifiques et techniques au moment
+                         de la mise en circulation du Logiciel ne permet pas d'en tester et d'en vérifier toutes les
+                         utilisations ni de détecter l'existence d'éventuels défauts. L'attention du Licencié a été
+                         attirée sur ce point sur les risques associés au chargement, à l'utilisation, la modification
+                         et/ou au développement et à la reproduction du Logiciel qui sont réservés à des utilisateurs
+                         avertis.</p>
+                        <p>Il relève de la responsabilité du Licencié de contrôler, par tous moyens, l'adéquation du produit
+                         à ses besoins, son bon fonctionnement et de s'assurer qu'il ne causera pas de dommages aux
+                         personnes et aux biens.</p>
+                    </li>
+                    <li>
+                        <b>9.2</b>
+                        <p>Le Concédant déclare de bonne foi être en droit de concéder l'ensemble des droits attachés au
+                         Logiciel (comprenant notamment les droits visés à l'article 5).</p>
+                    </li>
+                    <li>
+                        <b>9.3</b>
+                        <p>Le Licencié reconnaît que le Logiciel est fourni "en l'état" par le Concédant sans autre
+                         garantie, expresse ou tacite, que celle prévue à l'article 9.2 et notamment sans aucune
+                         garantie sur sa valeur commerciale, son caractère sécurisé, innovant ou pertinent.</p>
+                        <p>En particulier, le Concédant ne garantit pas que le Logiciel est exempt d'erreur, qu'il
+                         fonctionnera sans interruption, qu'il sera compatible avec l'équipement du Licencié et sa
+                         configuration logicielle ni qu'il remplira les besoins du Licencié.</p>
+                    </li>
+                    <li>
+                        <b>9.4</b>
+                        <p>Le Concédant ne garantit pas, de manière expresse ou tacite, que le Logiciel ne porte pas
+                         atteinte à un quelconque droit de propriété intellectuelle d'un tiers portant sur un brevet,
+                         un logiciel ou sur tout autre droit de propriété. Ainsi, le Concédant exclut toute garantie au
+                         profit du Licencié contre les actions en contrefaçon qui pourraient être diligentées au titre
+                         de l'utilisation, de la modification, et de la redistribution du Logiciel. Néanmoins, si de
+                         telles actions sont exercées contre le Licencié, le Concédant lui apportera son aide technique
+                         et juridique pour sa défense. Cette aide technique et juridique est déterminée au cas par cas
+                         entre le Concédant concerné et le Licencié dans le cadre d'un protocole d'accord. Le Concédant
+                         dégage toute responsabilité quant à l'utilisation de la dénomination du Logiciel par le
+                         Licencié. Aucune garantie n'est apportée quant à l'existence de droits antérieurs sur le nom
+                         du Logiciel et sur l'existence d'une marque.</p>
+                    </li>
+                </list>
+            </li>
+            <li>
+                <p>Article 10 - RESILIATION</p>
+                <list>
+                    <li>
+                      <b>10.1</b>
+                      <p>En cas de manquement par le Licencié aux obligations mises à sa charge par le Contrat, le
+                         Concédant pourra résilier de plein droit le Contrat trente (30) jours après notification
+                         adressée au Licencié et restée sans effet.</p>
+                    </li>
+                    <li>
+                      <b>10.2</b>
+                      <p>Le Licencié dont le Contrat est résilié n'est plus autorisé à utiliser, modifier ou distribuer le
+                         Logiciel. Cependant, toutes les licences qu'il aura concédées antérieurement à la résiliation
+                         du Contrat resteront valides sous réserve qu'elles aient été effectuées en conformité avec le
+                         Contrat.</p>
+                    </li>
+                </list>
+            </li>
+            <li>
+                <p>Article 11 - DISPOSITIONS DIVERSES</p>
+                <list>
+                    <li>
+                      <b>11.1</b>
+                      <p>CAUSE EXTERIEURE</p>
+                      <p>Aucune des Parties ne sera responsable d'un retard ou d'une défaillance d'exécution du Contrat
+                         qui serait dû à un cas de force majeure, un cas fortuit ou une cause extérieure, telle que,
+                         notamment, le mauvais fonctionnement ou les interruptions du réseau électrique ou de
+                         télécommunication, la paralysie du réseau liée à une attaque informatique, l'intervention des
+                         autorités gouvernementales, les catastrophes naturelles, les dégâts des eaux, les tremblements
+                         de terre, le feu, les explosions, les grèves et les conflits sociaux, l'état de guerre...</p>
+                    </li>
+                    <li>
+                      <b>11.2</b>
+                      <p>Le fait, par l'une ou l'autre des Parties, d'omettre en une ou plusieurs occasions de se
+                         prévaloir d'une ou plusieurs dispositions du Contrat, ne pourra en aucun cas impliquer
+                         renonciation par la Partie intéressée à s'en prévaloir ultérieurement.</p>
+                    </li>
+                    <li>
+                      <b>11.3</b>
+                      <p>Le Contrat annule et remplace toute convention antérieure, écrite ou orale, entre les Parties sur
+                         le même objet et constitue l'accord entier entre les Parties sur cet objet. Aucune addition ou
+                         modification aux termes du Contrat n'aura d'effet à l'égard des Parties à moins d'être faite
+                         par écrit et signée par leurs représentants dûment habilités.</p>
+                    </li>
+                    <li>
+                      <b>11.4</b>
+                      <p>Dans l'hypothèse où une ou plusieurs des dispositions du Contrat s'avèrerait contraire à une loi
+                         ou à un texte applicable, existants ou futurs, cette loi ou ce texte prévaudrait, et les
+                         Parties feraient les amendements nécessaires pour se conformer à cette loi ou à ce texte.
+                         Toutes les autres dispositions resteront en vigueur. De même, la nullité, pour quelque raison
+                         que ce soit, d'une des dispositions du Contrat ne saurait entraîner la nullité de l'ensemble
+                         du Contrat.</p>
+                    </li>
+                    <li>
+                      <b>11.5</b>
+                      <p>LANGUE</p>
+                      <p>Le Contrat est rédigé en langue française et en langue anglaise, ces deux versions faisant
+                         également foi.</p>
+                    </li>
+                </list>
+            </li>
+            <li>
+                <p>Article 12 - NOUVELLES VERSIONS DU CONTRAT</p>
+                <list>
+                    <li>
+                      <b>12.1</b>
+                      <p>Toute personne est autorisée à copier et distribuer des copies de ce Contrat.</p>
+                    </li>
+                    <li>
+                      <b>12.2</b>
+                      <p>Afin d'en préserver la cohérence, le texte du Contrat est protégé et ne peut être modifié que par
+                         les auteurs de la licence, lesquels se réservent le droit de publier périodiquement des mises
+                         à jour ou de nouvelles versions du Contrat, qui posséderont chacune un numéro distinct. Ces
+                         versions ultérieures seront susceptibles de prendre en compte de nouvelles problématiques
+                         rencontrées par les logiciels libres.</p>
+                    </li>
+                    <li>
+                      <b>12.3</b>
+                      <p>Tout Logiciel diffusé sous une version donnée du Contrat ne pourra faire l'objet d'une diffusion
+                         ultérieure que sous la même version du Contrat ou une version postérieure.</p>
+                    </li>
+                </list>
+            </li>
+            <li>
+                <p>Article 13 - LOI APPLICABLE ET COMPETENCE TERRITORIALE</p>
+                <list>
+                    <li>
+                      <b>13.1</b>
+                      <p>Le Contrat est régi par la loi française. Les Parties conviennent de tenter de régler à l'amiable
+                         les différends ou litiges qui viendraient à se produire par suite ou à l'occasion du
+                         Contrat.</p>
+                    </li>
+                    <li>
+                      <b>13.2</b>
+                      <p>A défaut d'accord amiable dans un délai de deux (2) mois à compter de leur survenance et sauf
+                         situation relevant d'une procédure d'urgence, les différends ou litiges seront portés par la
+                         Partie la plus diligente devant les Tribunaux compétents de Paris.</p>
+                    </li>
+                </list>
+            </li>
+        </list>
+    <p>1 CeCILL est pour Ce(a) C(nrs) I(nria) L(ogiciel) L(ibre)</p>
+    <optional>
+      <p>Version 1.0 du 2006-09-05.</p>
+    </optional>
+  </license>
+</SPDX>

--- a/src/CECILL-C.xml
+++ b/src/CECILL-C.xml
@@ -1,500 +1,658 @@
 <SPDX name="CeCILL-C Free Software License Agreement" identifier="CECILL-C" osi-approved="false">
   <urls>
-    <url>http://www.cecill.info/licences/Licence_CeCILL-C_V1-fr.html</url>
+    <url>http://www.cecill.info/licences/Licence_CeCILL-C_V1-en.html
+    </url>
   </urls>
-  <notes>English translation can be found here: http://www.cecill.info/licences/Licence_CeCILL-C_V1-en.html</notes>
+  <notes>
+French version can be found here: http://www.cecill.info/licences/Licence_CeCILL-C_V1-fr.html
+  </notes>
   <license>
     <title>
-      <p>CONTRAT DE LICENCE DE LOGICIEL LIBRE CeCILL-C</p>
+      <p>
+CeCILL-C FREE SOFTWARE LICENSE AGREEMENT
+      </p>
     </title>
     <optional>
-      <p>Avertissement</p>
-      <p>Ce contrat est une licence de logiciel libre issue d'une concertation entre ses auteurs afin que le
-         respect de deux grands principes préside à sa rédaction:</p>
+      <p>
+Notice
+      </p>
+      <p>
+This Agreement is a Free Software license agreement that is the result of discussions between its authors in order to ensure compliance with the two main principles guiding its drafting:
+      </p>
       <list>
         <li>
-          <p>d'une part, le respect des principes de diffusion des logiciels libres: accès au code source, droits
-            étendus conférés aux utilisateurs,</p>
+          <b>*</b>
+          <p>
+firstly, compliance with the principles governing the distribution of Free Software: access to source code, broad rights granted to users,
+          </p>
         </li>
         <li>
-            <p>d'autre part, la désignation d'un droit applicable, le droit français, auquel elle est conforme,
-             tant au regard du droit de la responsabilité civile que du droit de la propriété
-             intellectuelle et de la protection qu'il offre aux auteurs et titulaires des droits
-             patrimoniaux sur un logiciel.</p>
+          <b>*</b>
+          <p>
+secondly, the election of a governing law, French law, with which it is conformant, both as regards the law of torts and intellectual property law, and the protection that it offers to both authors and holders of the economic rights over software.
+          </p>
         </li>
       </list>
-      <p>Les auteurs de la licence CeCILL-C1 sont:</p>
-        <list>
-          <li>
-            <p>Commissariat à l'Energie Atomique - CEA, établissement public de recherche à caractère scientifique,
-             technique et industriel, dont le siège est situé 25 rue Leblanc, immeuble Le Ponant D, 75015
-             Paris.</p>
-          </li>
-          <li>
-            <p>Centre National de la Recherche Scientifique - CNRS, établissement public à caractère scientifique et
-             technologique, dont le siège est situé 3 rue Michel-Ange, 75794 Paris cedex 16.</p>
-          </li>
-          <li>
-            <p>Institut National de Recherche en Informatique et en Automatique - INRIA, établissement public à
-             caractère scientifique et technologique, dont le siège est situé Domaine de Voluceau, Rocquencourt, BP
-             105, 78153 Le Chesnay cedex.</p>
-          </li>
-        </list>
-        </optional>
-        <p>Préambule</p>
-        <p>Ce contrat est une licence de logiciel libre dont l'objectif est de conférer aux utilisateurs la liberté
-         de modifier et de réutiliser le logiciel régi par cette licence.</p>
-        <p>L'exercice de cette liberté est assorti d'une obligation de remettre à la disposition de la communauté
-         les modifications apportées au code source du logiciel afin de contribuer à son évolution.</p>
-        <p>L'accessibilité au code source et les droits de copie, de modification et de redistribution qui découlent
-         de ce contrat ont pour contrepartie de n'offrir aux utilisateurs qu'une garantie limitée et de ne
-         faire peser sur l'auteur du logiciel, le titulaire des droits patrimoniaux et les concédants
-         successifs qu'une responsabilité restreinte.</p>
-        <p>A cet égard l'attention de l'utilisateur est attirée sur les risques associés au chargement, à
-         l'utilisation, à la modification et/ou au développement et à la reproduction du logiciel par
-         l'utilisateur étant donné sa spécificité de logiciel libre, qui peut le rendre complexe à manipuler et
-         qui le réserve donc à des développeurs ou des professionnels avertis possédant des connaissances
-         informatiques approfondies. Les utilisateurs sont donc invités à charger et tester l'adéquation du
-         logiciel à leurs besoins dans des conditions permettant d'assurer la sécurité de leurs systèmes et/ou
-         de leurs données et, plus généralement, à l'utiliser et l'exploiter dans les mêmes conditions de
-         sécurité. Ce contrat peut être reproduit et diffusé librement, sous réserve de le conserver en l'état,
-         sans ajout ni suppression de clauses.</p>
-        <p>Ce contrat est susceptible de s'appliquer à tout logiciel dont le titulaire des droits patrimoniaux
-         décide de soumettre l'exploitation aux dispositions qu'il contient.</p>
-        <list>
-            <li>
-                <p>Article 1 - DEFINITIONS</p>
-                <p>Dans ce contrat, les termes suivants, lorsqu'ils seront écrits avec une lettre capitale, auront la
-                 signification suivante:</p>
-                <p>Contrat: désigne le présent contrat de licence, ses éventuelles versions postérieures et annexes.</p>
-                <p>Logiciel: désigne le logiciel sous sa forme de Code Objet et/ou de Code Source et le cas échéant sa
-                 documentation, dans leur état au moment de l'acceptation du Contrat par le Licencié.</p>
-                <p>Logiciel Initial: désigne le Logiciel sous sa forme de Code Source et éventuellement de Code Objet et le
-                 cas échéant sa documentation, dans leur état au moment de leur première diffusion sous les termes du
-                 Contrat.</p>
-                <p>Logiciel Modifié: désigne le Logiciel modifié par au moins une Contribution Intégrée.</p>
-                <p>Code Source: désigne l'ensemble des instructions et des lignes de programme du Logiciel et auquel l'accès
-                 est nécessaire en vue de modifier le Logiciel.</p>
-                <p>Code Objet: désigne les fichiers binaires issus de la compilation du Code Source.</p>
-                <p>Titulaire: désigne le ou les détenteurs des droits patrimoniaux d'auteur sur le Logiciel Initial.</p>
-                <p>Licencié: désigne le ou les utilisateurs du Logiciel ayant accepté le Contrat.</p>
-                <p>Contributeur: désigne le Licencié auteur d'au moins une Contribution Intégrée.</p>
-                <p>Concédant: désigne le Titulaire ou toute personne physique ou morale distribuant le Logiciel sous le
-                 Contrat.</p>
-                <p>Contribution Intégrée: désigne l'ensemble des modifications, corrections, traductions, adaptations et/ou
-                 nouvelles fonctionnalités intégrées dans le Code Source par tout Contributeur.</p>
-                <p>Module Lié: désigne un ensemble de fichiers sources y compris leur documentation qui, sans modification
-                 du Code Source, permet de réaliser des fonctionnalités ou services supplémentaires à ceux fournis par
-                 le Logiciel.</p>
-                <p>Logiciel Dérivé: désigne toute combinaison du Logiciel, modifié ou non, et d'un Module Lié.</p>
-                <p>Parties: désigne collectivement le Licencié et le Concédant.</p>
-                <p>Ces termes s'entendent au singulier comme au pluriel.</p>
-            </li>
-            <li>
-                <p>Article 2 - OBJET</p>
-                <p>Le Contrat a pour objet la concession par le Concédant au Licencié d'une licence non exclusive, cessible
-                 et mondiale du Logiciel telle que définie ci-après à l'article 5 pour toute la durée de protection des
-                 droits portant sur ce Logiciel.</p>
-            </li>
-            <li>
-                <p>Article 3 - ACCEPTATION</p>
-                <list>
-                    <li>
-                        <b>3.1</b>
-                        <p>L'acceptation par le Licencié des termes du Contrat est réputée acquise du fait du premier des
-                         faits suivants:</p>
-                        <list>
-                            <li>
-                                <b>(i)</b>
-                                <p>le chargement du Logiciel par tout moyen notamment par téléchargement à partir d'un serveur
-                                 distant ou par chargement à partir d'un support physique;</p>
-                            </li>
-                            <li>
-                                <b>(ii)</b>
-                                <p>le premier exercice par le Licencié de l'un quelconque des droits concédés par le Contrat.</p>
-                            </li>
-                        </list>
-                    </li>
-                    <li>
-                        <b>3.2</b>
-                        <p>Un exemplaire du Contrat, contenant notamment un avertissement relatif aux spécificités du
-                         Logiciel, à la restriction de garantie et à la limitation à un usage par des utilisateurs
-                         expérimentés a été mis à disposition du Licencié préalablement à son acceptation telle que
-                         définie à l'article 3.1 ci dessus et le Licencié reconnaît en avoir pris connaissance.</p>
-                    </li>
-                </list>
-            </li>
-            <li>
-                <p>Article 4 - ENTREE EN VIGUEUR ET DUREE</p>
-                <list>
-                    <li>
-                      <b>4.1</b>
-                      <p>ENTREE EN VIGUEUR</p>
-                      <p>Le Contrat entre en vigueur à la date de son acceptation par le Licencié telle que définie en 3.1.</p>
-                    </li>
-                    <li>
-                      <b>4.2</b>
-                      <p>DUREE</p>
-                      <p>Le Contrat produira ses effets pendant toute la durée légale de protection des droits
-                         patrimoniaux portant sur le Logiciel.</p>
-                      
-                    </li>
-                </list>
-            </li>
-            <li>
-                <p>Article 5 - ETENDUE DES DROITS CONCEDES</p>
-                <p>Le Concédant concède au Licencié, qui accepte, les droits suivants sur le Logiciel pour toutes
-                 destinations et pour la durée du Contrat dans les conditions ci-après détaillées.</p>
-                <p>Par ailleurs, si le Concédant détient ou venait à détenir un ou plusieurs brevets d'invention
-                 protégeant tout ou partie des fonctionnalités du Logiciel ou de ses composants, il s'engage à
-                 ne pas opposer les éventuels droits conférés par ces brevets aux Licenciés successifs qui
-                 utiliseraient, exploiteraient ou modifieraient le Logiciel. En cas de cession de ces brevets,
-                 le Concédant s'engage à faire reprendre les obligations du présent alinéa aux
-                 cessionnaires.</p>
-                <list>
-                    <li>
-                      <b>5.1</b>
-                      <p>DROIT D'UTILISATION</p>
-                      <p>Le Licencié est autorisé à utiliser le Logiciel, sans restriction quant aux domaines
-                         d'application, étant ci-après précisé que cela comporte:</p>
-                      <p>la reproduction permanente ou provisoire du Logiciel en tout ou partie par tout moyen et sous
-                         toute forme.</p>
-                      <p>le chargement, l'affichage, l'exécution, ou le stockage du Logiciel sur tout support.</p>
-                      <p>la possibilité d'en observer, d'en étudier, ou d'en tester le fonctionnement afin de déterminer
-                         les idées et principes qui sont à la base de n'importe quel élément de ce Logiciel; et ceci,
-                         lorsque le Licencié effectue toute opération de chargement, d'affichage, d'exécution, de
-                         transmission ou de stockage du Logiciel qu'il est en droit d'effectuer en vertu du
-                         Contrat.</p>
-                    </li>
-                    <li>
-                      <b>5.2</b>
-                      <p>DROIT DE MODIFICATION</p>
-                      <p>Le droit de modification comporte le droit de traduire, d'adapter, d'arranger ou d'apporter toute
-                         autre modification au Logiciel et le droit de reproduire le logiciel en résultant. Il comprend
-                         en particulier le droit de créer un Logiciel Dérivé.</p>
-                      <p>Le Licencié est autorisé à apporter toute modification au Logiciel sous réserve de mentionner, de
-                         façon explicite, son nom en tant qu'auteur de cette modification et la date de création de
-                         celle-ci.</p>
-                    </li>
-                    <li>
-                      <b>5.3</b>
-                      <p>DROIT DE DISTRIBUTION</p>
-                      <p>Le droit de distribution comporte notamment le droit de diffuser, de transmettre et de
-                         communiquer le Logiciel au public sur tout support et par tout moyen ainsi que le droit de
-                         mettre sur le marché à titre onéreux ou gratuit, un ou des exemplaires du Logiciel par tout
-                         procédé.</p>
-                      <p>Le Licencié est autorisé à distribuer des copies du Logiciel, modifié ou non, à des tiers dans
-                         les conditions ci-après détaillées.</p>
-                    </li>
-                    <li>
-                      <p>5.3.1 DISTRIBUTION DU LOGICIEL SANS MODIFICATION</p>
-                      <p>Le Licencié est autorisé à distribuer des copies conformes du Logiciel, sous forme de Code Source
-                         ou de Code Objet, à condition que cette distribution respecte les dispositions du Contrat dans
-                         leur totalité et soit accompagnée:</p>
-                        <list>
-                            <li>
-                                <p>d'un exemplaire du Contrat,</p>
-                            </li>
-                            <li>
-                                <p>d'un avertissement relatif à la restriction de garantie et de responsabilité du Concédant telle
-                                 que prévue aux articles 8 et 9,</p>
-                            </li>
-                        </list>
-                      <p>et que, dans le cas où seul le Code Objet du Logiciel est redistribué, le Licencié permette un
-                         accès effectif au Code Source complet du Logiciel pendant au moins toute la durée de sa
-                         distribution du Logiciel, étant entendu que le coût additionnel d'acquisition du Code Source
-                         ne devra pas excéder le simple coût de transfert des données.</p>
-                    </li>
-                    <li>
-                        <p>5.3.2 DISTRIBUTION DU LOGICIEL MODIFIE</p>
-                        <p>Lorsque le Licencié apporte une Contribution Intégrée au Logiciel, les conditions de distribution
-                         du Logiciel Modifié en résultant sont alors soumises à l'intégralité des dispositions du
-                         Contrat.</p>
-                        <p>Le Licencié est autorisé à distribuer le Logiciel Modifié sous forme de code source ou de code
-                         objet, à condition que cette distribution respecte les dispositions du Contrat dans leur
-                         totalité et soit accompagnée:</p>
-                        <list>
-                          <li><p>d'un exemplaire du Contrat,</p></li>
-                          <li><p>d'un avertissement relatif à la restriction de garantie et de responsabilité du Concédant telle
-                          que prévue aux articles 8 et 9,</p></li>
-                        </list>
-                        <p>et que, dans le cas où seul le code objet du Logiciel Modifié est redistribué, le Licencié
-                         permette un accès effectif à son code source complet pendant au moins toute la durée de sa
-                         distribution du Logiciel Modifié, étant entendu que le coût additionnel d'acquisition du code
-                         source ne devra pas excéder le simple coût de transfert des données.</p>
-                    </li>
-                    <li>
-                        <p>5.3.3 DISTRIBUTION DU LOGICIEL DERIVE</p>
-                        <p>Lorsque le Licencié crée un Logiciel Dérivé, ce Logiciel Dérivé peut être distribué sous un
-                         contrat de licence autre que le présent Contrat à condition de respecter les obligations de
-                         mention des droits sur le Logiciel telles que définies à l'article 6.4. Dans le cas où la
-                         création du Logiciel Dérivé a nécessité une modification du Code Source le licencié s'engage à
-                         ce que:</p>
-                        <list>
-                            <li>
-                                <p>le Logiciel Modifié correspondant à cette modification soit régi par le présent Contrat,</p>
-                            </li>
-                            <li>
-                                <p>les Contributions Intégrées dont le Logiciel Modifié résulte soient clairement identifiées
-                                 et documentées,</p>
-                            </li>
-                            <li>
-                                <p>le Licencié permette un accès effectif au code source du Logiciel Modifié, pendant au moins
-                                 toute la durée de la distribution du Logiciel Dérivé, de telle sorte que ces
-                                 modifications puissent être reprises dans une version ultérieure du Logiciel, étant
-                                 entendu que le coût additionnel d'acquisition du code source du Logiciel Modifié ne
-                                 devra pas excéder le simple coût du transfert des données.</p>
-                            </li>
-                        </list>
-                    </li>
-                    <li>
-                        <p>5.3.4 COMPATIBILITE AVEC LA LICENCE CeCILL</p>
-                        <p>Lorsqu'un Logiciel Modifié contient une Contribution Intégrée soumise au contrat de licence
-                         CeCILL, ou lorsqu'un Logiciel Dérivé contient un Module Lié soumis au contrat de licence
-                         CeCILL, les stipulations prévues au troisième item de l'article 6.4 sont facultatives.</p>
-                    </li>
-                </list>
-            </li>
-            <li>
-                <p>Article 6 - PROPRIETE INTELLECTUELLE</p>
-                <list>
-                    <li>
-                      <b>6.1</b>
-                      <p>SUR LE LOGICIEL INITIAL</p>
-                      <p>Le Titulaire est détenteur des droits patrimoniaux sur le Logiciel Initial. Toute utilisation du
-                         Logiciel Initial est soumise au respect des conditions dans lesquelles le Titulaire a choisi
-                         de diffuser son oeuvre et nul autre n'a la faculté de modifier les conditions de diffusion de
-                         ce Logiciel Initial.</p>
-                      <p>Le Titulaire s'engage à ce que le Logiciel Initial reste au moins régi par le Contrat et ce, pour
-                         la durée visée à l'article 4.2.</p>
-                    </li>
-                    <li>
-                      <b>6.2</b>
-                      <p>SUR LES CONTRIBUTIONS INTEGREES</p>
-                      <p>Le Licencié qui a développé une Contribution Intégrée est titulaire sur celle-ci des droits de
-                         propriété intellectuelle dans les conditions définies par la législation applicable.</p>
-                    </li>
-                    <li>
-                      <b>6.3</b>
-                      <p>SUR LES MODULES LIES</p>
-                      <p>Le Licencié qui a développé un Module Lié est titulaire sur celui-ci des droits de propriété
-                         intellectuelle dans les conditions définies par la législation applicable et reste libre du
-                         choix du contrat régissant sa diffusion dans les conditions définies à l'article 5.3.3.</p>
-                    </li>
-                     <li>
-                      <b>6.4</b>
-                      <p>MENTIONS DES DROITS</p>
-                      <p>Le Licencié s'engage expressément:</p>
-                      <list>
-                            <p>à ne pas supprimer ou modifier de quelque manière que ce soit les mentions de propriété
-                             intellectuelle apposées sur le Logiciel;</p>
-                            <p>à reproduire à l'identique lesdites mentions de propriété intellectuelle sur les copies du
-                             Logiciel modifié ou non;</p>
-                            <p>à faire en sorte que l'utilisation du Logiciel, ses mentions de propriété intellectuelle et le
-                             fait qu'il est régi par le Contrat soient indiqués dans un texte facilement accessible
-                             notamment depuis l'interface de tout Logiciel Dérivé.</p> 
-                      </list>
-                      <p>Le Licencié s'engage à ne pas porter atteinte, directement ou indirectement, aux droits de
-                        propriété intellectuelle du Titulaire et/ou des Contributeurs sur le Logiciel et à
-                        prendre, le cas échéant, à l'égard de son personnel toutes les mesures nécessaires
-                        pour assurer le respect des dits droits de propriété intellectuelle du Titulaire et/ou
-                        des Contributeurs.</p>
-                    </li> 
-                </list>
-            </li>
-            <li>
-                <p>Article 7 - SERVICES ASSOCIES</p>
-                <list>
-                    <li>
-                        <b>7.1</b>
-                        <p>Le Contrat n'oblige en aucun cas le Concédant à la réalisation de prestations d'assistance
-                         technique ou de maintenance du Logiciel.</p>
-                        <p>Cependant le Concédant reste libre de proposer ce type de services. Les termes et conditions
-                         d'une telle assistance technique et/ou d'une telle maintenance seront alors déterminés dans un
-                         acte séparé. Ces actes de maintenance et/ou assistance technique n'engageront que la seule
-                         responsabilité du Concédant qui les propose.</p>
-                    </li>
-                    <li>
-                        <b>7.2</b>
-                        <p>De même, tout Concédant est libre de proposer, sous sa seule responsabilité, à ses licenciés une
-                         garantie, qui n'engagera que lui, lors de la redistribution du Logiciel et/ou du Logiciel
-                         Modifié et ce, dans les conditions qu'il souhaite. Cette garantie et les modalités financières
-                         de son application feront l'objet d'un acte séparé entre le Concédant et le Licencié.</p>
-                    </li>
-                </list>
-            </li>
-            <li>
-                <p>Article 8 - RESPONSABILITE</p>
-                <list>
-                    <li>
-                        <b>8.1</b>
-                        <p>Sous réserve des dispositions de l'article 8.2, le Licencié a la faculté, sous réserve de prouver
-                         la faute du Concédant concerné, de solliciter la réparation du préjudice direct qu'il subirait
-                         du fait du Logiciel et dont il apportera la preuve.</p>
-                    </li>
-                    <li>
-                        <b>8.2</b>
-                        <p>La responsabilité du Concédant est limitée aux engagements pris en application du Contrat et ne
-                         saurait être engagée en raison notamment: (i) des dommages dus à l'inexécution, totale ou
-                         partielle, de ses obligations par le Licencié, (ii) des dommages directs ou indirects
-                         découlant de l'utilisation ou des performances du Logiciel subis par le Licencié et (iii) plus
-                         généralement d'un quelconque dommage indirect. En particulier, les Parties conviennent
-                         expressément que tout préjudice financier ou commercial (par exemple perte de données, perte
-                         de bénéfices, perte d'exploitation, perte de clientèle ou de commandes, manque à gagner,
-                         trouble commercial quelconque) ou toute action dirigée contre le Licencié par un tiers,
-                         constitue un dommage indirect et n'ouvre pas droit à réparation par le Concédant.</p>
-                    </li>
-                </list>
-            </li>
-            <li>
-                <p>Article 9 - GARANTIE</p>
-                <list>
-                    <li>
-                        <b>9.1</b>
-                        <p>Le Licencié reconnaît que l'état actuel des connaissances scientifiques et techniques au moment
-                         de la mise en circulation du Logiciel ne permet pas d'en tester et d'en vérifier toutes les
-                         utilisations ni de détecter l'existence d'éventuels défauts. L'attention du Licencié a été
-                         attirée sur ce point sur les risques associés au chargement, à l'utilisation, la modification
-                         et/ou au développement et à la reproduction du Logiciel qui sont réservés à des utilisateurs
-                         avertis.</p>
-                        <p>Il relève de la responsabilité du Licencié de contrôler, par tous moyens, l'adéquation du produit
-                         à ses besoins, son bon fonctionnement et de s'assurer qu'il ne causera pas de dommages aux
-                         personnes et aux biens.</p>
-                    </li>
-                    <li>
-                        <b>9.2</b>
-                        <p>Le Concédant déclare de bonne foi être en droit de concéder l'ensemble des droits attachés au
-                         Logiciel (comprenant notamment les droits visés à l'article 5).</p>
-                    </li>
-                    <li>
-                        <b>9.3</b>
-                        <p>Le Licencié reconnaît que le Logiciel est fourni "en l'état" par le Concédant sans autre
-                         garantie, expresse ou tacite, que celle prévue à l'article 9.2 et notamment sans aucune
-                         garantie sur sa valeur commerciale, son caractère sécurisé, innovant ou pertinent.</p>
-                        <p>En particulier, le Concédant ne garantit pas que le Logiciel est exempt d'erreur, qu'il
-                         fonctionnera sans interruption, qu'il sera compatible avec l'équipement du Licencié et sa
-                         configuration logicielle ni qu'il remplira les besoins du Licencié.</p>
-                    </li>
-                    <li>
-                        <b>9.4</b>
-                        <p>Le Concédant ne garantit pas, de manière expresse ou tacite, que le Logiciel ne porte pas
-                         atteinte à un quelconque droit de propriété intellectuelle d'un tiers portant sur un brevet,
-                         un logiciel ou sur tout autre droit de propriété. Ainsi, le Concédant exclut toute garantie au
-                         profit du Licencié contre les actions en contrefaçon qui pourraient être diligentées au titre
-                         de l'utilisation, de la modification, et de la redistribution du Logiciel. Néanmoins, si de
-                         telles actions sont exercées contre le Licencié, le Concédant lui apportera son aide technique
-                         et juridique pour sa défense. Cette aide technique et juridique est déterminée au cas par cas
-                         entre le Concédant concerné et le Licencié dans le cadre d'un protocole d'accord. Le Concédant
-                         dégage toute responsabilité quant à l'utilisation de la dénomination du Logiciel par le
-                         Licencié. Aucune garantie n'est apportée quant à l'existence de droits antérieurs sur le nom
-                         du Logiciel et sur l'existence d'une marque.</p>
-                    </li>
-                </list>
-            </li>
-            <li>
-                <p>Article 10 - RESILIATION</p>
-                <list>
-                    <li>
-                      <b>10.1</b>
-                      <p>En cas de manquement par le Licencié aux obligations mises à sa charge par le Contrat, le
-                         Concédant pourra résilier de plein droit le Contrat trente (30) jours après notification
-                         adressée au Licencié et restée sans effet.</p>
-                    </li>
-                    <li>
-                      <b>10.2</b>
-                      <p>Le Licencié dont le Contrat est résilié n'est plus autorisé à utiliser, modifier ou distribuer le
-                         Logiciel. Cependant, toutes les licences qu'il aura concédées antérieurement à la résiliation
-                         du Contrat resteront valides sous réserve qu'elles aient été effectuées en conformité avec le
-                         Contrat.</p>
-                    </li>
-                </list>
-            </li>
-            <li>
-                <p>Article 11 - DISPOSITIONS DIVERSES</p>
-                <list>
-                    <li>
-                      <b>11.1</b>
-                      <p>CAUSE EXTERIEURE</p>
-                      <p>Aucune des Parties ne sera responsable d'un retard ou d'une défaillance d'exécution du Contrat
-                         qui serait dû à un cas de force majeure, un cas fortuit ou une cause extérieure, telle que,
-                         notamment, le mauvais fonctionnement ou les interruptions du réseau électrique ou de
-                         télécommunication, la paralysie du réseau liée à une attaque informatique, l'intervention des
-                         autorités gouvernementales, les catastrophes naturelles, les dégâts des eaux, les tremblements
-                         de terre, le feu, les explosions, les grèves et les conflits sociaux, l'état de guerre...</p>
-                    </li>
-                    <li>
-                      <b>11.2</b>
-                      <p>Le fait, par l'une ou l'autre des Parties, d'omettre en une ou plusieurs occasions de se
-                         prévaloir d'une ou plusieurs dispositions du Contrat, ne pourra en aucun cas impliquer
-                         renonciation par la Partie intéressée à s'en prévaloir ultérieurement.</p>
-                    </li>
-                    <li>
-                      <b>11.3</b>
-                      <p>Le Contrat annule et remplace toute convention antérieure, écrite ou orale, entre les Parties sur
-                         le même objet et constitue l'accord entier entre les Parties sur cet objet. Aucune addition ou
-                         modification aux termes du Contrat n'aura d'effet à l'égard des Parties à moins d'être faite
-                         par écrit et signée par leurs représentants dûment habilités.</p>
-                    </li>
-                    <li>
-                      <b>11.4</b>
-                      <p>Dans l'hypothèse où une ou plusieurs des dispositions du Contrat s'avèrerait contraire à une loi
-                         ou à un texte applicable, existants ou futurs, cette loi ou ce texte prévaudrait, et les
-                         Parties feraient les amendements nécessaires pour se conformer à cette loi ou à ce texte.
-                         Toutes les autres dispositions resteront en vigueur. De même, la nullité, pour quelque raison
-                         que ce soit, d'une des dispositions du Contrat ne saurait entraîner la nullité de l'ensemble
-                         du Contrat.</p>
-                    </li>
-                    <li>
-                      <b>11.5</b>
-                      <p>LANGUE</p>
-                      <p>Le Contrat est rédigé en langue française et en langue anglaise, ces deux versions faisant
-                         également foi.</p>
-                    </li>
-                </list>
-            </li>
-            <li>
-                <p>Article 12 - NOUVELLES VERSIONS DU CONTRAT</p>
-                <list>
-                    <li>
-                      <b>12.1</b>
-                      <p>Toute personne est autorisée à copier et distribuer des copies de ce Contrat.</p>
-                    </li>
-                    <li>
-                      <b>12.2</b>
-                      <p>Afin d'en préserver la cohérence, le texte du Contrat est protégé et ne peut être modifié que par
-                         les auteurs de la licence, lesquels se réservent le droit de publier périodiquement des mises
-                         à jour ou de nouvelles versions du Contrat, qui posséderont chacune un numéro distinct. Ces
-                         versions ultérieures seront susceptibles de prendre en compte de nouvelles problématiques
-                         rencontrées par les logiciels libres.</p>
-                    </li>
-                    <li>
-                      <b>12.3</b>
-                      <p>Tout Logiciel diffusé sous une version donnée du Contrat ne pourra faire l'objet d'une diffusion
-                         ultérieure que sous la même version du Contrat ou une version postérieure.</p>
-                    </li>
-                </list>
-            </li>
-            <li>
-                <p>Article 13 - LOI APPLICABLE ET COMPETENCE TERRITORIALE</p>
-                <list>
-                    <li>
-                      <b>13.1</b>
-                      <p>Le Contrat est régi par la loi française. Les Parties conviennent de tenter de régler à l'amiable
-                         les différends ou litiges qui viendraient à se produire par suite ou à l'occasion du
-                         Contrat.</p>
-                    </li>
-                    <li>
-                      <b>13.2</b>
-                      <p>A défaut d'accord amiable dans un délai de deux (2) mois à compter de leur survenance et sauf
-                         situation relevant d'une procédure d'urgence, les différends ou litiges seront portés par la
-                         Partie la plus diligente devant les Tribunaux compétents de Paris.</p>
-                    </li>
-                </list>
-            </li>
-        </list>
-    <p>1 CeCILL est pour Ce(a) C(nrs) I(nria) L(ogiciel) L(ibre)</p>
-    <optional>
-      <p>Version 1.0 du 2006-09-05.</p>
+      <p>
+The authors of the CeCILL-C (for Ce[a] C[nrs] I[nria] L[ogiciel] L[ibre]) license are:
+      </p>
+      <list>
+        <li>
+          <p>
+Commissariat à l'Energie Atomique - CEA, a public scientific, technical and industrial research establishment, having its principal place of business at 25 rue Leblanc, immeuble Le Ponant D, 75015 Paris, France.
+          </p>
+        </li>
+        <li>
+          <p>
+Centre National de la Recherche Scientifique - CNRS, a public scientific and technological establishment, having its principal place of business at 3 rue Michel-Ange, 75794 Paris cedex 16, France.
+          </p>
+        </li>
+        <li>
+          <p>
+Institut National de Recherche en Informatique et en Automatique - INRIA, a public scientific and technological establishment, having its principal place of business at Domaine de Voluceau, Rocquencourt, BP 105, 78153 Le Chesnay cedex, France.
+          </p>
+        </li>
+      </list>
     </optional>
-  </license>
+    <list>
+      <li>
+        <b>Preamble</b>
+          <p>
+The purpose of this Free Software license agreement is to grant users the right to modify and re-use the software governed by this license.
+          </p>
+          <p>
+The exercising of this right is conditional upon the obligation to make available to the community the modifications made to the source code of the software so as to contribute to its evolution.
+          </p>
+          <p>
+In consideration of access to the source code and the rights to copy, modify and redistribute granted by the license, users are provided only with a limited warranty and the software's author, the holder of the economic rights, and the successive licensors only have limited liability.
+          </p>
+          <p>
+In this respect, the risks associated with loading, using, modifying and/or developing or reproducing the software by the user are brought to the user's attention, given its Free Software status, which may make it complicated to use, with the result that its use is reserved for developers and experienced professionals having in-depth computer knowledge. Users are therefore encouraged to load and test the suitability of the software as regards their requirements in conditions enabling the security of their systems and/or data to be ensured and, more generally, to use and operate it in the same conditions of security. This Agreement may be freely reproduced and published, provided it is not altered, and that no provisions are either added or removed herefrom.
+          </p>
+          <p>
+This Agreement may apply to any or all software for which the holder of the economic rights decides to submit the use thereof to its provisions.
+          </p>
+      </li>
+      <li>
+        <b>Article 1 -</b>
+      <p>
+        DEFINITIONS
+      </p>
+      <p>
+For the purpose of this Agreement, when the following expressions commence with a capital letter, they shall have the following meaning:
+      </p>
+      <list>
+        <li>
+          <p>
+Agreement: means this license agreement, and its possible subsequent versions and annexes.
+          </p>
+        </li>
+        <li>
+          <p>
+Software: means the software in its Object Code and/or Source Code form and, where applicable, its documentation, "as is" when the Licensee accepts the Agreement.
+          </p>
+        </li>
+        <li>
+          <p>
+Initial Software: means the Software in its Source Code and possibly its Object Code form and, where applicable, its documentation, "as is" when it is first distributed under the terms and conditions of the Agreement.
+          </p>
+        </li>
+        <li>
+          <p>
+Modified Software: means the Software modified by at least one Integrated Contribution.
+          </p>
+        </li>
+        <li>
+          <p>
+Source Code: means all the Software's instructions and program lines to which access is required so as to modify the Software.
+          </p>
+        </li>
+        <li>
+          <p>
+Object Code: means the binary files originating from the compilation of the Source Code.
+          </p>
+        </li>
+        <li>
+          <p>
+Holder: means the holder(s) of the economic rights over the Initial Software.
+          </p>
+        </li>
+        <li>
+          <p>
+Licensee: means the Software user(s) having accepted the Agreement.
+          </p>
+        </li>
+        <li>
+          <p>
+Contributor: means a Licensee having made at least one Integrated Contribution.
+          </p>
+        </li>
+        <li>
+          <p>
+Licensor: means the Holder, or any other individual or legal entity, who distributes the Software under the Agreement.
+          </p>
+        </li>
+        <li>
+          <p>
+Integrated Contribution: means any or all modifications, corrections, translations, adaptations and/or new functions integrated into the Source Code by any or all Contributors.
+          </p>
+        </li>
+        <li>
+          <p>
+Related Module: means a set of sources files including their documentation that, without modification to the Source Code, enables supplementary functions or services in addition to those offered by the Software.
+          </p>
+        </li>
+        <li>
+          <p>
+Derivative Software: means any combination of the Software, modified or not, and of a Related Module.
+          </p>
+        </li>
+        <li>
+          <p>
+Parties: mean both the Licensee and the Licensor.
+          </p>
+        </li>
+      </list>
+      <p>
+These expressions may be used both in singular and plural form.
+      </p>
+      </li>
+      <li>
+        <b>Article 2 -</b>
+      <p>
+PURPOSE
+      </p>
+      <p>
+The purpose of the Agreement is the grant by the Licensor to the Licensee of a non-exclusive, transferable and worldwide license for the Software as set forth in Article 5 hereinafter for the whole term of the protection granted by the rights over said Software. 
+      </p>
+      </li>
+      <li>
+        <b>Article 3 -</b>
+      <p>
+ACCEPTANCE
+      </p>
+      <list>
+        <li>
+          <b>3.1</b>
+          <p>
+The Licensee shall be deemed as having accepted the terms and conditions of this Agreement upon the occurrence of the first of the following events:
+          </p>
+          <list>
+            <li>
+              <b>(i)</b>
+              <p>
+loading the Software by any or all means, notably, by downloading from a remote server, or by loading from a physical medium;
+              </p>
+            </li>
+            <li>
+              <b>(ii)</b>
+              <p>
+the first time the Licensee exercises any of the rights granted hereunder.
+              </p>
+            </li>
+          </list>
+        </li>
+        <li>
+          <b>3.2</b>
+          <p>
+One copy of the Agreement, containing a notice relating to the characteristics of the Software, to the limited warranty, and to the fact that its use is restricted to experienced users has been provided to the Licensee prior to its acceptance as set forth in Article 3.1 hereinabove, and the Licensee hereby acknowledges that it has read and understood it.
+          </p>
+        </li>
+      </list>
+      </li>
+      <li>
+        <b>Article 4 -</b>
+      <p>
+EFFECTIVE DATE AND TERM
+      </p>
+      <list>
+        <li>
+          <b>4.1</b>
+          <p>
+EFFECTIVE DATE
+          </p>
+          <p>
+The Agreement shall become effective on the date when it is accepted by the Licensee as set forth in Article 3.1.
+          </p>
+        </li>
+        <li>
+          <b>4.2</b>
+          <p>
+TERM
+          </p>
+          <p>
+The Agreement shall remain in force for the entire legal term of protection of the economic rights over the Software.
+          </p>
+        </li>
+      </list>
+      </li>
+      <li>
+        <b>Article 5 -</b>
+      <p>
+SCOPE OF RIGHTS GRANTED
+      </p>
+      <p>
+The Licensor hereby grants to the Licensee, who accepts, the following rights over the Software for any or all use, and for the term of the Agreement, on the basis of the terms and conditions set forth hereinafter.
+      </p>
+      <p>
+Besides, if the Licensor owns or comes to own one or more patents protecting all or part of the functions of the Software or of its components, the Licensor undertakes not to enforce the rights granted by these patents against successive Licensees using, exploiting or modifying the Software. If these patents are transferred, the Licensor undertakes to have the transferees subscribe to the obligations set forth in this paragraph.
+      </p>
+      <list>
+        <li>
+          <b>5.1</b>
+          <p>
+RIGHT OF USE
+          </p>
+          <p>
+The Licensee is authorized to use the Software, without any limitation as to its fields of application, with it being hereinafter specified that this comprises:
+          </p>
+          <list>
+            <li>
+              <b>1.</b>
+              <p>
+permanent or temporary reproduction of all or part of the Software by any or all means and in any or all form.
+              </p>
+            </li>
+            <li>
+              <b>2.</b>
+              <p>
+loading, displaying, running, or storing the Software on any or all medium.
+              </p>
+            </li>
+            <li>
+              <b>3.</b>
+              <p>
+entitlement to observe, study or test its operation so as to determine the ideas and principles behind any or all constituent elements of said Software. This shall apply when the Licensee carries out any or all loading, displaying, running, transmission or storage operation as regards the Software, that it is entitled to carry out hereunder.
+              </p>
+            </li>
+          </list>
+        </li>
+        <li>
+          <b>5.2</b>
+          <p>
+RIGHT OF MODIFICATION
+          </p>
+          <p>
+The right of modification includes the right to translate, adapt, arrange, or make any or all modifications to the Software, and the right to reproduce the resulting software. It includes, in particular, the right to create a Derivative Software.
+          </p>
+          <p>
+The Licensee is authorized to make any or all modification to the Software provided that it includes an explicit notice that it is the author of said modification and indicates the date of the creation thereof.
+          </p>
+        </li>
+        <li>
+          <b>5.3</b>
+          <p>
+RIGHT OF DISTRIBUTION
+          </p>
+          <p>
+In particular, the right of distribution includes the right to publish, transmit and communicate the Software to the general public on any or all medium, and by any or all means, and the right to market, either in consideration of a fee, or free of charge, one or more copies of the Software by any means.
+          </p>
+          <p>
+The Licensee is further authorized to distribute copies of the modified or unmodified Software to third parties according to the terms and conditions set forth hereinafter.
+          </p>
+          <list>
+            <li>
+              <b>5.3.1.</b>
+              <p>
+DISTRIBUTION OF SOFTWARE WITHOUT MODIFICATION
+              </p>
+              <p>
+The Licensee is authorized to distribute true copies of the Software in Source Code or Object Code form, provided that said distribution complies with all the provisions of the Agreement and is accompanied by:
+              </p>
+              <list>
+                <li>
+                <b>1.</b>
+                <p>
+a copy of the Agreement,
+                </p>
+              </li>
+              <li>
+                <b>2.</b>
+                <p>
+a notice relating to the limitation of both the Licensor's warranty and liability as set forth in Articles 8 and 9,
+                </p>
+              </li>
+            </list>
+            <p>
+and that, in the event that only the Object Code of the Software is redistributed, the Licensee allows effective access to the full Source Code of the Software at a minimum during the entire period of its distribution of the Software, it being understood that the additional cost of acquiring the Source Code shall not exceed the cost of transferring the data.
+            </p>
+          </li>
+          <li>
+            <b>5.3.2.</b>
+            <p>
+DISTRIBUTION OF MODIFIED SOFTWARE
+            </p>
+            <p>
+When the Licensee makes an Integrated Contribution to the Software, the terms and conditions for the distribution of the resulting Modified Software become subject to all the provisions of this Agreement.
+            </p>
+            <p>
+The Licensee is authorized to distribute the Modified Software, in source code or object code form, provided that said distribution complies with all the provisions of the Agreement and is accompanied by:
+            </p>
+            <list>
+              <li>
+              <b>1.</b>
+              <p>
+a copy of the Agreement,
+              </p>
+            </li>
+            <li>
+              <b>2.</b>
+              <p>
+a notice relating to the limitation of both the Licensor's warranty and liability as set forth in Articles 8 and 9,
+              </p>
+            </li>
+            </list>
+            <p>
+and that, in the event that only the object code of the Modified Software is redistributed, the Licensee allows effective access to the full source code of the Modified Software at a minimum during the entire period of its distribution of the Modified Software, it being understood that the additional cost of acquiring the source code shall not exceed the cost of transferring the data.
+          </p>
+        </li>
+        <li>
+          <b>5.3.3.</b>
+          <p>
+DISTRIBUTION OF DERIVATIVE SOFTWARE
+          </p>
+          <p>
+When the Licensee creates Derivative Software, this Derivative Software may be distributed under a license agreement other than this Agreement, subject to compliance with the requirement to include a notice concerning the rights over the Software as defined in Article 6.4.  In the event the creation of the Derivative Software required modification of the Source Code, the Licensee undertakes that:
+          </p>
+	  <list>
+	    <li>
+	      <b>1.</b>
+	      <p>
+the resulting Modified Software will be governed by this Agreement,
+	      </p>
+	    </li>
+	    <li>
+	      <b>2.</b>
+	      <p>
+the Integrated Contributions in the resulting Modified Software will be clearly identified and documented,
+	      </p>
+	    </li>
+	    <li>
+	      <b>3.</b>
+	      <p>
+the Licensee will allow effective access to the source code of the Modified Software, at a minimum during the entire period of distribution of the Derivative Software, such that such modifications may be carried over in a subsequent version of the Software; it being understood that the additional cost of purchasing the source code of the Modified Software shall not exceed the cost of transferring the data.
+	      </p>
+	    </li>
+	  </list>
+          </li>
+          <li>
+            <b>5.3.4.</b>
+            <p>
+COMPATIBILITY WITH THE CeCILL LICENSE
+            </p>
+            <p>
+When a Modified Software contains an Integrated Contribution subject to the CeCILL license agreement, or when a Derivative Software contains a Related Module subject to the CeCILL license agreement, the provisions set forth in the third item of Article 6.4 are optional.
+            </p>
+          </li>
+        </list>
+      </li>
+      </list>
+    </li>
+      <li>
+        <b>Article 6 -</b>
+      <p>
+INTELLECTUAL PROPERTY
+      </p>
+      <list>
+        <li>
+          <b>6.1</b>
+          <p>
+OVER THE INITIAL SOFTWARE
+          </p>
+          <p>
+The Holder owns the economic rights over the Initial Software. Any or all use of the Initial Software is subject to compliance with the terms and conditions under which the Holder has elected to distribute its work and no one shall be entitled to modify the terms and conditions for the distribution of said Initial Software.
+          </p>
+          <p>
+The Holder undertakes that the Initial Software will remain ruled at least by this Agreement, for the duration set forth in Article 4.2.
+          </p>
+        </li>
+        <li>
+          <b>6.2</b>
+          <p>
+OVER THE INTEGRATED CONTRIBUTIONS
+          </p>
+          <p>
+The Licensee who develops an Integrated Contribution is the owner of the intellectual property rights over this Contribution as defined by applicable law.
+          </p>
+        </li>
+        <li>
+          <b>6.3</b>
+          <p>
+OVER THE RELATED MODULES
+          </p>
+          <p>
+The Licensee who develops a Related Module is the owner of the intellectual property rights over this Related Module as defined by applicable law and is free to choose the type of agreement that shall govern its distribution under the conditions defined in Article 5.3.3.
+          </p>
+        </li>
+        <li>
+          <b>6.4</b>
+          <p>
+NOTICE OF RIGHTS
+          </p>
+          <p>
+The Licensee expressly undertakes:
+          </p>
+            <list>
+              <li>
+              <b>1.</b>
+              <p>
+not to remove, or modify, in any manner, the intellectual property notices attached to the Software;
+              </p>
+            </li>
+            <li>
+              <b>2.</b>
+              <p>
+to reproduce said notices, in an identical manner, in the copies of the Software modified or not;
+              </p>
+            </li>
+            <li>
+              <b>3.</b>
+              <p>
+to ensure that use of the Software, its intellectual property notices and the fact that it is governed by the Agreement is indicated in a text that is easily accessible, specifically from the interface of any Derivative Software.
+              </p>
+            </li>
+          </list>
+          <p>
+The Licensee undertakes not to directly or indirectly infringe the intellectual property rights of the Holder and/or Contributors on the Software and to take, where applicable, vis-à-vis its staff, any and all measures required to ensure respect of said intellectual property rights of the Holder and/or Contributors.
+          </p>
+        </li>
+      </list>
+    </li>
+      <li>
+        <b>Article 7 -</b>
+      <p>
+RELATED SERVICES
+      </p>
+      <list>
+        <li>
+          <b>7.1</b>
+          <p>
+Under no circumstances shall the Agreement oblige the Licensor to provide technical assistance or maintenance services for the Software.
+          </p>
+          <p>
+However, the Licensor is entitled to offer this type of services. The terms and conditions of such technical assistance, and/or such maintenance, shall be set forth in a separate instrument. Only the Licensor offering said maintenance and/or technical assistance services shall incur liability therefor.
+          </p>
+        </li>
+        <li>
+          <b>7.2</b>
+          <p>
+Similarly, any Licensor is entitled to offer to its licensees, under its sole responsibility, a warranty, that shall only be binding upon itself, for the redistribution of the Software and/or the Modified Software, under terms and conditions that it is free to decide. Said warranty, and the financial terms and conditions of its application, shall be subject of a separate instrument executed between the Licensor and the Licensee.
+          </p>
+        </li>
+      </list>
+    </li>
+      <li>
+        <b>Article 8 -</b>
+      <p>
+LIABILITY
+      </p>
+      <list>
+        <li>
+          <b>8.1</b>
+          <p>
+Subject to the provisions of Article 8.2, the Licensee shall be entitled to claim compensation for any direct loss it may have suffered from the Software as a result of a fault on the part of the relevant Licensor, subject to providing evidence thereof.
+          </p>
+        </li>
+        <li>
+          <b>8.2</b>
+          <p>
+The Licensor's liability is limited to the commitments made under this Agreement and shall not be incurred as a result of in particular: (i) loss due the Licensee's total or partial failure to fulfill its obligations, (ii) direct or consequential loss that is suffered by the Licensee due to the use or performance of the Software, and (iii) more generally, any consequential loss. In particular the Parties expressly agree that any or all pecuniary or business loss (i.e. loss of data, loss of profits, operating loss, loss of customers or orders, opportunity cost, any disturbance to business activities) or any or all legal proceedings instituted against the Licensee by a third party, shall constitute consequential loss and shall not provide entitlement to any or all compensation from the Licensor.
+          </p>
+        </li>
+      </list>
+    </li>
+      <li>
+        <b>Article 9 -</b>
+      <p>
+WARRANTY
+      </p>
+      <list>
+        <li>
+          <b>9.1</b>
+          <p>
+The Licensee acknowledges that the scientific and technical state-of-the-art when the Software was distributed did not enable all possible uses to be tested and verified, nor for the presence of possible defects to be detected. In this respect, the Licensee's attention has been drawn to the risks associated with loading, using, modifying and/or developing and reproducing the Software which are reserved for experienced users.
+          </p>
+          <p>
+The Licensee shall be responsible for verifying, by any or all means, the suitability of the product for its requirements, its good working order, and for ensuring that it shall not cause damage to either persons or properties.
+          </p>
+        </li>
+        <li>
+          <b>9.2</b>
+          <p>
+The Licensor hereby represents, in good faith, that it is entitled to grant all the rights over the Software (including in particular the rights set forth in Article 5).
+          </p>
+        </li>
+        <li>
+          <b>9.3</b>
+          <p>
+The Licensee acknowledges that the Software is supplied "as is" by the Licensor without any other express or tacit warranty, other than that provided for in Article 9.2 and, in particular, without any warranty as to its commercial value, its secured, safe, innovative or relevant nature.
+
+          </p>
+          <p>
+Specifically, the Licensor does not warrant that the Software is free from any error, that it will operate without interruption, that it will be compatible with the Licensee's own equipment and software configuration, nor that it will meet the Licensee's requirements.
+          </p>
+        </li>
+        <li>
+          <b>9.4</b>
+          <p>
+The Licensor does not either expressly or tacitly warrant that the Software does not infringe any third party intellectual property right relating to a patent, software or any other property right. Therefore, the Licensor disclaims any and all liability towards the Licensee arising out of any or all proceedings for infringement that may be instituted in respect of the use, modification and redistribution of the Software. Nevertheless, should such proceedings be instituted against the Licensee, the Licensor shall provide it with technical and legal assistance for its defense. Such technical and legal assistance shall be decided on a case-by-case basis between the relevant Licensor and the Licensee pursuant to a memorandum of understanding. The Licensor disclaims any and all liability as regards the Licensee's use of the name of the Software. No warranty is given as regards the existence of prior rights over the name of the Software or as regards the existence of a trademark.
+          </p>
+        </li>
+      </list>
+    </li>
+      <li>
+        <b>Article 10 -</b>
+      <p>
+TERMINATION
+      </p>
+      <list>
+        <li>
+          <b>10.1</b>
+          <p>
+In the event of a breach by the Licensee of its obligations hereunder, the Licensor may automatically terminate this Agreement thirty (30) days after notice has been sent to the Licensee and has remained ineffective.
+          </p>
+        </li>
+        <li>
+          <b>10.2</b>
+          <p>
+A Licensee whose Agreement is terminated shall no longer be authorized to use, modify or distribute the Software. However, any licenses that it may have granted prior to termination of the Agreement shall remain valid subject to their having been granted in compliance with the terms and conditions hereof.
+          </p>
+        </li>
+      </list>
+    </li>
+      <li>
+        <b>Article 11 -</b>
+      <p>
+MISCELLANEOUS
+      </p>
+      <list>
+        <li>
+          <b>11.1</b>
+          <p>
+EXCUSABLE EVENTS
+          </p>
+          <p>
+Neither Party shall be liable for any or all delay, or failure to perform the Agreement, that may be attributable to an event of force majeure, an act of God or an outside cause, such as defective functioning or interruptions of the electricity or telecommunications networks, network paralysis following a virus attack, intervention by government authorities, natural disasters, water damage, earthquakes, fire, explosions, strikes and labor unrest, war, etc.
+          </p>
+        </li>
+        <li>
+          <b>11.2</b>
+          <p>
+Any failure by either Party, on one or more occasions, to invoke one or more of the provisions hereof, shall under no circumstances be interpreted as being a waiver by the interested Party of its right to invoke said provision(s) subsequently.
+          </p>
+        </li>
+        <li>
+          <b>11.3</b>
+          <p>
+The Agreement cancels and replaces any or all previous agreements, whether written or oral, between the Parties and having the same purpose, and constitutes the entirety of the agreement between said Parties concerning said purpose. No supplement or modification to the terms and conditions hereof shall be effective as between the Parties unless it is made in writing and signed by their duly authorized representatives.
+          </p>
+        </li>
+        <li>
+          <b>11.4</b>
+          <p>
+In the event that one or more of the provisions hereof were to conflict with a current or future applicable act or legislative text, said act or legislative text shall prevail, and the Parties shall make the necessary amendments so as to comply with said act or legislative text. All other provisions shall remain effective. Similarly, invalidity of a provision of the Agreement, for any reason whatsoever, shall not cause the Agreement as a whole to be invalid.
+          </p>
+        </li>
+        <li>
+          <b>11.5</b>
+          <p>
+LANGUAGE
+          </p>
+          <p>
+The Agreement is drafted in both French and English and both versions are deemed authentic.
+          </p>
+        </li>
+      </list>
+    </li>
+      <li>
+        <b>Article 12 -</b>
+      <p>
+NEW VERSIONS OF THE AGREEMENT
+      </p>
+      <list>
+        <li>
+          <b>12.1</b>
+          <p>
+Any person is authorized to duplicate and distribute copies of this Agreement.
+          </p>
+        </li>
+        <li>
+          <b>12.2</b>
+          <p>
+So as to ensure coherence, the wording of this Agreement is protected and may only be modified by the authors of the License, who reserve the right to periodically publish updates or new versions of the Agreement, each with a separate number. These subsequent versions may address new issues encountered by Free Software.
+          </p>
+        </li>
+        <li>
+          <b>12.3</b>
+          <p>
+Any Software distributed under a given version of the Agreement may only be subsequently distributed under the same version of the Agreement or a subsequent version.
+          </p>
+        </li>
+      </list>
+    </li>
+      <li>
+        <b>Article 13 -</b>
+      <p>
+GOVERNING LAW AND JURISDICTION
+      </p>
+      <list>
+        <li>
+          <b>13.1</b>
+          <p>
+The Agreement is governed by French law. The Parties agree to endeavor to seek an amicable solution to any disagreements or disputes that may arise during the performance of the Agreement.
+          </p>
+        </li>
+        <li>
+          <b>13.2</b>
+          <p>
+Failing an amicable solution within two (2) months as from their occurrence, and unless emergency proceedings are necessary, the disagreements or disputes shall be referred to the Paris Courts having jurisdiction, by the more diligent Party.
+          </p>
+        </li>
+      </list>
+    </li>
+  </list>
+  <p>
+Version 1.0 dated 2006-09-05.
+  </p>
+</license>
 </SPDX>


### PR DESCRIPTION
Since the authors of the licenses publish official versions in English (http://www.cecill.info/licences.en.html), it makes little sense for us to have the French versions.

I've created the English versions for CECILL-2.0, CECILL-2.1, CECILL-B and CECILL-C.
I have _not_ touched -1.0 or -1.1, since the license itself does not specify equivalence ("the French version shall be deemed authentic").