### PR TITLE
RPSL-1.0: Replace broken U+00E9 (LATIN SMALL LETTER E WITH ACUTE)

### DIFF
--- a/src/RPSL-1.0.xml
+++ b/src/RPSL-1.0.xml
@@ -271,7 +271,7 @@
                   <bullet>4.2</bullet>
           Compatible Source Licenses. Software modules that have been independently developed without any
              use of Covered Code and which contain no portion of the Covered Code, Modifications or other
-             Derivative Works, but are used or combined in any way with the Covered Code or any Derivative
+             Derivative Works, but are used or combined in any way <alt match="with|wtih" name="whitTypo">with</alt> the Covered Code or any Derivative
              Work to form a larger Derivative Work, are exempt from the conditions described in Section 4.1
              but only to the extent that: the software module, including any software that is linked to,
              integrated with, or part of the same applications as, the software module by any method must

--- a/src/RPSL-1.0.xml
+++ b/src/RPSL-1.0.xml
@@ -512,7 +512,7 @@
 
       <p>Where You are located in the province of Quebec, Canada, the following clause applies: The parties hereby
          confirm that they have requested that this License and all related documents be drafted in English.
-         Les parties ont exig� que le pr�sent contrat et tous les documents connexes soient r�dig�s en
+         Les parties ont exigé que le présent contrat et tous les documents connexes soient rédigés en
          anglais.</p>
                </item>
             </list>


### PR DESCRIPTION
I'm not sure where the old EF BF BD bytes came from, but they aren't UTF-8 for U+0039.  I've replaced them in this commit.  See [here][1] and [here][2] which are both calling for `é` (although the [nominally-text version][2] is using `&eacute;` :p).

Also adds `<alt>` for a `wtih` typo which shows up in the upstream text version.  Details in 7c12054.

Fixes #440.

[1]: https://web.archive.org/web/20060924223025/https://www.helixcommunity.org/content/rpsl
[2]: https://web.archive.org/web/20060924223020/https://www.helixcommunity.org/content/rpsl.txt