### PR TITLE
Artistic-2.0: Fix interleaved header/list markup

### DIFF
--- a/src/Artistic-2.0.xml
+++ b/src/Artistic-2.0.xml
@@ -78,8 +78,10 @@
           You are permitted to use the Standard Version and create and use Modified Versions for any
              purpose without restriction, provided that you do not Distribute the Modified Version.
         </item>
-        
-        <p>Permissions for Redistribution of the Standard Version</p>
+      </list>
+
+      <p>Permissions for Redistribution of the Standard Version</p>
+      <list>
         <item>
             <bullet>(2)</bullet>
           You may Distribute verbatim copies of the Source form of the Standard Version of this Package in
@@ -93,8 +95,10 @@
              Copyright Holder. The resulting Package will still be considered the Standard Version, and as
              such will be subject to the Original License.
         </item>
+      </list>
         
-        <p>Distribution of Modified Versions of the Package as Source</p>
+      <p>Distribution of Modified Versions of the Package as Source</p>
+      <list>
         <item>
             <bullet>(4)</bullet>
           You may Distribute your Modified Version as Source (either gratis or for a Distributor Fee, and
@@ -134,10 +138,12 @@
                    Distributor Fees are allowed.
               </item>
                </list>
-            </list>
+          </list>
         </item>
-        
-        <p>Distribution of Compiled Forms of the Standard Version or Modified Versions without the Source</p>
+      </list>
+
+      <p>Distribution of Compiled Forms of the Standard Version or Modified Versions without the Source</p>
+      <list>
         <item>
             <bullet>(5)</bullet>
           You may Distribute Compiled forms of the Standard Version without the Source, provided that you
@@ -153,8 +159,10 @@
           You may Distribute a Modified Version in Compiled form without the Source, provided that you
              comply with Section 4 with respect to the Source of the Modified Version.
         </item>
-        
-        <p>Aggregating or Linking the Package</p>
+      </list>
+
+      <p>Aggregating or Linking the Package</p>
+      <list>
         <item>
             <bullet>(7)</bullet>
           You may aggregate the Package (either the Standard Version or Modified Version) with other
@@ -170,8 +178,10 @@
              applications that include the Package, and Distribute the result without restriction, provided
              the result does not expose a direct interface to the Package.
         </item>
-        
-        <p>Items That are Not Considered Part of a Modified Version</p>
+      </list>
+
+      <p>Items That are Not Considered Part of a Modified Version</p>
+      <list>
         <item>
             <bullet>(9)</bullet>
           Works (including, but not limited to, modules and scripts) that merely extend or make use of the
@@ -179,8 +189,10 @@
              works are not considered parts of the Package itself, and are not subject to the terms of this
              license.
         </item>
-        
-        <p>General Provisions</p>
+      </list>
+
+      <p>General Provisions</p>
+      <list>
         <item>
             <bullet>(10)</bullet>
           Any use, modification, and distribution of the Standard or Modified Versions is governed by this


### PR DESCRIPTION
Part of #439.

The upstream markup has running list numbers, but interspersed headers:

```
$ curl -s http://www.perlfoundation.org/artistic_license_2_0 | grep -1 '<h3\|Compiled Forms'
Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.</p>
<h3 id="preamble">Preamble</h3>
<p>
--
You are always permitted to make arrangements wholly outside of this license directly with the Copyright Holder of a given Package. If the terms of this license do not permit the full use that you propose to make of the Package, you should contact the Copyright Holder and seek a different licensing arrangement.</p>
<h3 id="definitions">Definitions</h3>
<p>
--
&quot;Compiled&quot; form means the compiled bytecode, object code, binary, or any other form resulting from mechanical transformation or translation of the Source form.</p>
<h3 id="permission_for_use_and_modification_without_distribution">Permission for Use and Modification Without Distribution</h3>
<p>
(1) You are permitted to use the Standard Version and create and use Modified Versions for any purpose without restriction, provided that you do not Distribute the Modified Version.</p>
<h3 id="permissions_for_redistribution_of_the_standard_version">Permissions for Redistribution of the Standard Version</h3>
<p>
--
(3) You may apply any bug fixes, portability changes, and other modifications made available from the Copyright Holder. The resulting Package will still be considered the Standard Version, and as such will be subject to the Original License.</p>
<h3 id="distribution_of_modified_versions_of_the_package_as_source">Distribution of Modified Versions of the Package as Source</h3>
<p>
--
(ii) a license that permits the licensee to freely copy, modify and redistribute the Modified Version using the same licensing terms that apply to the copy that the licensee received, and requires that the Source form of the Modified Version, and of any works derived from it, be made freely available in that license fees are prohibited but Distributor Fees are allowed.<br />
Distribution of Compiled Forms of the Standard Version or Modified Versions without the Source</p>
<p>
--
(6) You may Distribute a Modified Version in Compiled form without the Source, provided that you comply with Section 4 with respect to the Source of the Modified Version.</p>
<h3 id="aggregating_or_linking_the_package">Aggregating or Linking the Package</h3>
<p>
--
(8) You are permitted to link Modified and Standard Versions with other works, to embed the Package in a larger work of your own, or to build stand-alone binary or bytecode versions of applications that include the Package, and Distribute the result without restriction, provided the result does not expose a direct interface to the Package.</p>
<h3 id="items_that_are_not_considered_part_of_a_modified_version">Items That are Not Considered Part of a Modified Version</h3>
<p>
(9) Works (including, but not limited to, modules and scripts) that merely extend or make use of the Package, do not, by themselves, cause the Package to be a Modified Version. In addition, such works are not considered parts of the Package itself, and are not subject to the terms of this license.</p>
<h3 id="general_provisions">General Provisions</h3>
<p>
```

They're currently missing an `<h3>` for the “Distribution of Compiled Forms…” line, but I'm pretty sure it's intended to be a header too.