### PR TITLE
*GPL-3.0: Optional HTTPS for outgoing link

### DIFF
--- a/src/AGPL-3.0.xml
+++ b/src/AGPL-3.0.xml
@@ -20,7 +20,7 @@
         <br/>Version 3, 19 November 2007 
       </p>
       </titleText>
-      <p>Copyright (C) 2007 Free Software Foundation, Inc. &lt;http://fsf.org/&gt;</p>
+      <p>Copyright (C) 2007 Free Software Foundation, Inc. &lt;http<optional>s</optional>://fsf.org/&gt;</p>
       <p>Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is
          not allowed.</p>
       <p>Preamble</p>
@@ -565,7 +565,7 @@
          the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
          General Public License for more details.</p>
          <p>You should have received a copy of the GNU Affero General Public License along with this program. If not,
-         see &lt;http://www.gnu.org/licenses/&gt;.</p>
+         see &lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.</p>
          <p>Also add information on how to contact you by electronic and paper mail.</p>
          <p>If your software can interact with users remotely through a computer network, you should also make sure
          that it provides a way for users to get its source. For example, if your program is a web application,
@@ -574,7 +574,7 @@
          programs; see section 13 for the specific requirements.</p>
          <p>You should also get your employer (if you work as a programmer) or school, if any, to sign a
          "copyright disclaimer" for the program, if necessary. For more information on this, and how
-         to apply and follow the GNU AGPL, see &lt;http://www.gnu.org/licenses/&gt;.</p>
+         to apply and follow the GNU AGPL, see &lt;http<optional>s</optional>https://www.gnu.org/licenses/&gt;.</p>
       </optional>
   </license>
 </SPDXLicenseCollection>

--- a/src/GPL-3.0.xml
+++ b/src/GPL-3.0.xml
@@ -21,7 +21,7 @@
         <br/>Version 3, 29 June 2007 
       </p>
       </titleText>
-      <p>Copyright © 2007 Free Software Foundation, Inc. &lt;http://fsf.org/&gt;</p>
+      <p>Copyright © 2007 Free Software Foundation, Inc. &lt;http<optional>s</optional>://fsf.org/&gt;</p>
       <p>Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is
          not allowed.</p>
       <p>Preamble</p>
@@ -574,7 +574,7 @@
          the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
          Public License for more details.</p>
          <p>You should have received a copy of the GNU General Public License along with this program. If not, see
-         &lt;http://www.gnu.org/licenses/&gt;.</p>
+         &lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.</p>
          <p>Also add information on how to contact you by electronic and paper mail.</p>
          <p>If the program does terminal interaction, make it output a short notice like this when it starts in an
          interactive mode:</p>
@@ -588,12 +588,12 @@
          interface, you would use an “about box”.</p>
          <p>You should also get your employer (if you work as a programmer) or school, if any, to sign a
          “copyright disclaimer” for the program, if necessary. For more information on this, and
-         how to apply and follow the GNU GPL, see &lt;http://www.gnu.org/licenses/&gt;.</p>
+         how to apply and follow the GNU GPL, see &lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.</p>
          <p>The GNU General Public License does not permit incorporating your program into proprietary programs. If
          your program is a subroutine library, you may consider it more useful to permit linking proprietary
          applications with the library. If this is what you want to do, use the GNU Lesser General Public
          License instead of this License. But first, please read
-         &lt;http://www.gnu.org/philosophy/why-not-lgpl.html&gt;.</p>
+         &lt;http<optional>s</optional://www.gnu.org/philosophy/why-not-lgpl.html&gt;.</p>
       </optional>
   </license>
 </SPDXLicenseCollection>

--- a/src/LGPL-3.0.xml
+++ b/src/LGPL-3.0.xml
@@ -13,7 +13,7 @@
         <br/>Version 3, 29 June 2007 
       </p>
       </titleText>
-      <p>Copyright (C) 2007 Free Software Foundation, Inc. &lt;http://fsf.org/&gt;</p>
+      <p>Copyright (C) 2007 Free Software Foundation, Inc. &lt;http<optional>s</optional>//fsf.org/&gt;</p>
       <p>Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is
          not allowed.</p>
       <p>This version of the GNU Lesser General Public License incorporates the terms and conditions of version 3


### PR DESCRIPTION
The FSF seems to have bumped their outgoing links from HTTP to HTTPS between 2017-09-28 and 2017-09-30 (detail for each license in the commit messages).  With this PR, I use `<alt>` tags to prefer the new canonical `https://`, but this will continue to match the old `http://`.

Spun off from github/choosealicense.com#543.