### PR TITLE
schema/ListedLicense: Punt license text into <text>

### DIFF
--- a/schema/ListedLicense.xsd
+++ b/schema/ListedLicense.xsd
@@ -17,18 +17,11 @@
 		</choice>
 	</complexType>
 	<complexType name="ExceptionType" mixed="true">
-		<choice minOccurs="1" maxOccurs="unbounded">
+		<all>
 			<element name="crossRefs" type="tns:crossRefsType" minOccurs="0" maxOccurs="1"/>
 			<element name="notes" type="tns:formattedFixedTextType" minOccurs="0" maxOccurs="1"/>
-			<element name="titleText" type="tns:formattedAltTextType" minOccurs="0" maxOccurs="1"/>
-			<element name="copyrightText" type="tns:formattedAltTextType" minOccurs="0" maxOccurs="1"/>
-			<element name="bullet" type="string"/>
-			<element name="list" type="tns:listType"/>
-			<element name="p" type="tns:formattedAltTextType"/>
-			<element name="optional" type="tns:optionalType"/>
-			<element name="alt" type="tns:altType"/>
-			<element name="br" type="tns:emptyType"/>
-		</choice>
+			<element name="text" type="tns:formattedAltTextType" minOccurs="0" maxOccurs="1"/>
+		</all>
 		<attribute name="licenseId" type="string" use="required" />
 		<attribute name="isDeprecated" type="boolean"/>
 		<attribute name="name" type="string" use="required" />
@@ -36,19 +29,12 @@
 		<attribute name="deprecatedVersion" type="string"/>
 	</complexType>
 	<complexType name="LicenseType" mixed="true">
-		<choice minOccurs="1" maxOccurs="unbounded">
+		<all>
 			<element name="crossRefs" type="tns:crossRefsType" minOccurs="0" maxOccurs="1"/>
 			<element name="notes" type="tns:formattedFixedTextType" minOccurs="0" maxOccurs="1"/>
 			<element name="standardLicenseHeader" type="tns:formattedAltTextType" minOccurs="0" maxOccurs="1"/>
-			<element name="titleText" type="tns:formattedAltTextType" minOccurs="0" maxOccurs="1"/>
-			<element name="copyrightText" type="tns:formattedAltTextType" minOccurs="0" maxOccurs="1"/>
-			<element name="bullet" type="string"/>
-			<element name="list" type="tns:listType"/>
-			<element name="p" type="tns:formattedAltTextType"/>
-			<element name="optional" type="tns:optionalType"/>
-			<element name="alt" type="tns:altType"/>
-			<element name="br" type="tns:emptyType"/>
-		</choice>
+			<element name="text" type="tns:formattedAltTextType" minOccurs="0" maxOccurs="1"/>
+		</all>
 		<attribute name="licenseId" type="string" use="required" />
 		<attribute name="isOsiApproved" type="boolean"/>
 		<attribute name="isDeprecated" type="boolean"/>

--- a/src/0BSD.xml
+++ b/src/0BSD.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>http://landley.net/toybox/license.html</crossRef>
       </crossRefs>
+    <text>
       <copyrightText>
          <p>Copyright (C) 2006 by Rob Landley &lt;rob@landley.net&gt;</p>
       </copyrightText>
@@ -15,6 +16,6 @@
          LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING
          FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
          ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/AAL.xml
+++ b/src/AAL.xml
@@ -12,6 +12,7 @@
         content or legal efficacy. You may use or modify the language freely, but entirely at your 
         own risk.
   </notes>
+    <text>
       <titleText>
          <p>Attribution Assurance License</p>
       </titleText>
@@ -86,6 +87,6 @@
          DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
          CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
          USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/ADSL.xml
+++ b/src/ADSL.xml
@@ -5,11 +5,12 @@
          <crossRef>https://fedoraproject.org/wiki/Licensing/AmazonDigitalServicesLicense</crossRef>
       </crossRefs>
     
+    <text>
       <p>This software code is made available "AS IS" without warranties of any kind. You may copy, display,
          modify and redistribute the software code either by itself or as incorporated into your code; provided
          that &gt; you do not remove any proprietary notices. Your use of this software code is at your own
          risk and you waive any claim against Amazon Digital Services, Inc. or its affiliates with respect to
          your use of this software code. (c) 2006 Amazon Digital Services, Inc. or its affiliates.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/AFL-1.1.xml
+++ b/src/AFL-1.1.xml
@@ -9,6 +9,7 @@
          Licensed under the Academic Free License version 1.1.
       </standardLicenseHeader>  
       <notes>This license has been superseded by later versions.</notes>
+    <text>
       <titleText>
          <p>Academic Free License</p>
          <p>Version 1.1</p>
@@ -76,6 +77,6 @@
       <p>This license is Copyright (C) 2002 Lawrence E. Rosen. All rights reserved.</p>
         <p>Permission is hereby granted to copy and distribute this license without modification. This license
              may not be modified without the express written permission of its copyright owner.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/AFL-1.2.xml
+++ b/src/AFL-1.2.xml
@@ -21,6 +21,7 @@
     * The AFL includes the warranty by the licensor that it either owns the copyright or that it is distributing the software under a license. None of the other licenses contain that warranty. All other warranties are disclaimed, as is the case for the other licenses.
     * The AFL is itself copyrighted (with the right granted to copy and distribute without modification). This ensures that the owner of the copyright to the license will control changes. The Apache license contains a copyright notice, but the BSD, MIT and UoI/NCSA licenses do not. 
   </notes>
+    <text>
       <titleText>
          <p>Academic Free License</p>
          <p>Version 1.2</p>
@@ -83,6 +84,6 @@
       <p>This license is Copyright (C) 2002 Lawrence E. Rosen. All rights reserved.</p>
       <p>Permission is hereby granted to copy and distribute this license without modification. This license
          may not be modified without the express written permission of its copyright owner.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/AFL-2.0.xml
+++ b/src/AFL-2.0.xml
@@ -8,6 +8,7 @@
       <standardLicenseHeader>
          <p>Licensed under the Academic Free License version 2.0</p>
       </standardLicenseHeader>
+    <text>
       <titleText>
          <p>The Academic Free License 
         <br/>v. 2.0 
@@ -188,5 +189,6 @@
         <br/>Permission is hereby granted to copy and distribute this license without modification. This license
              may not be modified without the express written permission of its copyright owner. 
       </p>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/AFL-2.1.xml
+++ b/src/AFL-2.1.xml
@@ -7,6 +7,7 @@
       <standardLicenseHeader>
          Licensed under the Academic Free License version 2.1
       </standardLicenseHeader>
+    <text>
       <titleText>
          <p>The Academic Free License 
         <br/>v.2.1 
@@ -189,6 +190,6 @@
         <br/>Permission is hereby granted to copy and distribute this license without modification. This license
              may not be modified without the express written permission of its copyright owner. 
       </p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/AFL-3.0.xml
+++ b/src/AFL-3.0.xml
@@ -8,6 +8,7 @@
       <standardLicenseHeader>
          Licensed under the Academic Free License version 3.0
       </standardLicenseHeader>
+    <text>
       <titleText>
          <p>Academic Free License ("AFL") v. 3.0</p>
       </titleText>
@@ -207,6 +208,6 @@
              and You comply with its license review and certification process.
         </item>
       </list>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/AGPL-1.0.xml
+++ b/src/AGPL-1.0.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>http://www.affero.org/oagpl.html</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>AFFERO GENERAL PUBLIC LICENSE
           <br/>Version 1, March 2002 </p>
@@ -272,5 +273,6 @@
              HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
         </item>
       </list>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/AGPL-3.0-only.xml
+++ b/src/AGPL-3.0-only.xml
@@ -26,6 +26,7 @@
     <notes>
       This version was released: 19 November 2007
     </notes>
+    <text>
     <titleText>
       <p>
         GNU AFFERO GENERAL PUBLIC LICENSE<br></br>
@@ -849,5 +850,6 @@
 	&lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.
       </p>
     </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/AGPL-3.0-or-later.xml
+++ b/src/AGPL-3.0-or-later.xml
@@ -23,6 +23,7 @@
     <notes>
       This version was released: 19 November 2007
     </notes>
+    <text>
     <titleText>
       <p>
         GNU AFFERO GENERAL PUBLIC LICENSE<br></br>
@@ -846,5 +847,6 @@
 	&lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.
       </p>
     </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/AGPL-3.0.xml
+++ b/src/AGPL-3.0.xml
@@ -23,6 +23,7 @@
       along with this program. If not, see
       &lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;
     </standardLicenseHeader>
+    <text>
     <titleText>
       <p>
         GNU AFFERO GENERAL PUBLIC LICENSE<br></br>
@@ -846,5 +847,6 @@
 	&lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.
       </p>
     </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/AMDPLPA.xml
+++ b/src/AMDPLPA.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/AMD_plpa_map_License</crossRef>
       </crossRefs>
+    <text>
       <copyrightText>
          Copyright (c) 2006, 2007 Advanced Micro Devices, Inc.
          <p>All rights reserved.</p>
@@ -70,6 +71,6 @@
          disputes arising out of this license shall be subject to the jurisdiction of the federal and state
          courts in Austin, Texas, and all defenses are hereby waived concerning personal jurisdiction and venue
          of these courts.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/AML.xml
+++ b/src/AML.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/Apple_MIT_License</crossRef>
       </crossRefs>
+    <text>
       <copyrightText>
          <p>Copyright: Copyright (c) 2006 by Apple Computer, Inc., All Rights Reserved.</p>
       </copyrightText>
@@ -33,6 +34,6 @@
          AND/OR DISTRIBUTION OF THE APPLE SOFTWARE, HOWEVER CAUSED AND WHETHER UNDER THEORY OF CONTRACT, TORT
          (INCLUDING NEGLIGENCE), STRICT LIABILITY OR OTHERWISE, EVEN IF APPLE HAS BEEN ADVISED OF THE
          POSSIBILITY OF SUCH DAMAGE.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/AMPAS.xml
+++ b/src/AMPAS.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/BSD#AMPASBSD</crossRef>
       </crossRefs>
+    <text>
       <copyrightText>
          <p>Copyright (c) 2006 Academy of Motion Picture Arts and Sciences ("A.M.P.A.S."). Portions contributed by
          others as indicated. All rights reserved.</p>
@@ -45,6 +46,6 @@
          LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
          LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
          IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/ANTLR-PD.xml
+++ b/src/ANTLR-PD.xml
@@ -6,6 +6,7 @@
       </crossRefs>
       <notes>ANTLR used this public domain notice through version 2.7 and then switched to a BSD license for version 3.0
          and later.</notes>
+    <text>
       <titleText>
          <p>ANTLR 2 License</p>
       </titleText>
@@ -20,6 +21,6 @@
          tool with the output, please mention that you developed it using ANTLR. In addition, we ask that the
          headers remain intact in our source code. As long as these guidelines are kept, we expect to continue
          enhancing this system and expect to make other tools available as they are completed.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/APAFML.xml
+++ b/src/APAFML.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/AdobePostscriptAFM</crossRef>
       </crossRefs>
+    <text>
       <copyrightText>
          <p>Copyright (c) 1985, 1987, 1989, 1990, 1991, 1992, 1993, 1997 Adobe Systems Incorporated. All Rights
          Reserved.</p>
@@ -15,6 +16,6 @@
          file or any of the AFM files are prominently noted in the modified file(s); and that this paragraph is
          not modified. Adobe Systems has no responsibility or obligation to support the use of the AFM
          files.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/APL-1.0.xml
+++ b/src/APL-1.0.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>http://www.opensource.org/licenses/APL-1.0</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>ADAPTIVE PUBLIC LICENSE 
         <br/>Version 1.0 
@@ -1014,5 +1015,6 @@ ________________________________________________ <br/>
          </list>
 	        <p>//***EXHIBIT A ENDS HERE.***//</p>
       </optional>
+    </text>
     </license>
 </SPDXLicenseCollection>

--- a/src/APSL-1.0.xml
+++ b/src/APSL-1.0.xml
@@ -6,6 +6,7 @@
          <crossRef>https://fedoraproject.org/wiki/Licensing/Apple_Public_Source_License_1.0</crossRef>
       </crossRefs>
       <notes>This license was released 16 March 1999.</notes>
+    <text>
       <titleText>
          <p>APPLE PUBLIC SOURCE LICENSE 
         <br/>Version 1.0 - March 16, 1999 
@@ -431,5 +432,6 @@
          PURPOSE OR NON-INFRINGEMENT. Please see the License for the specific language governing rights and
          limitations under the License."</p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/APSL-1.1.xml
+++ b/src/APSL-1.1.xml
@@ -6,6 +6,7 @@
          <crossRef>http://www.opensource.apple.com/source/IOSerialFamily/IOSerialFamily-7/APPLE_LICENSE</crossRef>
       </crossRefs>
       <notes>This license was released 19 April 1999.</notes>
+    <text>
       <titleText>
          <p>APPLE PUBLIC SOURCE LICENSE 
         <br/>Version 1.1 - April 19, 1999
@@ -429,5 +430,6 @@
          PURPOSE OR NON- INFRINGEMENT. Please see the License for the specific language governing rights and
          limitations under the License."</p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/APSL-1.2.xml
+++ b/src/APSL-1.2.xml
@@ -6,6 +6,7 @@
          <crossRef>http://www.samurajdata.se/opensource/mirror/licenses/apsl.php</crossRef>
       </crossRefs>
       <notes>This license was released 4 Jan 2001.</notes>
+    <text>
       <titleText>
          <p>Apple Public Source License Ver. 1.2</p>
       </titleText>
@@ -415,5 +416,6 @@
          PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT. Please see the License for the specific language
          governing rights and limitations under the License."</p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/APSL-2.0.xml
+++ b/src/APSL-2.0.xml
@@ -6,6 +6,7 @@
          <crossRef>http://www.opensource.apple.com/license/apsl/</crossRef>
       </crossRefs>
       <notes>This license was released: 6 August 2003.</notes>
+    <text>
       <titleText>
          <p>APPLE PUBLIC SOURCE LICENSE 
         <br/>Version 2.0 - August 6, 2003 
@@ -413,5 +414,6 @@
          PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT. Please see the License for the specific language
          governing rights and limitations under the License."</p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Abstyles.xml
+++ b/src/Abstyles.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/Abstyles</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>This is APREAMBL.TEX, version 1.10e, written by Hans-Hermann Bode 
         <br/>(HHBODE@DOSUNI1.BITNET), for the BibTeX `adaptable' family, version 1.10. 
@@ -18,6 +19,6 @@
       <p>Permission is granted to copy and distribute modified versions of this document under the conditions for
          verbatim copying, provided that the entire resulting derived work is distributed under the terms of a
          permission notice identical to this one.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Adobe-2006.xml
+++ b/src/Adobe-2006.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/AdobeLicense</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Adobe Systems Incorporated(r) Source Code License Agreement</p>
       </titleText>
@@ -31,6 +32,6 @@
          THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
          ARISING IN ANY WAY OUT OF THE USE OF THIS SOURCE CODE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
          DAMAGE.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Adobe-Glyph.xml
+++ b/src/Adobe-Glyph.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/MIT#AdobeGlyph</crossRef>
       </crossRefs>
+    <text>
       <copyrightText>
          <p>Copyright (c) 1997,1998,2002,2007 Adobe Systems Incorporated</p>
       </copyrightText>
@@ -34,6 +35,6 @@
          express, statutory, or implied warranties relating to the Adobe materials, including but not limited 
          to those concerning merchantability or fitness for a particular purpose or non-infringement of any
          third party rights regarding the Adobe materials.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Afmparse.xml
+++ b/src/Afmparse.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/Afmparse</crossRef>
       </crossRefs>
+    <text>
       <copyrightText>
          <p>(C) 1988, 1989 by Adobe Systems Incorporated. All rights reserved.</p>
       </copyrightText>
@@ -25,6 +26,6 @@
          RESPONSIBILITY OR LIABILITY FOR ANY ERRORS OR INACCURACIES, MAKES NO WARRANTY OF ANY KIND (EXPRESS,
          IMPLIED OR STATUTORY) WITH RESPECT TO THIS INFORMATION, AND EXPRESSLY DISCLAIMS ANY AND ALL WARRANTIES
          OF MERCHANTABILITY, FITNESS FOR PARTICULAR PURPOSES AND NONINFRINGEMENT OF THIRD PARTY RIGHTS.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Aladdin.xml
+++ b/src/Aladdin.xml
@@ -5,6 +5,7 @@
          <crossRef>http://pages.cs.wisc.edu/~ghost/doc/AFPL/6.01/Public.htm</crossRef>
       </crossRefs>
       <notes>This license was released 18 Nov 1999</notes>
+    <text>
       <titleText>
          <p>Aladdin Free Public License 
         <br/>(Version 8, November 18, 1999) 
@@ -242,6 +243,6 @@
              with the terms of this License.</p>
         </item>
       </list>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Apache-1.0.xml
+++ b/src/Apache-1.0.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>http://www.apache.org/licenses/LICENSE-1.0</crossRef>
       </crossRefs>
+    <text>
       <copyrightText>
          <p>Copyright (c) 1995-1999 The Apache Group. All rights reserved.</p>
       </copyrightText>
@@ -72,5 +73,6 @@
          Applications, University of Illinois, Urbana-Champaign. For more information on the Apache Group and
          the Apache HTTP server project, please see &lt;http://www.apache.org/&gt;.</optional>
       </p>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Apache-1.1.xml
+++ b/src/Apache-1.1.xml
@@ -6,6 +6,7 @@
          <crossRef>http://opensource.org/licenses/Apache-1.1</crossRef>
       </crossRefs>
       <notes>This license has been superseded by Apache License 2.0</notes>
+    <text>
       <titleText>
          <p>Apache License 1.1</p>
       </titleText>
@@ -73,5 +74,6 @@
        written at the National Center for Supercomputing Applications, University of Illinois,
       Urbana-Champaign.</optional>
       </p>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Apache-2.0.xml
+++ b/src/Apache-2.0.xml
@@ -24,6 +24,7 @@
        </p>
   </standardLicenseHeader>
       <notes>This license was released January 2004</notes>
+    <text>
       <titleText>
          <p>Apache License 
         <br/>Version 2.0, January 2004 
@@ -233,5 +234,6 @@
         <br/>limitations under the License. 
       </p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Artistic-1.0-Perl.xml
+++ b/src/Artistic-1.0-Perl.xml
@@ -7,6 +7,7 @@
       </crossRefs>
       <notes>This is the Artistic License 1.0 found on the Perl site, which is different (particularly, clauses 5, 6, 7
          and 8) than the Artistic License 1.0 w/clause 8 found on the OSI site.</notes>
+    <text>
       <titleText>
          <p>The "Artistic License"</p>
       </titleText>
@@ -150,5 +151,6 @@
       <optional>
          <p>The End</p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Artistic-1.0-cl8.xml
+++ b/src/Artistic-1.0-cl8.xml
@@ -7,6 +7,7 @@
       </crossRefs>
       <notes>This license was superseded by v2.0. This is Artistic License 1.0 as found on OSI site, including clause
          8.</notes>
+    <text>
       <titleText>
          <p>The Artistic License</p>
       </titleText>
@@ -140,5 +141,6 @@
       <optional>
          <p>The End</p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Artistic-1.0.xml
+++ b/src/Artistic-1.0.xml
@@ -6,6 +6,7 @@
       </crossRefs>
       <notes>This license was superseded by v2.0. This is Artistic License 1.0 as found on OSI site, excluding clause
          8.</notes>
+    <text>
       <titleText>
          <p>The Artistic License</p>
       </titleText>
@@ -134,5 +135,6 @@
       <optional>
          <p>The End</p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Artistic-2.0.xml
+++ b/src/Artistic-2.0.xml
@@ -6,6 +6,7 @@
          <crossRef>http://www.opensource.org/licenses/artistic-license-2.0</crossRef>
       </crossRefs>
       <notes>This license was released: 2006</notes>
+    <text>
       <titleText>
          <p>The Artistic License 2.0</p>
       </titleText>
@@ -231,6 +232,6 @@
          POSSIBILITY OF SUCH DAMAGE.</p>
         </item>
       </list>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/BSD-1-Clause.xml
+++ b/src/BSD-1-Clause.xml
@@ -4,6 +4,7 @@
     <crossRefs>
       <crossRef>https://svnweb.freebsd.org/base/head/include/ifaddrs.h?revision=326823</crossRef>
     </crossRefs>
+    <text>
     <copyrightText>
       <p>
         Copyright (c) <alt name="copyright" match=".+">&lt;year&gt; &lt;owner&gt;</alt>
@@ -38,5 +39,6 @@
       NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
       THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     </p>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/BSD-2-Clause-FreeBSD.xml
+++ b/src/BSD-2-Clause-FreeBSD.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>http://www.freebsd.org/copyright/freebsd-license.html</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>The FreeBSD Copyright</p>
       </titleText>
@@ -38,6 +39,6 @@
       <p>The views and conclusions contained in the software and documentation are those of the authors and should
          not be interpreted as representing official policies, either expressed or implied, of the FreeBSD
          Project.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/BSD-2-Clause-NetBSD.xml
+++ b/src/BSD-2-Clause-NetBSD.xml
@@ -6,6 +6,7 @@
          <crossRef>http://www.netbsd.org/about/redistribution.html#default</crossRef>
       </crossRefs>
       <notes>NetBSD adopted this 2-clause license in 2008 for code contributed to NetBSD Foundation.</notes>
+    <text>
       <copyrightText>
          <p>Copyright (c) 2008 The NetBSD Foundation, Inc. All rights reserved.</p>
       </copyrightText>
@@ -39,6 +40,6 @@
         TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
         ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
       </p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/BSD-2-Clause-Patent.xml
+++ b/src/BSD-2-Clause-Patent.xml
@@ -14,6 +14,7 @@
         c) which also has an express patent grant included.
       </p>
     </notes>
+    <text>
     <copyrightText>
       <p>
         Copyright (c)<alt name="copyright"
@@ -86,5 +87,6 @@
       (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
       OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     </p>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/BSD-2-Clause.xml
+++ b/src/BSD-2-Clause.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>http://www.opensource.org/licenses/BSD-2-Clause</crossRef>
       </crossRefs>
+    <text>
       <copyrightText>
          <p>Copyright (c) 
         <alt match=".+" name="copyright">&lt;year&gt; &lt;owner&gt;</alt><optional>. All rights reserved.</optional>
@@ -37,6 +38,6 @@
         TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
         ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
       </p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/BSD-3-Clause-Attribution.xml
+++ b/src/BSD-3-Clause-Attribution.xml
@@ -6,6 +6,7 @@
          <crossRef>https://fedoraproject.org/wiki/Licensing/BSD_with_Attribution</crossRef>
       </crossRefs>
     
+    <text>
       <p>Redistribution and use in source and binary forms, with or without modification, are permitted provided
          that the following conditions are met:</p>
       <list>
@@ -43,6 +44,6 @@
          DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
          CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
          USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/BSD-3-Clause-Clear.xml
+++ b/src/BSD-3-Clause-Clear.xml
@@ -7,6 +7,7 @@
       </crossRefs>
       <notes>This is same as BSD-3-Clause but with explicit statement as to no patent rights granted in last
          paragraph.</notes>
+    <text>
       <titleText>
          <p>The Clear BSD License</p>
       </titleText>
@@ -54,6 +55,6 @@
         TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
         ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
       </p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/BSD-3-Clause-LBNL.xml
+++ b/src/BSD-3-Clause-LBNL.xml
@@ -7,6 +7,7 @@
       </crossRefs>
       <notes>This license is the same as BSD-3-Clause, but with an additional default contribution licensing clause</notes>
     
+    <text>
       <p>Copyright (c) 2003, The Regents of the University of California, through Lawrence Berkeley National
          Laboratory (subject to receipt of any required approvals from the U.S. Dept. of Energy). All rights
          reserved. Redistribution and use in source and binary forms, with or without modification, are
@@ -46,6 +47,6 @@
          hereby grant the following license: a non-exclusive, royalty-free perpetual license to install, use,
          modify, prepare derivative works, incorporate into other computer software, distribute, and sublicense
          such Enhancements or derivative works thereof, in binary and source code form.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/BSD-3-Clause-No-Nuclear-License-2014.xml
+++ b/src/BSD-3-Clause-No-Nuclear-License-2014.xml
@@ -9,6 +9,7 @@
          BSD-3-Clause-No-Nuclear-License, except it has a different
          entire disclaimer clause that is the same as
          BSD-3-Clause.</notes>
+    <text>
       <copyrightText>
          <p>Copyright © 2008, 2014 Oracle and/or its affiliates. All rights
          reserved.</p>
@@ -55,5 +56,6 @@
       <p>You acknowledge that this software is not designed, licensed or
          intended for use in the design, construction, operation or
          maintenance of any nuclear facility.</p>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/BSD-3-Clause-No-Nuclear-License.xml
+++ b/src/BSD-3-Clause-No-Nuclear-License.xml
@@ -10,6 +10,7 @@
          specifies that that software is "not licensed" for use in a
          nuclear facility, as opposed to a disclaimer for such
          use.</notes>
+    <text>
       <copyrightText>
          <p>Copyright 1994-2009 Sun Microsystems, Inc. All Rights Reserved.</p>
       </copyrightText>
@@ -55,5 +56,6 @@
       <p>You acknowledge that this software is not designed, licensed or
          intended for use in the design, construction, operation or
          maintenance of any nuclear facility.</p>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/BSD-3-Clause-No-Nuclear-Warranty.xml
+++ b/src/BSD-3-Clause-No-Nuclear-Warranty.xml
@@ -9,6 +9,7 @@
          BSD-3-Clause-No-Nuclear-License, except it has a disclaimer
          for nuclear factility use, instead of the software "not
          licensed" for such use.</notes>
+    <text>
       <copyrightText>
          <p>Copyright (c) 2003-2005 Sun Microsystems, Inc. All Rights Reserved.</p>
       </copyrightText>
@@ -54,5 +55,6 @@
       <p>You acknowledge that this software is not designed or intended
          for use in the design, construction, operation or maintenance
          of any nuclear facility.</p>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/BSD-3-Clause.xml
+++ b/src/BSD-3-Clause.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>http://www.opensource.org/licenses/BSD-3-Clause</crossRef>
       </crossRefs>
+    <text>
       <copyrightText>
         <p>Copyright (c) <alt match=".+" name="copyright"> &lt;year&gt; &lt;owner&gt;</alt>. All rights reserved.</p>
       </copyrightText>
@@ -39,6 +40,6 @@
          LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
          WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY 
          OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/BSD-4-Clause-UC.xml
+++ b/src/BSD-4-Clause-UC.xml
@@ -9,6 +9,7 @@
          of California. Captures the retroactive deletion of the third (advertising) clause of the Original BSD
          license for BSD-licensed code developed by UC Berkeley and its contributors (see
          ftp://ftp.cs.berkeley.edu/pub/4bsd/README.Impt.License.Change)</notes>
+    <text>
       <titleText>
          <p>BSD-4-Clause (University of California-Specific)</p>
       </titleText>
@@ -48,6 +49,6 @@
          INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
          TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
          ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/BSD-4-Clause.xml
+++ b/src/BSD-4-Clause.xml
@@ -6,6 +6,7 @@
          <crossRef>http://directory.fsf.org/wiki/License:BSD_4Clause</crossRef>
       </crossRefs>
       <notes>This license was rescinded by the author on 22 July 1999.</notes>
+    <text>
       <copyrightText>
          <p>Copyright (c) 
         <alt match=".+" name="copyright">&lt;year&gt; &lt;owner&gt;</alt>. All rights reserved. 
@@ -54,6 +55,6 @@
         NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
         POSSIBILITY OF SUCH DAMAGE. 
       </p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/BSD-Protection.xml
+++ b/src/BSD-Protection.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/BSD_Protection_License</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>BSD Protection License 
         <br/>February 2002 
@@ -162,6 +163,6 @@
          BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
          LIABILITY, OR TORT, EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
          DAMAGES.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/BSD-Source-Code.xml
+++ b/src/BSD-Source-Code.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>https://github.com/robbiehanson/CocoaHTTPServer/blob/master/LICENSE.txt</crossRef>
       </crossRefs>
+    <text>
       <copyrightText>
          <p>Copyright (c) 
         <alt match=".+" name="copyright">2011, Deusty, LLC</alt>
@@ -50,6 +51,6 @@
         THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
         DAMAGE.
       </p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/BSL-1.0.xml
+++ b/src/BSL-1.0.xml
@@ -6,6 +6,7 @@
          <crossRef>http://www.opensource.org/licenses/BSL-1.0</crossRef>
       </crossRefs>
       <notes>This license was released: 17 August 2003</notes>
+    <text>
       <titleText>
          <p>Boost Software License - Version 1.0 - August 17th, 2003</p>
       </titleText>
@@ -24,6 +25,6 @@
          NON-INFRINGEMENT. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE
          LIABLE FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
          OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Bahyph.xml
+++ b/src/Bahyph.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/Bahyph</crossRef>
       </crossRefs>
+    <text>
       <optional>
          <p>COPYRIGHT NOTICE</p>
       </optional>
@@ -26,5 +27,6 @@
       <optional>
          <p>END OF COPYRIGHT NOTICE</p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Barr.xml
+++ b/src/Barr.xml
@@ -5,12 +5,13 @@
          <crossRef>https://fedoraproject.org/wiki/Licensing/Barr</crossRef>
       </crossRefs>
     
+    <text>
       <p>This is a package of commutative diagram macros built on top of Xy-pic by Michael Barr (email:
          barr@barrs.org). Its use is unrestricted. It may be freely distributed, unchanged, for non-commercial
          or commercial use. If changed, it must be renamed. Inclusion in a commercial software package is also
          permitted, but I would appreciate receiving a free copy for my personal examination and use. There are
          no guarantees that this package is good for anything. I have tested it with LaTeX 2e, LaTeX 2.09 and
          Plain TeX. Although I know of no reason it will not work with AMSTeX, I have not tested it.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Beerware.xml
+++ b/src/Beerware.xml
@@ -6,10 +6,11 @@
          <crossRef>https://people.freebsd.org/~phk/</crossRef>
       </crossRefs>
     
+    <text>
       <p>"THE BEER-WARE LICENSE" (Revision 42):
       <br></br>&lt;phk@FreeBSD.ORG&gt; wrote this file. As long as you retain
          this notice you can do whatever you want with this stuff. If we meet some day, and you think this
          stuff is worth it, you can buy me a beer in return Poul-Henning Kamp</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/BitTorrent-1.0.xml
+++ b/src/BitTorrent-1.0.xml
@@ -13,6 +13,7 @@
       either express or implied. See the License for the specific language governing rights and limitations under 
       the License.</p>
       </standardLicenseHeader>
+    <text>
       <titleText>
          <p>BitTorrent Open Source License 
         <br/>Version 1.0 
@@ -467,5 +468,6 @@
          either express or implied. See the License for the specific language governing rights and limitations
          under the License.</p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/BitTorrent-1.1.xml
+++ b/src/BitTorrent-1.1.xml
@@ -14,6 +14,7 @@
       under the License.</p>
       </standardLicenseHeader>
       <notes>Standard header seems to use wrong version number (this is how it appears on all references found.)</notes>
+    <text>
       <titleText>
          <p>BitTorrent Open Source License 
         <br/>Version 1.1 
@@ -512,5 +513,6 @@
          under the License.</p>
          <p>BitTorrent, Inc.</p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Borceux.xml
+++ b/src/Borceux.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/Borceux</crossRef>
       </crossRefs>
+    <text>
       <copyrightText>
          <p>Copyright 1993 Francis Borceux</p>
       </copyrightText>
@@ -27,6 +28,6 @@
       <p>Of course no support is guaranteed, but the author will attempt to assist with problems. Current email address: 
         <br/>francis dot borceux at uclouvain dot be. 
       </p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/CATOSL-1.1.xml
+++ b/src/CATOSL-1.1.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>http://opensource.org/licenses/CATOSL-1.1</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Computer Associates Trusted Open Source License 
         <br/>Version 1.1 
@@ -435,6 +436,6 @@
             </list>
         </item>
       </list>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/CC-BY-1.0.xml
+++ b/src/CC-BY-1.0.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>http://creativecommons.org/licenses/by/1.0/legalcode</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Creative Commons Attribution 1.0</p>
       </titleText>
@@ -264,6 +265,6 @@
          compliance with Creative Commons' then-current trademark usage guidelines, as may be published on
          its website or otherwise made available upon request from time to time.</p>
       <p>Creative Commons may be contacted at http://creativecommons.org/.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/CC-BY-2.0.xml
+++ b/src/CC-BY-2.0.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>http://creativecommons.org/licenses/by/2.0/legalcode</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Creative Commons Attribution 2.0</p>
       </titleText>
@@ -278,6 +279,6 @@
          compliance with Creative Commons' then-current trademark usage guidelines, as may be published on
          its website or otherwise made available upon request from time to time.</p>
       <p>Creative Commons may be contacted at http://creativecommons.org/.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/CC-BY-2.5.xml
+++ b/src/CC-BY-2.5.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>http://creativecommons.org/licenses/by/2.5/legalcode</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Creative Commons Attribution 2.5</p>
       </titleText>
@@ -279,6 +280,6 @@
          compliance with Creative Commons' then-current trademark usage guidelines, as may be published on
          its website or otherwise made available upon request from time to time.</p>
       <p>Creative Commons may be contacted at http://creativecommons.org/.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/CC-BY-3.0.xml
+++ b/src/CC-BY-3.0.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>http://creativecommons.org/licenses/by/3.0/legalcode</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Creative Commons Attribution 3.0 Unported</p>
       </titleText>
@@ -362,6 +363,6 @@
          request from time to time. For the avoidance of doubt, this trademark restriction does not form part
          of this License.</p>
       <p>Creative Commons may be contacted at http://creativecommons.org/.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/CC-BY-4.0.xml
+++ b/src/CC-BY-4.0.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>http://creativecommons.org/licenses/by/4.0/legalcode</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p><optional>Creative Commons </optional>Attribution 4.0 International</p>
       </titleText>
@@ -438,6 +439,6 @@
          licenses or any other arrangements, understandings, or agreements concerning use of licensed material.
          For the avoidance of doubt, this paragraph does not form part of the public licenses.</p>
       <p>Creative Commons may be contacted at creativecommons.org.</p>
-
+    </text>
     </license>
 </SPDXLicenseCollection>

--- a/src/CC-BY-NC-1.0.xml
+++ b/src/CC-BY-NC-1.0.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>http://creativecommons.org/licenses/by-nc/1.0/legalcode</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Creative Commons Attribution-NonCommercial 1.0</p>
       </titleText>
@@ -254,6 +255,6 @@
          compliance with Creative Commons' then-current trademark usage guidelines, as may be published on
          its website or otherwise made available upon request from time to time.</p>
       <p>Creative Commons may be contacted at http://creativecommons.org/.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/CC-BY-NC-2.0.xml
+++ b/src/CC-BY-NC-2.0.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>http://creativecommons.org/licenses/by-nc/2.0/legalcode</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Creative Commons Attribution-NonCommercial 2.0</p>
       </titleText>
@@ -288,6 +289,6 @@
          compliance with Creative Commons' then-current trademark usage guidelines, as may be published on
          its website or otherwise made available upon request from time to time.</p>
       <p>Creative Commons may be contacted at http://creativecommons.org/.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/CC-BY-NC-2.5.xml
+++ b/src/CC-BY-NC-2.5.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>http://creativecommons.org/licenses/by-nc/2.5/legalcode</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Creative Commons Attribution-NonCommercial 2.5</p>
       </titleText>
@@ -291,6 +292,6 @@
          compliance with Creative Commons' then-current trademark usage guidelines, as may be published on
          its website or otherwise made available upon request from time to time.</p>
       <p>Creative Commons may be contacted at http://creativecommons.org/.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/CC-BY-NC-3.0.xml
+++ b/src/CC-BY-NC-3.0.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>http://creativecommons.org/licenses/by-nc/3.0/legalcode</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Creative Commons Attribution-NonCommercial 3.0 Unported</p>
       </titleText>
@@ -377,6 +378,6 @@
          request from time to time. For the avoidance of doubt, this trademark restriction does not form part
          of the License.</p>
       <p>Creative Commons may be contacted at http://creativecommons.org/.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/CC-BY-NC-4.0.xml
+++ b/src/CC-BY-NC-4.0.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>http://creativecommons.org/licenses/by-nc/4.0/legalcode</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p><optional>Creative Commons </optional>Attribution-NonCommercial 4.0 International</p>
       </titleText>
@@ -469,6 +470,6 @@
             licenses or any other arrangements, understandings, or agreements concerning use of licensed material.
             For the avoidance of doubt, this paragraph does not form part of the public licenses.</p>
         <p>Creative Commons may be contacted at creativecommons.org.</p>
-
+    </text>
     </license>
 </SPDXLicenseCollection>

--- a/src/CC-BY-NC-ND-1.0.xml
+++ b/src/CC-BY-NC-ND-1.0.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>http://creativecommons.org/licenses/by-nd-nc/1.0/legalcode</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Creative Commons Attribution-NoDerivs-NonCommercial 1.0</p>
       </titleText>
@@ -251,6 +252,6 @@
          compliance with Creative Commons' then-current trademark usage guidelines, as may be published on
          its website or otherwise made available upon request from time to time.</p>
       <p>Creative Commons may be contacted at http://creativecommons.org/.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/CC-BY-NC-ND-2.0.xml
+++ b/src/CC-BY-NC-ND-2.0.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>http://creativecommons.org/licenses/by-nc-nd/2.0/legalcode</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Creative Commons Attribution-NonCommercial-NoDerivs 2.0</p>
       </titleText>
@@ -270,6 +271,6 @@
          compliance with Creative Commons' then-current trademark usage guidelines, as may be published on
          its website or otherwise made available upon request from time to time.</p>
       <p>Creative Commons may be contacted at http://creativecommons.org/.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/CC-BY-NC-ND-2.5.xml
+++ b/src/CC-BY-NC-ND-2.5.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>http://creativecommons.org/licenses/by-nc-nd/2.5/legalcode</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Creative Commons Attribution-NonCommercial-NoDerivs 2.5</p>
       </titleText>
@@ -272,6 +273,6 @@
          compliance with Creative Commons' then-current trademark usage guidelines, as may be published on
          its website or otherwise made available upon request from time to time.</p>
       <p>Creative Commons may be contacted at http://creativecommons.org/.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/CC-BY-NC-ND-3.0.xml
+++ b/src/CC-BY-NC-ND-3.0.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>http://creativecommons.org/licenses/by-nc-nd/3.0/legalcode</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported</p>
       </titleText>
@@ -347,6 +348,6 @@
          request from time to time. For the avoidance of doubt, this trademark restriction does not form part
          of this License.</p>
       <p>Creative Commons may be contacted at http://creativecommons.org/.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/CC-BY-NC-ND-4.0.xml
+++ b/src/CC-BY-NC-ND-4.0.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>http://creativecommons.org/licenses/by-nc-nd/4.0/legalcode</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p><optional>Creative Commons </optional>Attribution-NonCommercial-NoDerivatives 4.0 International</p>
       </titleText>
@@ -451,6 +452,6 @@
          licenses or any other arrangements, understandings, or agreements concerning use of licensed material.
          For the avoidance of doubt, this paragraph does not form part of the public licenses.</p>
       <p>Creative Commons may be contacted at creativecommons.org.</p>
-
+    </text>
     </license>
 </SPDXLicenseCollection>

--- a/src/CC-BY-NC-SA-1.0.xml
+++ b/src/CC-BY-NC-SA-1.0.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>http://creativecommons.org/licenses/by-nc-sa/1.0/legalcode</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Creative Commons Attribution-NonCommercial-ShareAlike 1.0</p>
       </titleText>
@@ -288,6 +289,6 @@
          compliance with Creative Commons' then-current trademark usage guidelines, as may be published on
          its website or otherwise made available upon request from time to time.</p>
       <p>Creative Commons may be contacted at http://creativecommons.org/.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/CC-BY-NC-SA-2.0.xml
+++ b/src/CC-BY-NC-SA-2.0.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>http://creativecommons.org/licenses/by-nc-sa/2.0/legalcode</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Creative Commons Attribution-NonCommercial-ShareAlike 2.0</p>
       </titleText>
@@ -317,6 +318,6 @@
          compliance with Creative Commons' then-current trademark usage guidelines, as may be published on
          its website or otherwise made available upon request from time to time.</p>
       <p>Creative Commons may be contacted at http://creativecommons.org/.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/CC-BY-NC-SA-2.5.xml
+++ b/src/CC-BY-NC-SA-2.5.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>http://creativecommons.org/licenses/by-nc-sa/2.5/legalcode</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Creative Commons Attribution-NonCommercial-ShareAlike 2.5</p>
       </titleText>
@@ -320,6 +321,6 @@
          compliance with Creative Commons' then-current trademark usage guidelines, as may be published on
          its website or otherwise made available upon request from time to time.</p>
       <p>Creative Commons may be contacted at http://creativecommons.org/.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/CC-BY-NC-SA-3.0.xml
+++ b/src/CC-BY-NC-SA-3.0.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>http://creativecommons.org/licenses/by-nc-sa/3.0/legalcode</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported</p>
       </titleText>
@@ -404,6 +405,6 @@
          request from time to time. For the avoidance of doubt, this trademark restriction does not form part
          of this License.</p>
       <p>Creative Commons may be contacted at http://creativecommons.org/.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/CC-BY-NC-SA-4.0.xml
+++ b/src/CC-BY-NC-SA-4.0.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>http://creativecommons.org/licenses/by-nc-sa/4.0/legalcode</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p><optional>Creative Commons </optional>Attribution-NonCommercial-ShareAlike 4.0 International</p>
       </titleText>
@@ -480,6 +481,6 @@
          licenses or any other arrangements, understandings, or agreements concerning use of licensed material.
          For the avoidance of doubt, this paragraph does not form part of the public licenses.</p>
       <p>Creative Commons may be contacted at creativecommons.org.</p>
-
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/CC-BY-ND-1.0.xml
+++ b/src/CC-BY-ND-1.0.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>http://creativecommons.org/licenses/by-nd/1.0/legalcode</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Creative Commons Attribution-NoDerivs 1.0</p>
       </titleText>
@@ -242,6 +243,6 @@
          compliance with Creative Commons' then-current trademark usage guidelines, as may be published on
          its website or otherwise made available upon request from time to time.</p>
       <p>Creative Commons may be contacted at http://creativecommons.org/.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/CC-BY-ND-2.0.xml
+++ b/src/CC-BY-ND-2.0.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>https://creativecommons.org/licenses/by-nd/2.0/legalcode</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Creative Commons Attribution-NoDerivs 2.0</p>
       </titleText>
@@ -258,6 +259,6 @@
          be in compliance with Creative Commons' then-current trademark usage guidelines, as may be
          published on its website or otherwise made available upon request from time to time.</p>
       <p>Creative Commons may be contacted at http<optional>s</optional>://creativecommons.org/.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/CC-BY-ND-2.5.xml
+++ b/src/CC-BY-ND-2.5.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>http://creativecommons.org/licenses/by-nd/2.5/legalcode</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Creative Commons Attribution-NoDerivs 2.5</p>
       </titleText>
@@ -258,6 +259,6 @@
          compliance with Creative Commons' then-current trademark usage guidelines, as may be published on
          its website or otherwise made available upon request from time to time.</p>
       <p>Creative Commons may be contacted at http://creativecommons.org/.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/CC-BY-ND-3.0.xml
+++ b/src/CC-BY-ND-3.0.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>http://creativecommons.org/licenses/by-nd/3.0/legalcode</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Creative Commons Attribution-NoDerivs 3.0 Unported</p>
       </titleText>
@@ -333,6 +334,6 @@
          request from time to time. For the avoidance of doubt, this trademark restriction does not form part
          of this License.</p>
       <p>Creative Commons may be contacted at http://creativecommons.org/.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/CC-BY-ND-4.0.xml
+++ b/src/CC-BY-ND-4.0.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>http://creativecommons.org/licenses/by-nd/4.0/legalcode</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p><optional>Creative Commons </optional>Attribution-NoDerivatives 4.0 International</p>
       </titleText>
@@ -430,5 +431,6 @@
          agreements concerning use of licensed material. For the avoidance of doubt, this paragraph does not
          form part of the public licenses.</p>
         <p>Creative Commons may be contacted at creativecommons.org.</p>
+    </text>
     </license>
 </SPDXLicenseCollection>

--- a/src/CC-BY-SA-1.0.xml
+++ b/src/CC-BY-SA-1.0.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>http://creativecommons.org/licenses/by-sa/1.0/legalcode</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Creative Commons Attribution-ShareAlike 1.0</p>
       </titleText>
@@ -280,6 +281,6 @@
          compliance with Creative Commons' then-current trademark usage guidelines, as may be published on
          its website or otherwise made available upon request from time to time.</p>
       <p>Creative Commons may be contacted at http://creativecommons.org/.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/CC-BY-SA-2.0.xml
+++ b/src/CC-BY-SA-2.0.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>http://creativecommons.org/licenses/by-sa/2.0/legalcode</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Creative Commons Attribution-ShareAlike 2.0</p>
       </titleText>
@@ -301,6 +302,6 @@
          compliance with Creative Commons' then-current trademark usage guidelines, as may be published on
          its website or otherwise made available upon request from time to time.</p>
       <p>Creative Commons may be contacted at http://creativecommons.org/.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/CC-BY-SA-2.5.xml
+++ b/src/CC-BY-SA-2.5.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>http://creativecommons.org/licenses/by-sa/2.5/legalcode</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Creative Commons Attribution-ShareAlike 2.5</p>
       </titleText>
@@ -304,6 +305,6 @@
          compliance with Creative Commons' then-current trademark usage guidelines, as may be published on
          its website or otherwise made available upon request from time to time.</p>
       <p>Creative Commons may be contacted at http://creativecommons.org/.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/CC-BY-SA-3.0.xml
+++ b/src/CC-BY-SA-3.0.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>http://creativecommons.org/licenses/by-sa/3.0/legalcode</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Creative Commons Attribution-ShareAlike 3.0 Unported</p>
       </titleText>
@@ -404,5 +405,6 @@
          request from time to time. For the avoidance of doubt, this trademark restriction does not form part
          of the License.</p>
       <p>Creative Commons may be contacted at http://creativecommons.org/.</p>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/CC-BY-SA-4.0.xml
+++ b/src/CC-BY-SA-4.0.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>http://creativecommons.org/licenses/by-sa/4.0/legalcode</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p><optional>Creative Commons </optional>Attribution-ShareAlike 4.0 International</p>
       </titleText>
@@ -469,5 +470,6 @@
          licenses or any other arrangements, understandings, or agreements concerning use of licensed material.
          For the avoidance of doubt, this paragraph does not form part of the public licenses.</p>
       <p>Creative Commons may be contacted at creativecommons.org.</p>
+    </text>
     </license>
 </SPDXLicenseCollection>

--- a/src/CC0-1.0.xml
+++ b/src/CC0-1.0.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>http://creativecommons.org/publicdomain/zero/1.0/legalcode</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <optional>
             <p>Creative Commons<optional> Legal Code</optional></p>
@@ -146,6 +147,6 @@
             </list>
         </item>
       </list>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/CDDL-1.0.xml
+++ b/src/CDDL-1.0.xml
@@ -6,6 +6,7 @@
          <crossRef>http://www.opensource.org/licenses/cddl1</crossRef>
       </crossRefs>
       <notes>This license was released: 24 January 2004.</notes>
+    <text>
       <titleText>
          <p>COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) 
         <br/>Version 1.0 
@@ -401,5 +402,6 @@
            Nothing herein is intended or shall be deemed to constitute any admission of liability.</p>
          </item>
       </list>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/CDDL-1.1.xml
+++ b/src/CDDL-1.1.xml
@@ -8,6 +8,7 @@
       </crossRefs>
       <notes>Same as 1.0, but changes name from Sun to Oracle in section 4.1 and adds patent infringement termination
          clause (section 6.3)</notes>
+    <text>
       <titleText>
          <p>COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) 
         <br/>Version 1.1 
@@ -422,5 +423,6 @@
              the state courts of the State of California, with venue lying in Santa Clara County,
              California. 
       </p>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/CDLA-Permissive-1.0.xml
+++ b/src/CDLA-Permissive-1.0.xml
@@ -5,6 +5,7 @@
     <crossRefs>
       <crossRef>https://cdla.io/permissive-1-0</crossRef>
     </crossRefs>
+    <text>
     <titleText>
       <p>
         Community Data License Agreement - Permissive - Version 1.0
@@ -322,5 +323,6 @@
         </list>
       </item>
     </list>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/CDLA-Sharing-1.0.xml
+++ b/src/CDLA-Sharing-1.0.xml
@@ -5,6 +5,7 @@
     <crossRefs>
       <crossRef>https://cdla.io/sharing-1-0</crossRef>
     </crossRefs>
+    <text>
     <titleText>
       <p>
         Community Data License Agreement - Sharing - Version 1.0
@@ -339,5 +340,6 @@
         </list>
       </item>
     </list>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/CECILL-1.0.xml
+++ b/src/CECILL-1.0.xml
@@ -6,6 +6,7 @@
          <crossRef>http://www.cecill.info/licences/Licence_CeCILL_V1-fr.html</crossRef>
       </crossRefs>
       <notes>English translation can be found here: http://www.cecill.info/licences/Licence_CeCILL_V1-US.html</notes>
+    <text>
       <titleText>
          <p>CONTRAT DE LICENCE DE LOGICIEL LIBRE CeCILL</p>
       </titleText>
@@ -515,5 +516,6 @@
       <optional>
          <p>Version 1 du 21/06/2004</p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/CECILL-1.1.xml
+++ b/src/CECILL-1.1.xml
@@ -6,6 +6,7 @@
          <crossRef>http://www.cecill.info/licences/Licence_CeCILL_V1.1-US.html</crossRef>
       </crossRefs>
       <notes>There is only an English version for 1.1, which includes some wording changes from v1.0</notes>
+    <text>
       <titleText>
          <p>FREE SOFTWARE LICENSING AGREEMENT CeCILL</p>
       </titleText>
@@ -578,6 +579,6 @@
       </list>
     
       <p>Version 1.1 of 10/26/2004</p>
-
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/CECILL-2.0.xml
+++ b/src/CECILL-2.0.xml
@@ -8,6 +8,7 @@
       <notes>
 French version can be found here: http://www.cecill.info/licences/Licence_CeCILL_V2-fr.html
   </notes>
+    <text>
       <titleText>
          <p>
 CeCILL FREE SOFTWARE LICENSE AGREEMENT
@@ -643,5 +644,6 @@ Failing an amicable solution within two (2) months as from their occurrence, and
 Version 2.0 dated 2006-09-05.
   </p>
   <optional>1 CeCILL stands for Ce(a) C(nrs) I(nria) L(ogiciel) L(ibre)</optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/CECILL-2.1.xml
+++ b/src/CECILL-2.1.xml
@@ -8,6 +8,7 @@
       <notes>
 French version can be found here: http://www.cecill.info/licences/Licence_CeCILL_V2.1-fr.html
   </notes>
+    <text>
       <titleText>
          <p>
 CeCILL FREE SOFTWARE LICENSE AGREEMENT
@@ -663,5 +664,6 @@ Failing an amicable solution within two (2) months as from their occurrence, and
          </item>
       </list>
 	  <optional>1 CeCILL stands for Ce(a) C(nrs) I(nria) L(ogiciel) L(ibre)</optional>
+    </text>
    </license>
 </SPDXLicenseCollection>

--- a/src/CECILL-B.xml
+++ b/src/CECILL-B.xml
@@ -8,6 +8,7 @@
       <notes>
 French version can be found here: http://www.cecill.info/licences/Licence_CeCILL-B_V1-fr.html
   </notes>
+    <text>
       <titleText>
          <p>
 CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
@@ -656,5 +657,6 @@ Failing an amicable solution within two (2) months as from their occurrence, and
 Version 1.0 dated 2006-09-05.
   </p>
   <optional>1 CeCILL stands for Ce(a) C(nrs) I(nria) L(ogiciel) L(ibre)</optional>
+    </text>
    </license>
 </SPDXLicenseCollection>

--- a/src/CECILL-C.xml
+++ b/src/CECILL-C.xml
@@ -9,6 +9,7 @@
       <notes>
 French version can be found here: http://www.cecill.info/licences/Licence_CeCILL-C_V1-fr.html
   </notes>
+    <text>
       <titleText>
          <p>
 CeCILL-C FREE SOFTWARE LICENSE AGREEMENT
@@ -657,5 +658,6 @@ Failing an amicable solution within two (2) months as from their occurrence, and
 Version 1.0 dated 2006-09-05.
   </p>
   <optional>1 CeCILL stands for Ce(a) C(nrs) I(nria) L(ogiciel) L(ibre)</optional>
+    </text>
    </license>
 </SPDXLicenseCollection>

--- a/src/CNRI-Jython.xml
+++ b/src/CNRI-Jython.xml
@@ -7,6 +7,7 @@
       <notes>This is very similar to CNRI-Python (also on this list), but for an extra clause covering restrictions on
          trademark and use of the name.</notes>
     
+    <text>
       <list>
         <item>
             <bullet>1.</bullet>
@@ -87,6 +88,6 @@
              Agreement.
         </item>
       </list>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/CNRI-Python-GPL-Compatible.xml
+++ b/src/CNRI-Python-GPL-Compatible.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>http://www.python.org/download/releases/1.6.1/download_win/</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>CNRI OPEN SOURCE GPL-COMPATIBLE LICENSE AGREEMENT</p>
       </titleText>
@@ -84,5 +85,6 @@
       <optional>
          <p>ACCEPT</p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/CNRI-Python.xml
+++ b/src/CNRI-Python.xml
@@ -5,6 +5,7 @@
          <crossRef>http://www.opensource.org/licenses/CNRI-Python</crossRef>
       </crossRefs>
       <notes>CNRI portion of the multi-part Python License (Python-2.0)</notes>
+    <text>
       <titleText>
          <p>CNRI OPEN SOURCE LICENSE AGREEMENT</p>
       </titleText>
@@ -79,5 +80,6 @@
       </list>
     
       <p>ACCEPT</p>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/CPAL-1.0.xml
+++ b/src/CPAL-1.0.xml
@@ -37,6 +37,7 @@
     may use your version of this file under either the CPAL or the 
             <alt match=".+" name="licenseName">[____]</alt> License. </p>
   </standardLicenseHeader>
+    <text>
       <titleText>
          <p>Common Public Attribution License Version 1.0 (CPAL)</p>
       </titleText>
@@ -666,5 +667,6 @@
              the terms of the CPAL. 
       </p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/CPL-1.0.xml
+++ b/src/CPL-1.0.xml
@@ -5,6 +5,7 @@
          <crossRef>http://opensource.org/licenses/CPL-1.0</crossRef>
       </crossRefs>
       <notes>This license was superseded by Eclipse Public License</notes>
+    <text>
       <titleText>
          <p>Common Public License Version 1.0</p>
       </titleText>
@@ -234,6 +235,6 @@
          United States of America. No party to this Agreement will bring a legal action under this Agreement
          more than one year after the cause of action arose. Each party waives its rights to a jury trial in
          any resulting litigation.</p>
-
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/CPOL-1.02.xml
+++ b/src/CPOL-1.02.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>http://www.codeproject.com/info/cpol10.aspx</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>The Code Project Open License (CPOL) 1.02</p>
       </titleText>
@@ -308,5 +309,6 @@
             </list>
         </item>
       </list>    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/CUA-OPL-1.0.xml
+++ b/src/CUA-OPL-1.0.xml
@@ -28,6 +28,7 @@
         License. If you do not delete the provisions above, a recipient may use your version of this file 
         under either the CUAPL or the <alt match=".+" name="AltLicenseName">[____]</alt> License. </p>
       </standardLicenseHeader>
+    <text>
       <titleText>
          <p>CUA Office Public License Version 1.0</p>
       </titleText>
@@ -540,5 +541,6 @@
          files of the Original Code. You should use the text of this Exhibit A rather than the text found in
          the Original Code Source Code for Your Modifications.]</p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Caldera.xml
+++ b/src/Caldera.xml
@@ -5,6 +5,7 @@
          <crossRef>http://www.lemis.com/grog/UNIX/ancient-source-all.pdf</crossRef>
       </crossRefs>
     
+    <text>
       <p>Caldera International, Inc. hereby grants a fee free license that includes the rights use, modify and
          distribute this named source code, including creating derived binary products created from the source
          code. The source code for which Caldera International, Inc. grants rights are limited to the following
@@ -43,6 +44,6 @@
          TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED 
          OF THE POSSIBILITY OF SUCH DAMAGE. 
       </p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/ClArtistic.xml
+++ b/src/ClArtistic.xml
@@ -5,6 +5,7 @@
          <crossRef>http://gianluca.dellavedova.org/2011/01/03/clarified-artistic-license/</crossRef>
          <crossRef>http://www.ncftp.com/ncftp/doc/LICENSE.txt</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>The Clarified Artistic License</p>
       </titleText>
@@ -154,5 +155,6 @@
         </item>
       </list>
       <optional><p>The End</p></optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Condor-1.1.xml
+++ b/src/Condor-1.1.xml
@@ -6,6 +6,7 @@
          <crossRef>http://web.archive.org/web/20111123062036/http://research.cs.wisc.edu/condor/license.html#condor</crossRef>
       </crossRefs>
       <notes>This license was released 30 October 2003</notes>
+    <text>
       <titleText>
          <p>Condor Public License</p>
          <p>Version 1.1, October 30, 2003</p>
@@ -127,6 +128,6 @@
           <br/>http://pages.cs.wisc.edu/~miron/miron.html 
         </p>
       </optional>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Crossword.xml
+++ b/src/Crossword.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/Crossword</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Copyright (C) 1995-2009 Gerd Neugebauer</p>
       </titleText>
@@ -15,6 +16,6 @@
         <br/>Everyone is granted permission to copy, modify and redistribute cwpuzzle.dtx, provided this
              copyright notice is preserved and any modifications are indicated. 
       </p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/CrystalStacker.xml
+++ b/src/CrystalStacker.xml
@@ -5,6 +5,7 @@
          <crossRef>https://fedoraproject.org/wiki/Licensing:CrystalStacker?rd=Licensing/CrystalStacker</crossRef>
       </crossRefs>
     
+    <text>
       <p>Crystal Stacker is freeware. This means you can pass copies around freely provided you include this
          document in it's original form in your distribution. Please see the "Contacting Us" section of this
          document if you need to contact us for any reason.</p>
@@ -17,6 +18,6 @@
          regarding the usability of the source but are willing to help with any problems you might run into.
          Please see the "Contacting Us" section of this document if you need to get in touch with us about any
          issues you have regarding the source.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Cube.xml
+++ b/src/Cube.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/Cube</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Cube game engine source code, 20 dec 2003 release.</p>
       </titleText>
@@ -40,6 +41,6 @@
              explicitly written permission.
         </item>
       </list>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/D-FSL-1.0.xml
+++ b/src/D-FSL-1.0.xml
@@ -14,6 +14,7 @@
       </crossRefs>
       <notes>This license was created for and is backed by the German state. The English translation can be found here:
          http://www.dipp.nrw.de/d-fsl/index_html/lizenzen/en/D-FSL-1_0_en.txt</notes>
+    <text>
         <titleText>
             <p>Deutsche Freie Software Lizenz</p>
         </titleText>
@@ -430,5 +431,6 @@
             <p>Die Lizenz kann unter http://www.d-fsl.de abgerufen werden."</p>
         </item>
       </list>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/DOC.xml
+++ b/src/DOC.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>http://www.cs.wustl.edu/~schmidt/ACE-copying.html</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Copyright and Licensing Information for ACE(TM), TAO(TM), CIAO(TM), DAnCE(TM), and CoSMIC(TM)</p>
       </titleText>
@@ -56,6 +57,6 @@
          Washington University, UC Irvine, or Vanderbilt University to appear in their names.</p>
       <p>If you have any suggestions, additions, comments, or questions, please let me know.</p>
       <p>Douglas C. Schmidt</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/DSDP.xml
+++ b/src/DSDP.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/DSDP</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>COPYRIGHT NOTIFICATION</p>
       </titleText>
@@ -38,6 +39,6 @@
              GOVERNMENT OR ANY AGENCY THEREOF. THE VIEW AND OPINIONS OF AUTHORS EXPRESSED HEREIN DO NOT
              NECESSARILY STATE OR REFLECT THOSE OF THE UNITED STATES GOVERNMENT OR ANY AGENCY THEREOF. 
       </p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Dotseqn.xml
+++ b/src/Dotseqn.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/Dotseqn</crossRef>
       </crossRefs>
+    <text>
       <copyrightText>
          <p>Copyright (C) 1995 by Donald Arseneau</p>
       </copyrightText>
@@ -11,6 +12,6 @@
       <p>This file may be freely transmitted and reproduced, but it may not be changed unless the name is changed
          also (except that you may freely change the paper-size option for \documentclass).</p>
       <p>This notice must be left intact.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/ECL-1.0.xml
+++ b/src/ECL-1.0.xml
@@ -9,6 +9,7 @@
     <alt match=".+" name="copyright">&lt;year&gt; &lt;copyright holders&gt;</alt> Licensed under the Educational
     Community License version 1.0 
   </standardLicenseHeader>
+    <text>
       <titleText>
          <p>The Educational Community License</p>
       </titleText>
@@ -42,5 +43,6 @@
          the Original or Derivative Works without specific, written prior permission. Title to copyright in the
          Original Work and any associated documentation will at all times remain with the copyright
          holders.</p>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/ECL-2.0.xml
+++ b/src/ECL-2.0.xml
@@ -18,6 +18,7 @@
          communities using this license. The url included in the boilerplate notice does not work.
          (15/10/10)
   </notes>
+    <text>
       <titleText>
          <p>Educational Community License 
         <br/>Version 2.0, April 2007 
@@ -242,5 +243,6 @@
         <br/>permissions and limitations under the License. 
       </p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/EFL-1.0.xml
+++ b/src/EFL-1.0.xml
@@ -6,6 +6,7 @@
          <crossRef>http://opensource.org/licenses/EFL-1.0</crossRef>
       </crossRefs>
       <notes>This license has been superseded by v2.0</notes>
+    <text>
       <titleText>
          <p>Eiffel Forum License, version 1</p>
       </titleText>
@@ -35,6 +36,6 @@
          PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS BE LIABLE TO ANY PARTY FOR ANY DIRECT, INDIRECT,
          INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES ARISING IN ANY WAY OUT OF THE USE OF THIS
          PACKAGE.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/EFL-2.0.xml
+++ b/src/EFL-2.0.xml
@@ -5,6 +5,7 @@
          <crossRef>http://www.eiffel-nice.org/license/eiffel-forum-license-2.html</crossRef>
          <crossRef>http://opensource.org/licenses/EFL-2.0</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Eiffel Forum License, version 2</p>
       </titleText>
@@ -36,6 +37,6 @@
          PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS BE LIABLE TO ANY PARTY FOR ANY DIRECT, INDIRECT,
          INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES ARISING IN ANY WAY OUT OF THE USE OF THIS
          PACKAGE.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/EPL-1.0.xml
+++ b/src/EPL-1.0.xml
@@ -6,6 +6,7 @@
          <crossRef>http://www.opensource.org/licenses/EPL-1.0</crossRef>
       </crossRefs>
       <notes>EPL replaced the CPL on 28 June 2005.</notes>
+    <text>
       <titleText>
          <p>Eclipse Public License - v 1.0</p>
       </titleText>
@@ -249,6 +250,6 @@
          any resulting litigation.</p>
          </item>
       </list>  
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/EPL-2.0.xml
+++ b/src/EPL-2.0.xml
@@ -6,6 +6,7 @@
 			<crossRef>https://www.eclipse.org/legal/epl-2.0</crossRef>
 			<crossRef>https://www.opensource.org/licenses/EPL-2.0</crossRef>
 		</crossRefs>
+    <text>
 		<titleText>
 			<p>Eclipse Public License - v 2.0</p>
 		</titleText>
@@ -630,5 +631,6 @@
 				</p>
 			</item>
 		</list>
+    </text>
 	</license>
 </SPDXLicenseCollection>

--- a/src/EUDatagrid.xml
+++ b/src/EUDatagrid.xml
@@ -5,6 +5,7 @@
          <crossRef>http://eu-datagrid.web.cern.ch/eu-datagrid/license.html</crossRef>
          <crossRef>http://www.opensource.org/licenses/EUDatagrid</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>EU DataGrid Software License</p>
       </titleText>
@@ -72,6 +73,6 @@
          PROFITS, OR BUSINESS INTERRUPTION, HOWEVER CAUSED AND ON ANY THEORY OF CONTRACT, WARRANTY, TORT
          (INCLUDING NEGLIGENCE), PRODUCT LIABILITY OR OTHERWISE, ARISING IN ANY WAY OUT OF THE USE OF THIS
          SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/EUPL-1.0.xml
+++ b/src/EUPL-1.0.xml
@@ -7,6 +7,7 @@
          <crossRef>http://ec.europa.eu/idabc/servlets/Doc027f.pdf?id=31096</crossRef>
       </crossRefs>
       <notes>The European Commission has approved the EUPL on 9 January 2007.</notes>
+    <text>
       <titleText>
          <p>European Union Public Licence V.1.0</p>
       </titleText>
@@ -320,6 +321,6 @@
               Cecill v. 2.0
           </item>
       </list>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/EUPL-1.1.xml
+++ b/src/EUPL-1.1.xml
@@ -9,6 +9,7 @@
       </crossRefs>
       <notes>This license was released: 16 May 2008 This license is available in the 22 official languages of the EU. The
          English version is included here.</notes>
+    <text>
       <titleText>
          <p>European Union Public Licence V. 1.1</p>
       </titleText>
@@ -331,6 +332,6 @@
                 Cecill v. 2.0
             </item>
         </list>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/EUPL-1.2.xml
+++ b/src/EUPL-1.2.xml
@@ -13,6 +13,7 @@
       This license was released: 19 May 2016. This license is available in the
       22 official languages of the EU. The English version is included here.
     </notes>
+    <text>
     <titleText>
       <p>
         European Union Public Licence v. 1.2
@@ -495,5 +496,6 @@
       All other changes or additions to this Appendix
       require the production of a new EUPL version.
     </p>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Entessa.xml
+++ b/src/Entessa.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>http://opensource.org/licenses/Entessa</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Entessa Public License Version. 1.0</p>
       </titleText>
@@ -55,6 +56,6 @@
       <p>This software consists of voluntary contributions made by many individuals on behalf of openSEAL and was
        originally based on software contributed by Entessa, LLC, http://www.entessa.com. For more information on
        the openSEAL, please see &lt;http://www.openseal.org/&gt;.</p>
-  
+    </text>
    </license>
 </SPDXLicenseCollection>

--- a/src/ErlPL-1.1.xml
+++ b/src/ErlPL-1.1.xml
@@ -6,6 +6,7 @@
       </crossRefs>
       <notes>This Erlang License is a derivative work of the Mozilla Public License, Version 1.0. It contains terms which
          differ from the Mozilla Public License, Version 1.0.</notes>
+    <text>
       <titleText>
          <p>ERLANG PUBLIC LICENSE Version 1.1</p>
       </titleText>
@@ -323,5 +324,6 @@
         limitations under the License.</p>
       <p>The Initial Developer of the Original Code is Ericsson Utvecklings AB. Portions created by Ericsson are
         Copyright 1999, Ericsson Utvecklings AB. All Rights Reserved.''</p>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Eurosym.xml
+++ b/src/Eurosym.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/Eurosym</crossRef>
       </crossRefs>
+    <text>
       <copyrightText>
          <p>Copyright (c) 1999-2002 Henrik Theiling</p>
       </copyrightText>
@@ -46,6 +47,6 @@
         </item>
       </list>
       <p>This licence is governed by the Laws of Germany. Disputes shall be settled by Saarbruecken City Court.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/FSFAP.xml
+++ b/src/FSFAP.xml
@@ -4,9 +4,11 @@
       <crossRefs>
          <crossRef>http://www.gnu.org/prep/maintain/html_node/License-Notices-for-Other-Files.html</crossRef>
       </crossRefs>
+    <text>
       <p>Copying and distribution of this file, with or without
          modification, are permitted in any medium without royalty
          provided the copyright notice and this notice are preserved. 
          This file is offered as-is, without any warranty.</p>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/FSFUL.xml
+++ b/src/FSFUL.xml
@@ -4,12 +4,13 @@
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/FSF_Unlimited_License</crossRef>
       </crossRefs>
+    <text>
       <copyrightText>
          <p>Copyright (C) 1992-1996, 1998-2012 Free Software Foundation, Inc.</p>
       </copyrightText>
     
       <p>This configure script is free software; the Free Software Foundation gives unlimited permission to copy,
          distribute and modify it.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/FSFULLR.xml
+++ b/src/FSFULLR.xml
@@ -5,12 +5,13 @@
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/FSF_Unlimited_License#License_Retention_Variant</crossRef>
       </crossRefs>
+    <text>
       <copyrightText>
          <p>Copyright 1996-2006 Free Software Foundation, Inc.</p>
       </copyrightText>
     
       <p>This file is free software; the Free Software Foundation gives unlimited permission to copy and/or
          distribute it, with or without modifications, as long as this notice is preserved.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/FTL.xml
+++ b/src/FTL.xml
@@ -6,6 +6,7 @@
          <crossRef>http://git.savannah.gnu.org/cgit/freetype/freetype2.git/tree/docs/FTL.TXT</crossRef>
       </crossRefs>
       <notes>This license was released 27 Jan 2006</notes>
+    <text>
       <titleText>
          <p>The FreeType Project LICENSE</p>
          <p>2006-Jan-27</p>
@@ -144,5 +145,6 @@
       <optional>
          <p>--- end of FTL.TXT ---</p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Fair.xml
+++ b/src/Fair.xml
@@ -5,6 +5,7 @@
          <crossRef>http://www.opensource.org/licenses/Fair</crossRef>
          <crossRef>http://fairlicense.org/</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Fair License</p>
       </titleText>
@@ -15,6 +16,6 @@
       <p>Usage of the works is permitted provided that this instrument is retained with the works, so that any
          entity that uses the works is notified of this instrument.</p>
       <p>DISCLAIMER: THE WORKS ARE WITHOUT WARRANTY.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Frameworx-1.0.xml
+++ b/src/Frameworx-1.0.xml
@@ -6,6 +6,7 @@
          <crossRef>http://www.opensource.org/licenses/Frameworx-1.0</crossRef>
       </crossRefs>
       <notes>The url included in the license does not work. (15/10/10)</notes>
+    <text>
       <titleText>
          <p>THE FRAMEWORX OPEN LICENSE 1.0</p>
       </titleText>
@@ -229,6 +230,6 @@
         </item>
       </list>
       <copyrightText>(C) THE FRAMEWORX COMPANY 2003</copyrightText>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/FreeImage.xml
+++ b/src/FreeImage.xml
@@ -6,6 +6,7 @@
          <crossRef>http://freeimage.sourceforge.net/freeimage-license.txt</crossRef>
       </crossRefs>
       <notes>This is similar to MPL-1.0, but for the names, choice of law, and jurisdiction</notes>
+    <text>
       <titleText>
          <p>FreeImage Public License - Version 1.0</p>
       </titleText>
@@ -432,5 +433,6 @@
          ANY KIND, either express or implied. See the License for the specific language governing rights and
          limitations under the License.</p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/GFDL-1.1-only.xml
+++ b/src/GFDL-1.1-only.xml
@@ -17,6 +17,7 @@
     <notes>
       This license was released March 2000
     </notes>
+    <text>
     <titleText>
       <p>
         GNU Free Documentation License<br></br>
@@ -476,5 +477,6 @@
         General Public License, to permit their use in free software.
       </p>
     </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/GFDL-1.1-or-later.xml
+++ b/src/GFDL-1.1-or-later.xml
@@ -18,6 +18,7 @@
     <notes>
       This license was released March 2000
     </notes>
+    <text>
     <titleText>
       <p>
         GNU Free Documentation License<br></br>
@@ -477,5 +478,6 @@
         General Public License, to permit their use in free software.
       </p>
     </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/GFDL-1.1.xml
+++ b/src/GFDL-1.1.xml
@@ -20,6 +20,7 @@
       Back-Cover Texts being LIST. A copy of the license is included
       in the section entitled "GNU Free Documentation License".
     </standardLicenseHeader>
+    <text>
     <titleText>
       <p>
         GNU Free Documentation License<br></br>
@@ -479,5 +480,6 @@
         General Public License, to permit their use in free software.
       </p>
     </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/GFDL-1.2-only.xml
+++ b/src/GFDL-1.2-only.xml
@@ -16,6 +16,7 @@
     <notes>
       This license was released November 2002
     </notes>
+    <text>
     <titleText>
       <p>
         GNU Free Documentation License<br></br>
@@ -524,5 +525,6 @@
         General Public License, to permit their use in free software.
       </p>
     </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/GFDL-1.2-or-later.xml
+++ b/src/GFDL-1.2-or-later.xml
@@ -17,6 +17,7 @@
     <notes>
       This license was released November 2002
     </notes>
+    <text>
     <titleText>
       <p>
         GNU Free Documentation License<br></br>
@@ -525,5 +526,6 @@
         General Public License, to permit their use in free software.
       </p>
     </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/GFDL-1.2.xml
+++ b/src/GFDL-1.2.xml
@@ -19,6 +19,7 @@
       and no Back-Cover Texts. A copy of the license is included
       in the section entitled "GNU Free Documentation License".
     </standardLicenseHeader>
+    <text>
     <titleText>
       <p>
         GNU Free Documentation License<br></br>
@@ -527,5 +528,6 @@
         General Public License, to permit their use in free software.
       </p>
     </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/GFDL-1.3-only.xml
+++ b/src/GFDL-1.3-only.xml
@@ -16,6 +16,7 @@
     <notes>
       This license was released 3 November 2008.
     </notes>
+    <text>
     <titleText>
       <p>
         GNU Free Documentation License<br></br>
@@ -585,5 +586,6 @@
         General Public License, to permit their use in free software.
       </p>
     </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/GFDL-1.3-or-later.xml
+++ b/src/GFDL-1.3-or-later.xml
@@ -17,6 +17,7 @@
     <notes>
       This license was released 3 November 2008.
     </notes>
+    <text>
     <titleText>
       <p>
         GNU Free Documentation License<br></br>
@@ -586,5 +587,6 @@
         General Public License, to permit their use in free software.
       </p>
     </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/GFDL-1.3.xml
+++ b/src/GFDL-1.3.xml
@@ -19,6 +19,7 @@
       and no Back-Cover Texts. A copy of the license is included
       in the section entitled "GNU Free Documentation License".
     </standardLicenseHeader>
+    <text>
     <titleText>
       <p>
         GNU Free Documentation License<br></br>
@@ -588,5 +589,6 @@
         General Public License, to permit their use in free software.
       </p>
     </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/GL2PS.xml
+++ b/src/GL2PS.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>http://www.geuz.org/gl2ps/COPYING.GL2PS</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>GL2PS LICENSE Version 2, November 2003</p>
       </titleText>
@@ -29,6 +30,6 @@
         </item>
       </list>
       <p>This software is provided "as is" without express or implied warranty.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/GPL-1.0+.xml
+++ b/src/GPL-1.0+.xml
@@ -15,6 +15,7 @@
          <p>You should have received a copy of the GNU General Public License along with
     this program; if not, write to the Free Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA. </p>
       </standardLicenseHeader>
+    <text>
       <titleText>
          <p>GNU GENERAL PUBLIC LICENSE 
         <br/>Version 1, February 1989 
@@ -234,5 +235,6 @@
          <p>&lt;signature of Ty Coon&gt;, 1 April 1989 Ty Coon, President of Vice</p>
          <p>That's all there is to it!</p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/GPL-1.0-only.xml
+++ b/src/GPL-1.0-only.xml
@@ -28,6 +28,7 @@
       This license was released: February 1989. This refers to when this GPL version
       1.0 only is being used (as opposed to "or later").
     </notes>
+    <text>
     <titleText>
       <p>
         GNU GENERAL PUBLIC LICENSE<br></br>
@@ -356,5 +357,6 @@
         That's all there is to it!
       </p>
     </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/GPL-1.0-or-later.xml
+++ b/src/GPL-1.0-or-later.xml
@@ -29,6 +29,7 @@
       This license was released: February 1989. This license
       has been deprecated by its authors.
     </notes>
+    <text>
     <titleText>
       <p>
         GNU GENERAL PUBLIC LICENSE<br></br>
@@ -358,5 +359,6 @@
         That's all there is to it!
       </p>
     </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/GPL-1.0.xml
+++ b/src/GPL-1.0.xml
@@ -29,6 +29,7 @@
         Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
       </p>
     </standardLicenseHeader>
+    <text>
     <titleText>
       <p>
         GNU GENERAL PUBLIC LICENSE<br></br>
@@ -358,5 +359,6 @@
         That's all there is to it!
       </p>
     </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/GPL-2.0+.xml
+++ b/src/GPL-2.0+.xml
@@ -19,6 +19,7 @@
     this program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
     02110-1301<optional>,</optional> USA.</p>
       </standardLicenseHeader>
+    <text>
       <titleText>
          <p>GNU GENERAL PUBLIC LICENSE
         <br/>Version 2, June 1991
@@ -305,5 +306,6 @@
          passes at compilers) written by James Hacker.</p>
          <p><optional>&lt;</optional>signature of Ty Coon<optional>&gt;</optional>, 1 April 1989 Ty Coon, President of Vice</p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/GPL-2.0-only.xml
+++ b/src/GPL-2.0-only.xml
@@ -31,6 +31,7 @@
       This license was released: June 1991 This refers to when this
       GPL 2.0 only is being used (as opposed to GPLv2 or later).
     </notes>
+    <text>
     <titleText>
       <p>
         GNU GENERAL PUBLIC LICENSE<br></br>
@@ -465,5 +466,6 @@
 	1 April 1989 Ty Coon, President of Vice
       </p>
     </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/GPL-2.0-or-later.xml
+++ b/src/GPL-2.0-or-later.xml
@@ -31,6 +31,7 @@
     <notes>
       This license was released: June 1991
     </notes>
+    <text>
     <titleText>
       <p>
         GNU GENERAL PUBLIC LICENSE<br></br>
@@ -465,5 +466,6 @@
 	1 April 1989 Ty Coon, President of Vice
       </p>
     </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/GPL-2.0-with-GCC-exception.xml
+++ b/src/GPL-2.0-with-GCC-exception.xml
@@ -7,9 +7,10 @@
       </crossRefs>
       <notes>DEPRECATED: Use License Expression Syntax and Exceptions list to create equivalent license.</notes>
      
+    <text>
 	     <p>insert GPL v2 license text here</p>
 	     <p>GCC Linking Exception </p>
 	     <p>In addition to the permissions in the GNU General Public License, the Free Software Foundation gives you unlimited permission to link the compiled version of this file into combinations with other programs, and to distribute those combinations without any restriction coming from the use of this file. (The General Public License restrictions do apply in other respects; for example, they cover modification of the file, and distribution when not linked into a combine executable.</p>
-	
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/GPL-2.0-with-autoconf-exception.xml
+++ b/src/GPL-2.0-with-autoconf-exception.xml
@@ -7,11 +7,12 @@
       </crossRefs>
       <notes>DEPRECATED: Use License Expression Syntax and Exceptions list to create equivalent license.</notes>
      
+    <text>
 	     <p>insert GPL v2 license text here</p>
 	     <p>Autoconf Exception</p>
 	     <p>As a special exception, the Free Software Foundation gives unlimited permission to copy, distribute and modify the configure scripts that are the output of Autoconf. You need not follow the terms of the GNU General Public License when using or distributing such scripts, even though portions of the text of Autoconf appear in them. The GNU General Public License (GPL) does govern all other use of the material that constitutes the Autoconf program.</p>
 	     <p>Certain portions of the Autoconf source text are designed to be copied (in certain cases, depending on the input) into the output of Autoconf. We call these the "data" portions. The rest of the Autoconf source text consists of comments plus executable code that decides which of the data portions to output in any given case. We call these comments and executable code the "non-data" portions. Autoconf never copies any of the non-data portions into its output.</p>
 	     <p>This special exception to the GPL applies to versions of Autoconf released by the Free Software Foundation. When you make and distribute a modified version of Autoconf, you may extend this special exception to the GPL to apply to your modified version as well, *unless* your modified version has the potential to copy into its output some of the text that was the non-data portion of the version that you started with. (In other words, unless your change moves or copies text from the non-data portions to the data portions.) If your modification has such potential, you must delete any notice of this special exception to the GPL from your modified version.</p>
-	
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/GPL-2.0-with-bison-exception.xml
+++ b/src/GPL-2.0-with-bison-exception.xml
@@ -6,10 +6,11 @@
          <crossRef>http://git.savannah.gnu.org/cgit/bison.git/tree/data/yacc.c?id=193d7c7054ba7197b0789e14965b739162319b5e#n141</crossRef>
       </crossRefs>
       <notes>DEPRECATED: Use License Expression Syntax and Exceptions list to create equivalent license.</notes>
+    <text>
 	     <titleText>Bison Exception</titleText>
      
 	     <p>As a special exception, you may create a larger work that contains part or all of the Bison parser skeleton and distribute that work under terms of your choice, so long as that work isn't itself a parser generator using the skeleton or a modified version thereof as a parser skeleton. Alternatively, if you modify or redistribute the parser skeleton itself, you may (at your option) remove this special exception, which will cause the skeleton and the resulting Bison output files to be licensed under the GNU General Public License without this special exception.</p>
 	     <p>This special exception was added by the Free Software Foundation in version 2.2 of Bison.</p>
-	
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/GPL-2.0-with-classpath-exception.xml
+++ b/src/GPL-2.0-with-classpath-exception.xml
@@ -7,10 +7,11 @@
       </crossRefs>
       <notes>DEPRECATED: Use License Expression Syntax and Exceptions list to create equivalent license.</notes>
      
+    <text>
 	     <p>insert GPL v2 license text here</p>
 	     <p>Class Path Exception</p>
 	     <p>Linking this library statically or dynamically with other modules is making a combined work based on this library. Thus, the terms and conditions of the GNU General Public License cover the whole combination.</p>
 	     <p>As a special exception, the copyright holders of this library give you permission to link this library with independent modules to produce an executable, regardless of the license terms of these independent modules, and to copy and distribute the resulting executable under terms of your choice, provided that you also meet, for each linked independent module, the terms and conditions of the license of that module. An independent module is a module which is not derived from or based on this library. If you modify this library, you may extend this exception to your version of the library, but you are not obligated to do so. If you do not wish to do so, delete this exception statement from your version.</p>
-	
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/GPL-2.0-with-font-exception.xml
+++ b/src/GPL-2.0-with-font-exception.xml
@@ -7,9 +7,10 @@
       </crossRefs>
       <notes>DEPRECATED: Use License Expression Syntax and Exceptions list to create equivalent license.</notes>
      
+    <text>
 	     <p>insert GPL v2 license text here</p>
 	     <p>Font Exception</p>
 	     <p>As a special exception, if you create a document which uses this font, and embed this font or unaltered portions of this font into the document, this font does not by itself cause the resulting document to be covered by the GNU General Public License. This exception does not however invalidate any other reasons why the document might be covered by the GNU General Public License. If you modify this font, you may extend this exception to your version of the font, but you are not obligated to do so. If you do not wish to do so, delete this exception statement from your version.</p>
-	
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/GPL-2.0.xml
+++ b/src/GPL-2.0.xml
@@ -32,6 +32,7 @@
         USA.
       </p>
     </standardLicenseHeader>
+    <text>
     <titleText>
       <p>
         GNU GENERAL PUBLIC LICENSE<br></br>
@@ -466,5 +467,6 @@
 	1 April 1989 Ty Coon, President of Vice
       </p>
     </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/GPL-3.0+.xml
+++ b/src/GPL-3.0+.xml
@@ -27,6 +27,7 @@
         &lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.
       </p>
   </standardLicenseHeader>
+    <text>
       <titleText>
          <p>GNU GENERAL PUBLIC LICENSE 
         <br/>Version 3, 29 June 2007 
@@ -606,5 +607,6 @@
          License instead of this License. But first, please read
          &lt;http<optional>s</optional>://www.gnu.org/philosophy/why-not-lgpl.html&gt;.</p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/GPL-3.0-only.xml
+++ b/src/GPL-3.0-only.xml
@@ -30,6 +30,7 @@
       This license was released: 29 June 2007 This refers to when
       this GPL 3.0 only is being used (as opposed to "or later).
     </notes>
+    <text>
     <titleText>
       <p>
         GNU GENERAL PUBLIC LICENSE<br></br>
@@ -851,5 +852,6 @@
 	&lt;http<optional>s</optional>://www.gnu.org/philosophy/why-not-lgpl.html&gt;.
       </p>
     </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/GPL-3.0-or-later.xml
+++ b/src/GPL-3.0-or-later.xml
@@ -30,6 +30,7 @@
     <notes>
       This license was released: 29 June 2007
     </notes>
+    <text>
     <titleText>
       <p>
         GNU GENERAL PUBLIC LICENSE<br></br>
@@ -851,5 +852,6 @@
 	&lt;http<optional>s</optional>://www.gnu.org/philosophy/why-not-lgpl.html&gt;.
       </p>
     </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/GPL-3.0-with-GCC-exception.xml
+++ b/src/GPL-3.0-with-GCC-exception.xml
@@ -6,6 +6,7 @@
       <crossRefs>
          <crossRef>http://www.gnu.org/licenses/gcc-exception-3.1.html</crossRef>
       </crossRefs>
+    <text>
 	  <p>﻿insert GPL v3 text here</p>
       <titleText>
          <p>GCC RUNTIME LIBRARY EXCEPTION</p>
@@ -92,5 +93,6 @@
       <p>The availability of this Exception does not imply any general
          presumption that third-party software is unaffected by the
          copyleft requirements of the license of GCC.</p>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/GPL-3.0-with-autoconf-exception.xml
+++ b/src/GPL-3.0-with-autoconf-exception.xml
@@ -7,6 +7,7 @@
       </crossRefs>
       <notes>DEPRECATED: Use License Expression Syntax and Exceptions list to create equivalent license.</notes>
      
+    <text>
 	     <p>insert GPL v3 text here</p>
 	     <p>AUTOCONF CONFIGURE SCRIPT EXCEPTION</p>
 	     <p>Version 3.0, 18 August 2009</p>
@@ -33,6 +34,6 @@
 			<p>The availability of this Exception does not imply any general presumption that third-party software is unaffected by the copyleft requirements of the license of Autoconf.</p>
 		       </item>
 	     </list>
-	
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/GPL-3.0.xml
+++ b/src/GPL-3.0.xml
@@ -31,6 +31,7 @@
         &lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.
       </p>
     </standardLicenseHeader>
+    <text>
     <titleText>
       <p>
         GNU GENERAL PUBLIC LICENSE<br></br>
@@ -852,5 +853,6 @@
 	&lt;http<optional>s</optional>://www.gnu.org/philosophy/why-not-lgpl.html&gt;.
       </p>
     </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Giftware.xml
+++ b/src/Giftware.xml
@@ -6,6 +6,7 @@
       </crossRefs>
       <notes>This license may also be known as Allegro 4. The Allegro 5 license shown at the alleg.sourceforge.net URL is
          the same as zlib</notes>
+    <text>
       <titleText>
          <p>Allegro 4 (the giftware license)</p>
       </titleText>
@@ -25,6 +26,6 @@
          NON-INFRINGEMENT. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE
          LIABLE FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
          OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Glide.xml
+++ b/src/Glide.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>http://www.users.on.net/~triforce/glidexp/COPYING.txt</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>3DFX GLIDE Source Code General Public License</p>
       </titleText>
@@ -308,6 +309,6 @@
               </list>
             </item>
           </list>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Glulxe.xml
+++ b/src/Glulxe.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/Glulxe</crossRef>
       </crossRefs>
+    <text>
       <copyrightText>
          <p>The source code in this package is copyright 1999-2010 by Andrew Plotkin.</p>
       </copyrightText>
@@ -12,6 +13,6 @@
          documentation is not changed. You may also incorporate this code into your own program and distribute
          that, or modify this code and use and distribute the modified version, as long as you retain a notice
          in your program or documentation which mentions my name and the URL shown above.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/HPND.xml
+++ b/src/HPND.xml
@@ -17,6 +17,7 @@
     one that includes a double-disclaimer. That is acceptable, as long as it remains impossible to construct a non-OSD-compliant 
     license that matches the pattern.
   </notes>
+    <text>
       <titleText>
          <p>Historical Permission Notice and Disclaimer</p>
       </titleText>
@@ -44,6 +45,6 @@
            OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, 
            NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.</p>
       </optional>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/HaskellReport.xml
+++ b/src/HaskellReport.xml
@@ -6,6 +6,7 @@
          <crossRef>https://fedoraproject.org/wiki/Licensing/Haskell_Language_Report_License</crossRef>
       </crossRefs>
     
+    <text>
       <p>Code derived from the document "Report on the Programming Language 
         <br/>Haskell 2010", is distributed under the following license: 
       </p>
@@ -17,6 +18,6 @@
          Notice. Modified versions of this Report may also be copied and distributed for any purpose, provided
          that the modified version is clearly presented as such, and that it does not claim to be a definition
          of the Haskell 2010 Language.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/IBM-pibs.xml
+++ b/src/IBM-pibs.xml
@@ -6,6 +6,7 @@
          <crossRef>http://git.denx.de/?p=u-boot.git;a=blob;f=arch/powerpc/cpu/ppc4xx/miiphy.c;h=297155fdafa064b955e53e9832de93bfb0cfb85b;hb=9fab4bf4cc077c21e43941866f3f2c196f28670d</crossRef>
       </crossRefs>
     
+    <text>
       <p>This source code has been made available to you by IBM on an AS-IS basis. Anyone receiving this source is
          licensed under IBM copyrights to use it in any way he or she deems fit, including copying it,
          modifying it, compiling it, and redistributing it either with or without modifications. No license
@@ -17,6 +18,6 @@
       <p>COPYRIGHT I B M CORPORATION 2002 
         <br/>LICENSED MATERIAL - PROGRAM PROPERTY OF I B M 
       </p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/ICU.xml
+++ b/src/ICU.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>http://source.icu-project.org/repos/icu/icu/trunk/license.html</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>ICU License - ICU 1.8.1 and later</p>
          <p>COPYRIGHT AND PERMISSION NOTICE</p>
@@ -30,6 +31,6 @@
       <p>Except as contained in this notice, the name of a copyright holder shall not be used in advertising or
          otherwise to promote the sale, use or other dealings in this Software without prior written
          authorization of the copyright holder.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/IJG.xml
+++ b/src/IJG.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>http://dev.w3.org/cvsweb/Amaya/libjpeg/Attic/README?rev=1.2</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Independent JPEG Group License</p>
       </titleText>
@@ -85,6 +86,6 @@
         <br/>"The Graphics Interchange Format(c) is the Copyright property of CompuServe Incorporated.
              GIF(sm) is a Service Mark property of CompuServe Incorporated." 
       </p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/IPA.xml
+++ b/src/IPA.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>http://www.opensource.org/licenses/IPA</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>IPA Font License Agreement v1.0</p>
       </titleText>
@@ -240,6 +241,6 @@
           This Agreement shall be construed under the laws of Japan.
         </item>
       </list>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/IPL-1.0.xml
+++ b/src/IPL-1.0.xml
@@ -5,6 +5,7 @@
          <crossRef>http://www.opensource.org/licenses/IPL-1.0</crossRef>
       </crossRefs>
       <notes>This license was superseded by CPL.</notes>
+    <text>
       <titleText>
          <p>IBM Public License Version 1.0</p>
       </titleText>
@@ -307,6 +308,6 @@
           </p>
          </item>
       </list>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/ISC.xml
+++ b/src/ISC.xml
@@ -5,6 +5,7 @@
          <crossRef>https://www.isc.org/downloads/software-support-policy/isc-license/</crossRef>
          <crossRef>http://www.opensource.org/licenses/ISC</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p><alt name="title" match="(The )?ISC License( \(ISC[L]?\))?:?">ISC License</alt></p>
       </titleText>
@@ -23,6 +24,6 @@
          SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF
          USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING
          OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/ImageMagick.xml
+++ b/src/ImageMagick.xml
@@ -14,6 +14,7 @@
          implied. See the License for the specific language governing permissions and limitations under the
          License.
   </notes>
+    <text>
       <optional>
          <p>Before we get to the text of the license, lets just review what the license says in simple terms:</p>
          <p>It allows you to:</p>
@@ -292,5 +293,6 @@
          implied. See the License for the specific language governing permissions and limitations under the
          License.</p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Imlib2.xml
+++ b/src/Imlib2.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>https://git.enlightenment.org/legacy/imlib2.git/tree/COPYING</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Imlib2 License</p>
       </titleText>
@@ -30,6 +31,6 @@
          NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
          OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
          OTHER DEALINGS IN THE SOFTWARE.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Info-ZIP.xml
+++ b/src/Info-ZIP.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>http://www.info-zip.org/license.html</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Info-ZIP License</p>
       </titleText>
@@ -64,6 +65,6 @@
              "Pocket Zip," and "MacZip" for its own source and binary releases.
         </item>
       </list>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Intel-ACPI.xml
+++ b/src/Intel-ACPI.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/Intel_ACPI_Software_License_Agreement</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>ACPI - Software License Agreement</p>
       </titleText>
@@ -139,6 +140,6 @@
             </list>
         </item>
       </list>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Intel.xml
+++ b/src/Intel.xml
@@ -7,6 +7,7 @@
       <notes>This license has been deprecated. A note at the top of the OSI license page states, "The Intel Open
          Source License for CDSA/CSSM Implementation (BSD License with Export Notice) (Intel has ceased to use
          or recommend this license)"</notes>
+    <text>
       <titleText>
          <p>Intel Open Source License</p>
       </titleText>
@@ -50,6 +51,6 @@
          from the U.S. and can be downloaded by or otherwise exported or reexported worldwide EXCEPT to U.S.
          embargoed destinations which include Cuba, Iraq, Libya, North Korea, Iran, Syria, Sudan, Afghanistan
          and any other country to which the U.S. has embargoed goods and services.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Interbase-1.0.xml
+++ b/src/Interbase-1.0.xml
@@ -17,6 +17,7 @@
          <p>Contributor(s): <alt match=".+" name="contributor">______________________________________.</alt> 
          </p>
       </standardLicenseHeader>
+    <text>
       <titleText>
          <p>INTERBASE PUBLIC LICENSE 
         <br/>Version 1.0 
@@ -574,5 +575,6 @@
             </list> 
          </item>
       </list>  
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/JSON.xml
+++ b/src/JSON.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>http://www.json.org/license.html</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>JSON License</p>
       </titleText>
@@ -24,6 +25,6 @@
          NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
          WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
          SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/JasPer-2.0.xml
+++ b/src/JasPer-2.0.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>http://www.ece.uvic.ca/~mdadams/jasper/LICENSE</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>JasPer License Version 2.0</p>
       </titleText>
@@ -52,5 +53,6 @@
       PHYSICAL OR ENVIRONMENTAL DAMAGE ("HIGH RISK ACTIVITIES"). THE COPYRIGHT HOLDERS SPECIFICALLY
       DISCLAIM ANY EXPRESS OR IMPLIED WARRANTY OF FITNESS FOR HIGH RISK ACTIVITIES. 
       </p>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/LAL-1.2.xml
+++ b/src/LAL-1.2.xml
@@ -9,6 +9,7 @@
 English: http://artlibre.org/licence/lal/licence-art-libre-12/
 Italian: http://artlibre.org/licence/lal/it/
 Spanish: http://artlibre.org/licence/lal/es/</notes>
+    <text>
       <titleText>
          <p>Licence Art Libre
         <br/>[ Copyleft Attitude ]
@@ -179,5 +180,6 @@ Spanish: http://artlibre.org/licence/lal/es/</notes>
         </item>
       </list>
       <p>Cette licence est soumise au droit français.</p>
+    </text>
     </license>
 </SPDXLicenseCollection>

--- a/src/LAL-1.3.xml
+++ b/src/LAL-1.3.xml
@@ -9,6 +9,7 @@
             English:  http://artlibre.org/licence/lal/en/
             Portuguese: http://artlibre.org/licence/lal/pt/
             Polish: http://artlibre.org/licence/lal/pl/</notes>
+    <text>
       <titleText>
          <p>Licence Art Libre 1.3 (LAL 1.3)</p>
       </titleText>
@@ -280,5 +281,6 @@
          
       </item>
       </list>
+    </text>
     </license>
 </SPDXLicenseCollection>

--- a/src/LGPL-2.0+.xml
+++ b/src/LGPL-2.0+.xml
@@ -15,6 +15,7 @@
     License along with this library; if not, write to the Free Software Foundation, Inc., 51 Franklin St, Fifth
     Floor, Boston, MA 02110-1301, USA. 
   </standardLicenseHeader>
+    <text>
       <titleText>
          <p>GNU LIBRARY GENERAL PUBLIC LICENSE</p>
          <p>Version 2, June 1991</p>
@@ -427,5 +428,6 @@
       </p>
          <p>That's all there is to it!</p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/LGPL-2.0-only.xml
+++ b/src/LGPL-2.0-only.xml
@@ -24,6 +24,7 @@
       been superseded by LGPL v2.1 This refers to when this
       LGPL 2.0 only is being used (as opposed to "or later).
     </notes>
+    <text>
     <titleText>
       <p>
         GNU LIBRARY GENERAL PUBLIC LICENSE
@@ -633,5 +634,6 @@
         That's all there is to it!
       </p>
     </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/LGPL-2.0-or-later.xml
+++ b/src/LGPL-2.0-or-later.xml
@@ -24,6 +24,7 @@
       This license was released: June 1991. This license has
       been superseded by LGPL v2.1
     </notes>
+    <text>
     <titleText>
       <p>
         GNU LIBRARY GENERAL PUBLIC LICENSE
@@ -633,5 +634,6 @@
         That's all there is to it!
       </p>
     </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/LGPL-2.0.xml
+++ b/src/LGPL-2.0.xml
@@ -22,6 +22,7 @@
       License along with this library; if not, write to the Free Software
       Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     </standardLicenseHeader>
+    <text>
     <titleText>
       <p>
         GNU LIBRARY GENERAL PUBLIC LICENSE
@@ -631,5 +632,6 @@
         That's all there is to it!
       </p>
     </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/LGPL-2.1+.xml
+++ b/src/LGPL-2.1+.xml
@@ -19,6 +19,7 @@
     License along with this library; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth
     Floor, Boston, MA 02110-1301 USA </p>
       </standardLicenseHeader>
+    <text>
       <titleText>
          <p>GNU LESSER GENERAL PUBLIC LICENSE</p>
          <p>Version 2.1, February 1999</p>
@@ -443,5 +444,6 @@
         <br/>That's all there is to it!
       </p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/LGPL-2.1-only.xml
+++ b/src/LGPL-2.1-only.xml
@@ -29,6 +29,7 @@
       This license was released: February 1999. This refers to when
       this LGPL 2.1 only is being used (as opposed to "or later).
     </notes>
+    <text>
     <titleText>
       <p>
         GNU LESSER GENERAL PUBLIC LICENSE
@@ -655,5 +656,6 @@
         That's all there is to it!
       </p>
     </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/LGPL-2.1-or-later.xml
+++ b/src/LGPL-2.1-or-later.xml
@@ -29,6 +29,7 @@
     <notes>
       This license was released: February 1999.
     </notes>
+    <text>
     <titleText>
       <p>
         GNU LESSER GENERAL PUBLIC LICENSE
@@ -655,5 +656,6 @@
         That's all there is to it!
       </p>
     </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/LGPL-2.1.xml
+++ b/src/LGPL-2.1.xml
@@ -30,6 +30,7 @@
         Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
       </p>
     </standardLicenseHeader>
+    <text>
     <titleText>
       <p>
         GNU LESSER GENERAL PUBLIC LICENSE
@@ -656,5 +657,6 @@
         That's all there is to it!
       </p>
     </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/LGPL-3.0+.xml
+++ b/src/LGPL-3.0+.xml
@@ -7,6 +7,7 @@
          <crossRef>http://www.gnu.org/licenses/lgpl-3.0-standalone.html</crossRef>
          <crossRef>http://www.opensource.org/licenses/LGPL-3.0</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>GNU LESSER GENERAL PUBLIC LICENSE 
         <br/>Version 3, 29 June 2007 
@@ -201,5 +202,6 @@
           </p>
         </item>
       </list>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/LGPL-3.0-only.xml
+++ b/src/LGPL-3.0-only.xml
@@ -10,6 +10,7 @@
       This license was released: 29 June 2007. This refers to when
       this LGPL 3.0 only is being used (as opposed to "or later).
     </notes>
+    <text>
     <titleText>
       <p>
         GNU LESSER GENERAL PUBLIC LICENSE<br></br>
@@ -253,5 +254,6 @@
         </p>
       </item>
     </list>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/LGPL-3.0-or-later.xml
+++ b/src/LGPL-3.0-or-later.xml
@@ -9,6 +9,7 @@
     <notes>
       This license was released: 29 June 2007.
     </notes>
+    <text>
     <titleText>
       <p>
         GNU LESSER GENERAL PUBLIC LICENSE<br></br>
@@ -252,5 +253,6 @@
         </p>
       </item>
     </list>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/LGPL-3.0.xml
+++ b/src/LGPL-3.0.xml
@@ -11,6 +11,7 @@
       DEPRECATED: Deprecated in lieu of more
       explicit license identifier of LGPL-3.0-only
     </notes>
+    <text>
     <titleText>
       <p>
         GNU LESSER GENERAL PUBLIC LICENSE<br></br>
@@ -254,5 +255,6 @@
         </p>
       </item>
     </list>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/LGPLLR.xml
+++ b/src/LGPLLR.xml
@@ -6,6 +6,7 @@
          <crossRef>http://www-igm.univ-mlv.fr/~unitex/lgpllr.html</crossRef>
       </crossRefs>
       <notes>Appears to have borrowed some language from the LGPL-2.1.</notes>
+    <text>
       <titleText>
          <p>Lesser General Public License For Linguistic Resources</p>
       </titleText>
@@ -267,5 +268,6 @@
         </item>
       </list>
       <p>END OF TERMS AND CONDITIONS</p>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/LPL-1.0.xml
+++ b/src/LPL-1.0.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>http://opensource.org/licenses/LPL-1.0</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Lucent Public License Version 1.0</p>
       </titleText>
@@ -263,6 +264,6 @@
       </p>
          </item>
       </list>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/LPL-1.02.xml
+++ b/src/LPL-1.02.xml
@@ -5,6 +5,7 @@
          <crossRef>http://plan9.bell-labs.com/plan9/license.html</crossRef>
          <crossRef>http://www.opensource.org/licenses/LPL-1.02</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Lucent Public License Version 1.02</p>
       </titleText>
@@ -253,6 +254,6 @@
          any resulting litigation.</p>
          </item>
       </list>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/LPPL-1.0.xml
+++ b/src/LPPL-1.0.xml
@@ -11,6 +11,7 @@
     macros/latex/base/lppl.txt; either version 1 of the License, or (at your option) any later version. 
   </standardLicenseHeader>
       <notes>This license was released 1 Mar 1999</notes>
+    <text>
       <titleText>
          <p>LaTeX Project Public License</p>
          <p>LPPL Version 1.0 1999-03-01</p>
@@ -185,5 +186,6 @@
              meets these requirements.
         </item>
       </list>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/LPPL-1.1.xml
+++ b/src/LPPL-1.1.xml
@@ -13,6 +13,7 @@
     <alt match=".+" name="the work">the files pig.dtx and pig.ins</alt>
       </standardLicenseHeader>
       <notes>This license was released 10 July 1999.</notes>
+    <text>
       <titleText>
          <p>The LaTeX Project Public License 
         <br/>=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=- 
@@ -275,5 +276,6 @@
          `.cfg') are examples of files bearing less restrictive conditions on the distribution of a
          modified version of the file. The additional conditions on LaTeX software given above are examples of
          declaring a category of files bearing exceptional additional conditions.</p>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/LPPL-1.2.xml
+++ b/src/LPPL-1.2.xml
@@ -13,6 +13,7 @@
     <alt match=".+" name="the work">the files pig.dtx and pig.ins</alt>
       </standardLicenseHeader>
       <notes>This license was released 3 Sept 1999.</notes>
+    <text>
       <titleText>
          <p>The LaTeX Project Public License 
         <br/>=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=- 
@@ -273,5 +274,6 @@
          `.cfg') are examples of files bearing less restrictive conditions on the distribution of a
          modified version of the file. The additional conditions on LaTeX software given above are examples of
          declaring a category of files bearing exceptional additional conditions.</p>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/LPPL-1.3a.xml
+++ b/src/LPPL-1.3a.xml
@@ -15,6 +15,7 @@
     <alt match=".+" name="the work">pig.dtx and pig.ins and the derived file pig.sty</alt>.
   </standardLicenseHeader>
       <notes>This license was released 1 Oct 2004</notes>
+    <text>
       <titleText>
          <p>The LaTeX Project Public License 
         <br/>=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=- 
@@ -370,5 +371,6 @@
       <p>in that place. In the absence of an unequivocal list it might be impossible for the licensee to determine
          what is considered by you to comprise the Work and, in such a case, the licensee would be entitled to
          make reasonable conjectures as to which files comprise the Work.</p>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/LPPL-1.3c.xml
+++ b/src/LPPL-1.3c.xml
@@ -16,6 +16,7 @@
     <alt match=".+" name="the work">pig.dtx and pig.ins and the derived file pig.sty</alt>. 
   </standardLicenseHeader>
       <notes>This license was released: 4 May 2008</notes>
+    <text>
       <titleText>
          <p>The LaTeX Project Public License 
         <br/>=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=- 
@@ -381,5 +382,6 @@
       <p>in that place. In the absence of an unequivocal list it might be impossible for the licensee to determine
          what is considered by you to comprise the Work and, in such a case, the licensee would be entitled to
          make reasonable conjectures as to which files comprise the Work.</p>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Latex2e.xml
+++ b/src/Latex2e.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/Latex2e</crossRef>
       </crossRefs>
+    <text>
       <copyrightText>
          <p>Copyright (C) 2007, 2008, 2009, 2010 Karl Berry. 
         <br/>Copyright (C) 1988, 1994, 2007 Stephen Gilmore. 
@@ -18,6 +19,6 @@
          permission notice identical to this one.</p>
       <p>Permission is granted to copy and distribute translations of this manual into another language, under the
          above conditions for modified versions.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Leptonica.xml
+++ b/src/Leptonica.xml
@@ -6,6 +6,7 @@
       </crossRefs>
       <notes>This is an older license for Leptonica. Currently, it uses BSD-2-Clause (see
          http://www.leptonica.com/about-the-license.html)</notes>
+    <text>
       <copyrightText>
          <p>Copyright (C) 2001 Leptonica. All rights reserved.</p>
       </copyrightText>
@@ -29,6 +30,6 @@
           this notice may not be removed or altered from any source or modified source distribution.
         </item>
       </list>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/LiLiQ-P-1.1.xml
+++ b/src/LiLiQ-P-1.1.xml
@@ -9,6 +9,7 @@
       <notes>French is the canonical language for this license. An English
          translation is provided here:
          https://forge.gouv.qc.ca/licence/en/liliq-v1-1/#permissive-liliq-p</notes>
+    <text>
       <titleText>
          <p>Licence Libre du Québec – Permissive (LiLiQ-P)</p>
          <p>Version 1.1</p>
@@ -226,5 +227,6 @@
          </p>
         </item>
       </list>
+    </text>
    </license>
 </SPDXLicenseCollection>

--- a/src/LiLiQ-R-1.1.xml
+++ b/src/LiLiQ-R-1.1.xml
@@ -9,6 +9,7 @@
       <notes>French is the canonical language for this license. An English
          translation is provided here:
          https://www.forge.gouv.qc.ca/participez/licence-logicielle/licence-libre-du-quebec-liliq-in-english/quebec-free-and-open-source-licence-reciprocity-liliq-r-v1-1/</notes>
+    <text>
       <titleText>
          <p>Licence Libre du Québec – Réciprocité (LiLiQ-R)</p>
          <p>Version 1.1</p>
@@ -289,5 +290,6 @@
          d'identifier la provenance de la licence.</p>
         </item>
       </list>
+    </text>
    </license>
 </SPDXLicenseCollection>

--- a/src/LiLiQ-Rplus-1.1.xml
+++ b/src/LiLiQ-Rplus-1.1.xml
@@ -9,6 +9,7 @@
       <notes>French is the canonical language for this license. An English
          translation is provided here:
          https://www.forge.gouv.qc.ca/participez/licence-logicielle/licence-libre-du-quebec-liliq-in-english/quebec-free-and-open-source-licence-strong-reciprocity-liliq-r-v1-1/</notes>
+    <text>
       <titleText>
          <p>Licence Libre du Québec – Réciprocité forte (LiLiQ-R+)</p>
          <p>Version 1.1</p>
@@ -284,5 +285,6 @@
          d'identifier la provenance de la licence.</p>
          </item>
       </list>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Libpng.xml
+++ b/src/Libpng.xml
@@ -5,6 +5,7 @@
          <crossRef>http://www.libpng.org/pub/png/src/libpng-LICENSE.txt</crossRef>
       </crossRefs>
     
+    <text>
       <p>This copy of the libpng notices is provided for your convenience. In case of any discrepancy between this
          copy and the notices in the file png.h that is included in the libpng distribution, the latter shall
          prevail.</p>
@@ -96,6 +97,6 @@
         <br/>glennrp at users.sourceforge.net 
         <br/>December 9, 2010 
       </p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/MIT-CMU.xml
+++ b/src/MIT-CMU.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing:MIT?rd=Licensing/MIT#CMU_Style</crossRef>
       </crossRefs>
+    <text>
       <copyrightText>
          <p>Copyright 1989, 1991, 1992 by Carnegie Mellon University</p>
          <p>Derivative Work - 1996, 1998-2000 Copyright 1996, 1998-2000 The Regents of the University of California</p>
@@ -21,6 +22,6 @@
          DAMAGES WHATSOEVER RESULTING FROM THE LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
          NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
          THIS SOFTWARE.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/MIT-advertising.xml
+++ b/src/MIT-advertising.xml
@@ -6,6 +6,7 @@
          <crossRef>https://fedoraproject.org/wiki/Licensing/MIT_With_Advertising</crossRef>
       </crossRefs>
       <notes>This license is a modified version of the common MIT license, with an additional advertising clause</notes>
+    <text>
       <copyrightText>
          <p>Copyright (C) 2000-2008 Carsten Haitzler, Geoff Harrison and various contributors Copyright (C) 2004-2008
          Kim Woelders</p>
@@ -24,6 +25,6 @@
          NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
          OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
          OTHER DEALINGS IN THE SOFTWARE.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/MIT-enna.xml
+++ b/src/MIT-enna.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/MIT#enna</crossRef>
       </crossRefs>
+    <text>
       <copyrightText>
          <p>Copyright (C) 2000 Carsten Haitzler and various contributors (see AUTHORS)</p>
       </copyrightText>
@@ -26,6 +27,6 @@
          NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
          OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
          OTHER DEALINGS IN THE SOFTWARE.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/MIT-feh.xml
+++ b/src/MIT-feh.xml
@@ -5,6 +5,7 @@
          <crossRef>https://fedoraproject.org/wiki/Licensing/MIT#feh</crossRef>
       </crossRefs>
     
+    <text>
       <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
          associated documentation files (the "Software"), to deal in the Software without restriction,
          including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
@@ -18,6 +19,6 @@
          NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
          OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
          OTHER DEALINGS IN THE SOFTWARE.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/MIT.xml
+++ b/src/MIT.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>http://www.opensource.org/licenses/MIT</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>MIT License</p>
       </titleText>
@@ -23,6 +24,6 @@
          NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
          WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
          SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/MITNFA.xml
+++ b/src/MITNFA.xml
@@ -5,6 +5,7 @@
          <crossRef>https://fedoraproject.org/wiki/Licensing/MITNFA</crossRef>
       </crossRefs>
     
+    <text>
       <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
          associated documentation files (the "Software"), to deal in the Software without restriction,
          including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
@@ -23,6 +24,6 @@
          NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
          WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
          SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/MPL-1.0.xml
+++ b/src/MPL-1.0.xml
@@ -17,6 +17,7 @@
     <alt match=".+" name="contributor">_____</alt>. 
   </standardLicenseHeader>
       <notes>This license has been superseded by v1.1</notes>
+    <text>
       <titleText>
          <p>MOZILLA PUBLIC LICENSE 
         <br/>Version 1.0 
@@ -452,5 +453,6 @@
         <alt match=".+" name="contributor">_____</alt>."
       </p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/MPL-1.1.xml
+++ b/src/MPL-1.1.xml
@@ -28,6 +28,7 @@
     <alt match=".+" name="licenseName">[____]</alt>] License." 
   </standardLicenseHeader>
       <notes>This license has been superseded by v2.0</notes>
+    <text>
       <titleText>
          <p>Mozilla Public License Version 1.1</p>
       </titleText>
@@ -559,5 +560,6 @@
          files of the Original Code. You should use the text of this Exhibit A rather than the text found in
          the Original Code Source Code for Your Modifications.</p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/MPL-2.0-no-copyleft-exception.xml
+++ b/src/MPL-2.0-no-copyleft-exception.xml
@@ -8,6 +8,7 @@
       </crossRefs>
       <notes>This license was released in January 2012. This license list entry is for use when the MPL's Exhibit B,
          which removes the Sec 3.3 copyleft exception.</notes>
+    <text>
       <titleText>
          <p>Mozilla Public License Version 2.0</p>
       </titleText>
@@ -413,5 +414,6 @@
         <p>This Source Code Form is "Incompatible With Secondary Licenses", as defined by the Mozilla
          Public License, v. 2.0.</p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/MPL-2.0.xml
+++ b/src/MPL-2.0.xml
@@ -7,6 +7,7 @@
       </crossRefs>
       <notes>This license was released in January 2012. This license list entry is for use when the standard MPL 2.0 is
          used, as indicated by the standard header (Exhibit A but no Exhibit B).</notes>
+    <text>
       <titleText>
          <p>Mozilla Public License Version 2.0</p>
       </titleText>
@@ -430,5 +431,6 @@
          <p>This Source Code Form is "Incompatible With Secondary Licenses", as defined by the Mozilla
          Public License, v. 2.0.</p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/MS-PL.xml
+++ b/src/MS-PL.xml
@@ -5,6 +5,7 @@
          <crossRef>http://www.microsoft.com/opensource/licenses.mspx</crossRef>
          <crossRef>http://www.opensource.org/licenses/MS-PL</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Microsoft Public License (Ms-PL)</p>
       </titleText>
@@ -83,6 +84,6 @@
             </list>
         </item>
       </list>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/MS-RL.xml
+++ b/src/MS-RL.xml
@@ -5,6 +5,7 @@
          <crossRef>http://www.microsoft.com/opensource/licenses.mspx</crossRef>
          <crossRef>http://www.opensource.org/licenses/MS-RL</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Microsoft Reciprocal License (Ms-RL)</p>
       </titleText>
@@ -91,6 +92,6 @@
             </list>
         </item>
       </list>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/MTLL.xml
+++ b/src/MTLL.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/Matrix_Template_Library_License</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Software License for MTL</p>
       </titleText>
@@ -73,6 +74,6 @@
          HORSES", "TRAP DOORS", "WORMS", OR OTHER HARMFUL CODE. LICENSEE ASSUMES THE
          ENTIRE RISK AS TO THE PERFORMANCE OF SOFTWARE AND/OR ASSOCIATED MATERIALS, AND TO THE PERFORMANCE AND
          VALIDITY OF INFORMATION GENERATED USING SOFTWARE.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/MakeIndex.xml
+++ b/src/MakeIndex.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/MakeIndex</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>MakeIndex Distribution Notice</p>
          <p>11/11/1989</p>
@@ -38,6 +39,6 @@
          considered modified versions. All modified versions should be reported back to the author.</p>
       <p>This program is distributed with no warranty of any sort. No contributor accepts responsibility for the
          consequences of using this program or for whether it serves any particular purpose.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/MirOS.xml
+++ b/src/MirOS.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>http://www.opensource.org/licenses/MirOS</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>MirOS License</p>
       </titleText>
@@ -92,5 +93,6 @@
             </list>
          </p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Motosoto.xml
+++ b/src/Motosoto.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>http://www.opensource.org/licenses/Motosoto</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>MOTOSOTO OPEN SOURCE LICENSE - Version 0.9.1</p>
       </titleText>
@@ -400,6 +401,6 @@
          WORK STOPPAGE, COMPUTER FAILURE OR MALFUNCTION, OR ANY AND ALL OTHER COMMERCIAL DAMAGES OR LOSSES,
          EVEN IF SUCH PARTY SHALL HAVE BEEN INFORMED OF THE POSSIBILITY OF SUCH DAMAGES. THIS LIMITATION OF
          LIABILITY SHALL NOT APPLY TO LIABILITY FOR DEATH OR PERSONAL INJURY RESULTING FROM SUCH PARTY</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Multics.xml
+++ b/src/Multics.xml
@@ -7,6 +7,7 @@
       <notes>
      
   </notes>
+    <text>
       <titleText>
          <p>Multics License</p>
       </titleText>
@@ -45,6 +46,6 @@
           <br/>Copyright 2006 by Bull SAS All Rights Reserved 
         </p>
       </copyrightText>
-      
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Mup.xml
+++ b/src/Mup.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/Mup</crossRef>
       </crossRefs>
+    <text>
       <copyrightText>
          <p>Copyright (c) 1995-2012 by Arkkra Enterprises. All rights reserved.</p>
       </copyrightText>
@@ -37,6 +38,6 @@
          OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
          WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
          OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/NASA-1.3.xml
+++ b/src/NASA-1.3.xml
@@ -5,6 +5,7 @@
          <crossRef>http://ti.arc.nasa.gov/opensource/nosa/</crossRef>
          <crossRef>http://www.opensource.org/licenses/NASA-1.3</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>NASA OPEN SOURCE AGREEMENT VERSION 1.3</p>
       </titleText>
@@ -370,5 +371,6 @@
             </list>
         </item>
       </list>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/NBPL-1.0.xml
+++ b/src/NBPL-1.0.xml
@@ -6,6 +6,7 @@
       </crossRefs>
       <notes>This license was released 22 August 1998. This license was issued twice, but only with formatting
          differences.</notes>
+    <text>
       <titleText>
          <p>The Net Boolean Public License</p>
       </titleText>
@@ -144,5 +145,6 @@
       <optional>
          <p>The End</p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/NCSA.xml
+++ b/src/NCSA.xml
@@ -6,6 +6,7 @@
          <crossRef>http://otm.illinois.edu/uiuc_openSource</crossRef>
          <crossRef>http://www.opensource.org/licenses/NCSA</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>University of Illinois/NCSA Open Source License</p>
       </titleText>
@@ -54,6 +55,6 @@
          NO EVENT SHALL THE CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
          LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
          WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE SOFTWARE.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/NGPL.xml
+++ b/src/NGPL.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>http://www.opensource.org/licenses/NGPL</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>NETHACK GENERAL PUBLIC LICENSE</p>
       </titleText>
@@ -102,6 +103,6 @@
          Agreement. In other words, go ahead and share NetHack, but don't try to stop anyone else
          from sharing it farther. 
       </p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/NLOD-1.0.xml
+++ b/src/NLOD-1.0.xml
@@ -7,6 +7,7 @@
       </crossRefs>
       <notes>Norwegian translation available here:
          http://data.norge.no/nlod/no/1.0</notes>
+    <text>
       <titleText>
          <p>Norwegian Licence for Open Government Data (NLOD)</p>
       </titleText>
@@ -296,5 +297,6 @@
          claim at other competent legal venues and/or based on the laws
          of the country where the intellectual property rights are
          sought enforced.</p>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/NLPL.xml
+++ b/src/NLPL.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/NLPL</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>NO LIMIT PUBLIC LICENSE</p>
          <p>Version 0, June 2012</p>
@@ -25,6 +26,6 @@
           No limit to do anything with this work and this license.
         </item>
       </list>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/NOSL.xml
+++ b/src/NOSL.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>http://bits.netizen.com.au/licenses/NOSL/nosl.txt</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>NETIZEN OPEN SOURCE LICENSE 
         <br/>Version 1.0 
@@ -550,5 +551,6 @@
        files of the Original Code. You should use the text of this Exhibit A rather than the text found in
        the Original Code Source Code for Your Modifications.]</p>
      </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/NPL-1.0.xml
+++ b/src/NPL-1.0.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>http://www.mozilla.org/MPL/NPL/1.0/</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>NETSCAPE PUBLIC LICENSE 
         <br/>Version 1.0
@@ -467,5 +468,6 @@
              Modifications.] 
       </p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/NPL-1.1.xml
+++ b/src/NPL-1.1.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>http://www.mozilla.org/MPL/NPL/1.1/</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Netscape Public LIcense version 1.1</p>
       </titleText>
@@ -626,5 +627,6 @@
          files of the Original Code. You should use the text of this Exhibit A rather than the text found in
          the Original Code Source Code for Your Modifications.</p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/NPOSL-3.0.xml
+++ b/src/NPOSL-3.0.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>http://www.opensource.org/licenses/NOSL3.0</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Non-Profit Open Software License 3.0</p>
       </titleText>
@@ -242,5 +243,6 @@
             </list>
         </item>
       </list>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/NRL.xml
+++ b/src/NRL.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>http://web.mit.edu/network/isakmp/nrllicense.html</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>NRL License</p>
       </titleText>
@@ -81,6 +82,6 @@
       <p>The views and conclusions contained in the software and documentation are those of the authors and should
          not be interpreted as representing official policies, either expressed or implied, of the US Naval
          Research Laboratory (NRL).</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/NTP.xml
+++ b/src/NTP.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>http://www.opensource.org/licenses/NTP</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>NTP License (NTP)</p>
       </titleText>
@@ -22,6 +23,6 @@
         <alt match=".+" name="TMname">(TrademarkedName)</alt> makes no representations about the suitability
         this software for any purpose. It is provided "as is" without express or implied warranty. 
       </p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Naumen.xml
+++ b/src/Naumen.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>http://www.opensource.org/licenses/Naumen</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>NAUMEN Public License</p>
       </titleText>
@@ -53,6 +54,6 @@
          POSSIBILITY OF SUCH DAMAGE.</p>
       <p>This software consists of contributions made by NAUMEN and Contributors. Specific attributions are listed
          in the accompanying credits file.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Net-SNMP.xml
+++ b/src/Net-SNMP.xml
@@ -9,6 +9,7 @@
          licenses which are referred to in totality by the notices in
          the source files.</notes>
     
+    <text>
       <p>---- Part 1: CMU/UCD copyright notice: (BSD like) -----</p>
     
       <copyrightText>
@@ -382,6 +383,6 @@
          CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
          OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
          EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/NetCDF.xml
+++ b/src/NetCDF.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>http://www.unidata.ucar.edu/software/netcdf/copyright.html</crossRef>
       </crossRefs>
+    <text>
       <copyrightText>
          <p>Copyright 1993-2014 University Corporation for Atmospheric Research/Unidata</p>
       </copyrightText>
@@ -28,6 +29,6 @@
          DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
          CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE ACCESS, USE OR
          PERFORMANCE OF THIS SOFTWARE.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Newsletr.xml
+++ b/src/Newsletr.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/Newsletr</crossRef>
       </crossRefs>
+    <text>
       <copyrightText>
          <p>Copyright 1989--2004 by Hunter Goatley.</p>
       </copyrightText>
@@ -22,6 +23,6 @@
              original software.
         </item>
       </list>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Nokia.xml
+++ b/src/Nokia.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>http://www.opensource.org/licenses/nokia</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Nokia Open Source License (NOKOS License)</p>
          <p>Version 1.0a</p>
@@ -446,5 +447,6 @@
          <p>Copyright © &lt;year&gt; Nokia and others. All Rights Reserved.</p>
          <p>Contributor(s): ______________________________________.</p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Noweb.xml
+++ b/src/Noweb.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/Noweb</crossRef>
       </crossRefs>
+    <text>
       <copyrightText>
          <p>Noweb is copyright 1989-2000 by Norman Ramsey. All rights reserved.</p>
       </copyrightText>
@@ -20,6 +21,6 @@
          source code to be used and modified under the terms of this license. You must state clearly that your
          work uses or is based on noweb and that noweb is available free of change. You must also request that
          bug reports on your work be reported to you.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Nunit.xml
+++ b/src/Nunit.xml
@@ -5,6 +5,7 @@
          <crossRef>https://fedoraproject.org/wiki/Licensing/Nunit</crossRef>
       </crossRefs>
       <notes>DEPRECATED: This license was added twice by accident. Use short identifier: zlib-acknowledgement </notes>
+    <text>
       <copyrightText>
          <p>Copyright © 2002-2004 James W. Newkirk, Michael C. Two, Alexei A. Vorontsov, Charlie Poole 
         <br/>Copyright © 2000-2004 Philip A. Craig 
@@ -34,6 +35,6 @@
           This notice may not be removed or altered from any source distribution.
         </item>
       </list>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/OCCT-PL.xml
+++ b/src/OCCT-PL.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>http://www.opencascade.com/content/occt-public-license</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Open CASCADE Technology Public License 
         <br/>Version 6.6, April 2013 
@@ -284,5 +285,6 @@
         <br/>End of Schedule "B" 
       </p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/OCLC-2.0.xml
+++ b/src/OCLC-2.0.xml
@@ -23,6 +23,7 @@
     <alt match=".+" name="contributor">_____</alt>. 
   </standardLicenseHeader>
       <notes>This license was released: May 2002</notes>
+    <text>
       <titleText>
          <p>OCLC Research Public License 2.0 
       <br/>Terms &amp; Conditions Of Use 
@@ -180,5 +181,6 @@
        subject matter hereof and may not be amended except by the written agreement of the parties. This License
        shall be governed by and construed in accordance with the laws of the State of Ohio and the United States
        of America, without regard to principles of conflicts of law.</p>
+    </text>
    </license>
 </SPDXLicenseCollection>

--- a/src/ODbL-1.0.xml
+++ b/src/ODbL-1.0.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>http://www.opendatacommons.org/licenses/odbl/1.0/</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>ODC Open Database License (ODbL)</p>
       </titleText>
@@ -644,6 +645,6 @@
              in this License in order to meet the terms of this License.
         </item>
       </list>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/OFL-1.0.xml
+++ b/src/OFL-1.0.xml
@@ -5,6 +5,7 @@
          <crossRef>http://scripts.sil.org/cms/scripts/page.php?item_id=OFL10_web</crossRef>
       </crossRefs>
       <notes>This license has been superseded. This license was released in November 2005.</notes>
+    <text>
       <titleText>
          <p>SIL OPEN FONT LICENSE</p>
          <p>Version 1.0 - 22 November 2005</p>
@@ -97,6 +98,6 @@
          ANY CLAIM, DAMAGES OR OTHER LIABILITY, INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR
          CONSEQUENTIAL DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF THE
          USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM OTHER DEALINGS IN THE FONT SOFTWARE.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/OFL-1.1.xml
+++ b/src/OFL-1.1.xml
@@ -6,6 +6,7 @@
          <crossRef>http://www.opensource.org/licenses/OFL-1.1</crossRef>
       </crossRefs>
       <notes>This license was released: 26 February 2007.</notes>
+    <text>
       <copyrightText><optional><p>Copyright (c) &lt;dates&gt;, &lt;Copyright Holder&gt; (&lt;URL|email&gt;),
          <br/>with Reserved Font Name &lt;Reserved Font Name&gt;.</p></optional></copyrightText>
       <optional>
@@ -85,6 +86,6 @@
          ANY CLAIM, DAMAGES OR OTHER LIABILITY, INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR
          CONSEQUENTIAL DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF THE
          USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM OTHER DEALINGS IN THE FONT SOFTWARE.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/OGTSL.xml
+++ b/src/OGTSL.xml
@@ -5,6 +5,7 @@
          <crossRef>http://www.opengroup.org/testing/downloads/The_Open_Group_TSL.txt</crossRef>
          <crossRef>http://www.opensource.org/licenses/OGTSL</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>The Open Group Test Suite License</p>
       </titleText>
@@ -109,5 +110,6 @@
       <optional>
          <p>The End</p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/OLDAP-1.1.xml
+++ b/src/OLDAP-1.1.xml
@@ -6,6 +6,7 @@
          <crossRef>http://www.openldap.org/devel/gitweb.cgi?p=openldap.git;a=blob;f=LICENSE;hb=806557a5ad59804ef3a44d5abfbe91d706b0791f</crossRef>
       </crossRefs>
       <notes>This license was released 25 August 1998.</notes>
+    <text>
       <titleText>
          <p>The OpenLDAP Public License 
         <br/>Version 1.1, 25 August 1998 
@@ -145,5 +146,6 @@
       <optional>
          <p>The End</p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/OLDAP-1.2.xml
+++ b/src/OLDAP-1.2.xml
@@ -7,6 +7,7 @@
       </crossRefs>
       <notes>This license was released 1 September 1998. This license was issued four time, but only with formatting
          differences.</notes>
+    <text>
       <titleText>
          <p>The OpenLDAP Public License 
         <br/>Version 1.2, 1 September 1998 
@@ -146,5 +147,6 @@
       <optional>
          <p>The End</p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/OLDAP-1.3.xml
+++ b/src/OLDAP-1.3.xml
@@ -7,6 +7,7 @@
       </crossRefs>
       <notes>This license was released 17 January 1999. This license was issued twice in the same day with a minor
          correction. This is the corrected (second) version.</notes>
+    <text>
       <titleText>
          <p>The OpenLDAP Public License 
         <br/>Version 1.3, 17 January 1999 
@@ -154,5 +155,6 @@
       <optional>
          <p>The End</p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/OLDAP-1.4.xml
+++ b/src/OLDAP-1.4.xml
@@ -6,6 +6,7 @@
          <crossRef>http://www.openldap.org/devel/gitweb.cgi?p=openldap.git;a=blob;f=LICENSE;hb=c9f95c2f3f2ffb5e0ae55fe7388af75547660941</crossRef>
       </crossRefs>
       <notes>This license was released 18 January 1999.</notes>
+    <text>
       <titleText>
          <p>The OpenLDAP Public License 
         <br/>Version 1.4, 18 January 1999 
@@ -153,5 +154,6 @@
       <optional>
          <p>The End</p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/OLDAP-2.0.1.xml
+++ b/src/OLDAP-2.0.1.xml
@@ -7,6 +7,7 @@
       </crossRefs>
       <notes>This license was released 21 December 1999. This license is the same as 2.0 with the word "registered"
          removed from in front of "trademark."</notes>
+    <text>
       <titleText>
          <p>The OpenLDAP Public License 
         <br/>Version 2.0.1, 21 December 1999 
@@ -55,6 +56,6 @@
          DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
          CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
          USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/OLDAP-2.0.xml
+++ b/src/OLDAP-2.0.xml
@@ -6,6 +6,7 @@
          <crossRef>http://www.openldap.org/devel/gitweb.cgi?p=openldap.git;a=blob;f=LICENSE;hb=cbf50f4e1185a21abd4c0a54d3f4341fe28f36ea</crossRef>
       </crossRefs>
       <notes>This license was released 7 June 1999.</notes>
+    <text>
       <titleText>
          <p>The OpenLDAP Public License 
         <br/>Version 2.0, 7 June 1999 
@@ -54,6 +55,6 @@
          DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
          CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
          USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/OLDAP-2.1.xml
+++ b/src/OLDAP-2.1.xml
@@ -6,6 +6,7 @@
          <crossRef>http://www.openldap.org/devel/gitweb.cgi?p=openldap.git;a=blob;f=LICENSE;hb=b0d176738e96a0d3b9f85cb51e140a86f21be715</crossRef>
       </crossRefs>
       <notes>This license was released 29 February 2000.</notes>
+    <text>
       <titleText>
          <p>The OpenLDAP Public License 
         <br/>Version 2.1, 29 February 2000 
@@ -60,6 +61,6 @@
          DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
          CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
          USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/OLDAP-2.2.1.xml
+++ b/src/OLDAP-2.2.1.xml
@@ -6,6 +6,7 @@
          <crossRef>http://www.openldap.org/devel/gitweb.cgi?p=openldap.git;a=blob;f=LICENSE;hb=4bc786f34b50aa301be6f5600f58a980070f481e</crossRef>
       </crossRefs>
       <notes>This license was released 1 March 2000.</notes>
+    <text>
       <titleText>
          <p>The OpenLDAP Public License 
         <br/>Version 2.2.1, 1 March 2000 
@@ -60,6 +61,6 @@
         <copyrightText>Copyright 1999-2000 The OpenLDAP Foundation, Redwood City, California, USA. All Rights Reserved.</copyrightText>
         Permission to copy and distributed verbatim copies of this document is granted.
       </p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/OLDAP-2.2.2.xml
+++ b/src/OLDAP-2.2.2.xml
@@ -6,6 +6,7 @@
          <crossRef>http://www.openldap.org/devel/gitweb.cgi?p=openldap.git;a=blob;f=LICENSE;hb=df2cc1e21eb7c160695f5b7cffd6296c151ba188</crossRef>
       </crossRefs>
       <notes>This license was released 28 July 2000.</notes>
+    <text>
       <titleText>
          <p>The OpenLDAP Public License 
         <br/>Version 2.2.2, 28 July 2000 
@@ -63,6 +64,6 @@
         <copyrightText>Copyright 1999-2000 The OpenLDAP Foundation, Redwood City, California, USA. All Rights Reserved.</copyrightText>
         Permission to copy and distributed verbatim copies of this document is granted.
       </p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/OLDAP-2.2.xml
+++ b/src/OLDAP-2.2.xml
@@ -6,6 +6,7 @@
          <crossRef>http://www.openldap.org/devel/gitweb.cgi?p=openldap.git;a=blob;f=LICENSE;hb=470b0c18ec67621c85881b2733057fecf4a1acc3</crossRef>
       </crossRefs>
       <notes>This license was released 1 March 2000.</notes>
+    <text>
       <titleText>
          <p>The OpenLDAP Public License 
         <br/>Version 2.2, 1 March 2000 
@@ -62,6 +63,6 @@
         </copyrightText>
         Permission to copy and distributed verbatim copies of this document is granted.
       </p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/OLDAP-2.3.xml
+++ b/src/OLDAP-2.3.xml
@@ -6,6 +6,7 @@
          <crossRef>http://www.openldap.org/devel/gitweb.cgi?p=openldap.git;a=blob;f=LICENSE;hb=d32cf54a32d581ab475d23c810b0a7fbaf8d63c3</crossRef>
       </crossRefs>
       <notes>This license was released 28 July 2000.</notes>
+    <text>
       <titleText>
          <p>The OpenLDAP Public License 
         <br/>Version 2.3, 28 July 2000 
@@ -63,6 +64,6 @@
         <copyrightText>Copyright 1999-2000 The OpenLDAP Foundation, Redwood City, California, USA. All Rights Reserved.</copyrightText>
         Permission to copy and distributed verbatim copies of this document is granted.
       </p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/OLDAP-2.4.xml
+++ b/src/OLDAP-2.4.xml
@@ -6,6 +6,7 @@
          <crossRef>http://www.openldap.org/devel/gitweb.cgi?p=openldap.git;a=blob;f=LICENSE;hb=cd1284c4a91a8a380d904eee68d1583f989ed386</crossRef>
       </crossRefs>
       <notes>This license was released 8 December 2000.</notes>
+    <text>
       <titleText>
          <p>The OpenLDAP Public License 
         <br/>Version 2.4, 8 December 2000 
@@ -59,6 +60,6 @@
         <copyrightText>Copyright 1999-2000 The OpenLDAP Foundation, Redwood City, California, USA. All Rights Reserved.</copyrightText>
         Permission to copy and distributed verbatim copies of this document is granted.
       </p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/OLDAP-2.5.xml
+++ b/src/OLDAP-2.5.xml
@@ -6,6 +6,7 @@
          <crossRef>http://www.openldap.org/devel/gitweb.cgi?p=openldap.git;a=blob;f=LICENSE;hb=6852b9d90022e8593c98205413380536b1b5a7cf</crossRef>
       </crossRefs>
       <notes>This license was released 11 May 2001.</notes>
+    <text>
       <titleText>
          <p>The OpenLDAP Public License 
         <br/>Version 2.5, 11 May 2001 
@@ -60,6 +61,6 @@
         <copyrightText>Copyright 1999-2001 The OpenLDAP Foundation, Redwood City, California, USA. All Rights Reserved.</copyrightText>
         Permission to copy and distributed verbatim copies of this document is granted.
       </p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/OLDAP-2.6.xml
+++ b/src/OLDAP-2.6.xml
@@ -6,6 +6,7 @@
          <crossRef>http://www.openldap.org/devel/gitweb.cgi?p=openldap.git;a=blob;f=LICENSE;hb=1cae062821881f41b73012ba816434897abf4205</crossRef>
       </crossRefs>
       <notes>This license was released 14 June 2001.</notes>
+    <text>
       <titleText>
          <p>The OpenLDAP Public License 
         <br/>Version 2.6, 14 June 2001 
@@ -56,6 +57,6 @@
         <copyrightText>Copyright 1999-2001 The OpenLDAP Foundation, Redwood City, California, USA. All Rights Reserved.</copyrightText>
         Permission to copy and distributed verbatim copies of this document is granted.
       </p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/OLDAP-2.7.xml
+++ b/src/OLDAP-2.7.xml
@@ -6,6 +6,7 @@
          <crossRef>http://www.openldap.org/devel/gitweb.cgi?p=openldap.git;a=blob;f=LICENSE;hb=47c2415c1df81556eeb39be6cad458ef87c534a2</crossRef>
       </crossRefs>
       <notes>This license was released 7 September 2001.</notes>
+    <text>
       <titleText>
          <p>The OpenLDAP Public License 
         <br/>Version 2.7, 7 September 2001 
@@ -50,6 +51,6 @@
         <copyrightText>Copyright 1999-2001 The OpenLDAP Foundation, Redwood City, California, USA. All Rights Reserved.</copyrightText>
         Permission to copy and distribute verbatim copies of this document is granted.
       </p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/OLDAP-2.8.xml
+++ b/src/OLDAP-2.8.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>http://www.openldap.org/software/release/license.html</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>The OpenLDAP Public License 
         <br/>Version 2.8, 17 August 2003 
@@ -49,6 +50,6 @@
         <copyrightText>Copyright 1999-2003 The OpenLDAP Foundation, Redwood City, California, USA. All Rights Reserved.</copyrightText>
         Permission to copy and distribute verbatim copies of this document is granted.
       </p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/OML.xml
+++ b/src/OML.xml
@@ -4,7 +4,7 @@
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/Open_Market_License</crossRef>
       </crossRefs>
-    
+    <text>
       <p>This FastCGI application library source and object code (the "Software") and its documentation (the
          "Documentation") are copyrighted by Open Market, Inc ("Open Market"). The following terms apply to all
          files associated with the Software and Documentation unless explicitly disclaimed in individual
@@ -24,6 +24,6 @@
          HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES. THE SOFTWARE AND DOCUMENTATION ARE PROVIDED "AS
          IS". OPEN MARKET HAS NO LIABILITY IN CONTRACT, TORT, NEGLIGENCE OR OTHERWISE ARISING OUT OF THIS
          SOFTWARE OR THE DOCUMENTATION.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/OPL-1.0.xml
+++ b/src/OPL-1.0.xml
@@ -5,6 +5,7 @@
          <crossRef>http://old.koalateam.com/jackaroo/OPL_1_0.TXT</crossRef>
          <crossRef>https://fedoraproject.org/wiki/Licensing/Open_Public_License</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>OPEN PUBLIC LICENSE 
         <br/>Version 1.0 
@@ -468,5 +469,6 @@
          <p>Text for this Exhibit B is found in the corresponding addendum, described in section 6.4 above, text file
          provided by the Initial Developer. This license is not valid or complete with out that file.</p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/OSET-PL-2.1.xml
+++ b/src/OSET-PL-2.1.xml
@@ -6,6 +6,7 @@
          <crossRef>http://opensource.org/licenses/OPL-2.1</crossRef>
          <crossRef>http://www.osetfoundation.org/public-license</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>OSET Public License</p>
       </titleText>
@@ -623,5 +624,6 @@
                   <p>This Source Code Form is "Incompatible With Secondary Licenses",
             	      as defined by the OSET Public License, v.2.1.</p>
 	     </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/OSL-1.0.xml
+++ b/src/OSL-1.0.xml
@@ -6,6 +6,7 @@
       </crossRefs>
       <standardLicenseHeader>Licensed under the Open Software License version 1.0</standardLicenseHeader>
       <notes>This license has been superseded.</notes>
+    <text>
       <titleText>
          <p>The Open Software License v. 1.0</p>
       </titleText>
@@ -175,6 +176,6 @@
       <p>This license is Copyright (C) 2002 Lawrence E. Rosen. All rights reserved. Permission is hereby granted
          to copy and distribute this license without modification. This license may not be modified without the
          express written permission of its copyright owner.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/OSL-1.1.xml
+++ b/src/OSL-1.1.xml
@@ -5,6 +5,7 @@
          <crossRef>https://fedoraproject.org/wiki/Licensing/OSL1.1</crossRef>
       </crossRefs>
       <standardLicenseHeader>Licensed under the Open Software License version 1.1</standardLicenseHeader>
+    <text>
       <titleText>
          <p>The Open Software License v. 1.1</p>
       </titleText>
@@ -189,6 +190,6 @@
       <p>This license is Copyright (C) 2002 Lawrence E. Rosen. All rights reserved. Permission is hereby granted
          to copy and distribute this license without modification. This license may not be modified without the
          express written permission of its copyright owner.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/OSL-2.0.xml
+++ b/src/OSL-2.0.xml
@@ -5,6 +5,7 @@
          <crossRef>http://web.archive.org/web/20041020171434/http://www.rosenlaw.com/osl2.0.html</crossRef>
       </crossRefs>
       <standardLicenseHeader>Licensed under the Open Software License version 2.0</standardLicenseHeader>
+    <text>
       <titleText>
          <p>Open Software Licensev. 2.0</p>
       </titleText>
@@ -192,6 +193,6 @@
       <p>This license is Copyright (C) 2003 Lawrence E. Rosen. All rights reserved. Permission is hereby granted
          to copy and distribute this license without modification. This license may not be modified without the
          express written permission of its copyright owner.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/OSL-2.1.xml
+++ b/src/OSL-2.1.xml
@@ -7,6 +7,7 @@
       </crossRefs>
       <standardLicenseHeader>Licensed under the Open Software License version 2.1</standardLicenseHeader>
       <notes>Same as version 2.0 of this license except with changes to section 10</notes>
+    <text>
       <titleText>
          <p>The Open Software Licensev. 2.1</p>
       </titleText>
@@ -194,6 +195,6 @@
       <p>This license is Copyright (C) 2003-2004 Lawrence E. Rosen. All rights reserved. Permission is hereby
          granted to copy and distribute this license without modification. This license may not be modified
          without the express written permission of its copyright owner.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/OSL-3.0.xml
+++ b/src/OSL-3.0.xml
@@ -8,6 +8,7 @@
       <standardLicenseHeader>
     Licensed under the Open Software License version 3.0
   </standardLicenseHeader>
+    <text>
       <titleText>
          <p>Open Software License v. 3.0 (OSL-3.0)</p>
       </titleText>
@@ -204,6 +205,6 @@
              and You comply with its license review and certification process.
         </item>
       </list>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/OpenSSL.xml
+++ b/src/OpenSSL.xml
@@ -6,6 +6,7 @@
       </crossRefs>
       <notes>The OpenSSL toolkit stays under a dual license, i.e. both the conditions of the OpenSSL License and the
          original SSLeay license apply to the toolkit.</notes>
+    <text>
       <titleText>
          <p>OpenSSL License</p>
       </titleText>
@@ -121,6 +122,6 @@
       <p>The licence and distribution terms for any publically available version or derivative of this code cannot
          be changed. i.e. this code cannot simply be copied and put under another distribution licence
          [including the GNU Public Licence.]</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/PDDL-1.0.xml
+++ b/src/PDDL-1.0.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>http://opendatacommons.org/licenses/pddl/1.0/</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Open Data Commons - Public Domain Dedication &amp; License (PDDL)</p>
       </titleText>
@@ -347,6 +348,6 @@
              are included in this Document in order to meet the intent of this Document.
         </item>
       </list>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/PHP-3.0.xml
+++ b/src/PHP-3.0.xml
@@ -5,6 +5,7 @@
          <crossRef>http://www.opensource.org/licenses/PHP-3.0</crossRef>
          <crossRef>http://www.php.net/license/3_0.txt</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>The PHP License, version 3.0</p>
       </titleText>
@@ -65,6 +66,6 @@
       <p>The PHP Group can be contacted via Email at group@php.net.</p>
       <p>For more information on the PHP Group and the PHP project, please see &lt;http://www.php.net&gt;.</p>
       <p>This product includes the Zend Engine, freely available at &lt;http://www.zend.com&gt;.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/PHP-3.01.xml
+++ b/src/PHP-3.01.xml
@@ -6,6 +6,7 @@
       </crossRefs>
       <notes>The PHP License v3.01 is essentially the same as v3.0, with the exception of a couple word differences and
          updated url in section 6.</notes>
+    <text>
       <titleText>
          <p>The PHP License, version 3.01</p>
       </titleText>
@@ -66,6 +67,6 @@
       <p>The PHP Group can be contacted via Email at group@php.net.</p>
       <p>For more information on the PHP Group and the PHP project, please see &lt;http://www.php.net&gt;.</p>
       <p>PHP includes the Zend Engine, freely available at &lt;http://www.zend.com&gt;.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Plexus.xml
+++ b/src/Plexus.xml
@@ -5,6 +5,7 @@
          <crossRef>https://fedoraproject.org/wiki/Licensing/Plexus_Classworlds_License</crossRef>
       </crossRefs>
       <notes>dom4j uses this same license.</notes>
+    <text>
       <copyrightText>
          <p>Copyright 
         <alt match=".+" name="copyright">2002 (C) The Codehaus</alt>. All Rights Reserved. 
@@ -63,6 +64,6 @@
         NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
         POSSIBILITY OF SUCH DAMAGE. 
       </p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/PostgreSQL.xml
+++ b/src/PostgreSQL.xml
@@ -5,6 +5,7 @@
          <crossRef>http://www.postgresql.org/about/licence</crossRef>
          <crossRef>http://www.opensource.org/licenses/PostgreSQL</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>PostgreSQL Database Management System 
         <br/>(formerly known as Postgres, then as Postgres95) 
@@ -26,6 +27,6 @@
          IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED
          HEREUNDER IS ON AN "AS IS" BASIS, AND <alt match=".+" name="copyrightHolderAsIs">THE UNIVERSITY OF CALIFORNIA</alt> HAS NO OBLIGATIONS TO PROVIDE
          MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Python-2.0.xml
+++ b/src/Python-2.0.xml
@@ -5,6 +5,7 @@
          <crossRef>http://www.opensource.org/licenses/Python-2.0</crossRef>
       </crossRefs>
       <notes>This is the overall Python license, which is comprised of several licenses.</notes>
+    <text>
       <titleText>
          <p>PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2</p>
       </titleText>
@@ -213,6 +214,6 @@
          LIABLE FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
          LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
          ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/QPL-1.0.xml
+++ b/src/QPL-1.0.xml
@@ -5,6 +5,7 @@
          <crossRef>http://doc.qt.nokia.com/3.3/license.html</crossRef>
          <crossRef>http://www.opensource.org/licenses/QPL-1.0</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>THE Q PUBLIC LICENSE version 1.0</p>
       </titleText>
@@ -119,6 +120,6 @@
          WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.</p>
       <p>Choice of Law</p>
       <p>This license is governed by the Laws of Norway. Disputes shall be settled by Oslo City Court.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Qhull.xml
+++ b/src/Qhull.xml
@@ -4,12 +4,12 @@
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/Qhull</crossRef>
       </crossRefs>
+    <text>
       <copyrightText>
          <p>Qhull, Copyright (c) 1993-2003</p>
          <p>The National Science and Technology Research Center for Computation and Visualization of Geometric
          Structures (The Geometry Center) University of Minnesota</p>
       </copyrightText>
-    
       <p>email: qhull@qhull.org</p>
       <p>This software includes Qhull from The Geometry Center. Qhull is copyrighted as noted above. Qhull is free
          software and may be obtained via http from www.qhull.org. It may be freely copied, modified, and
@@ -42,6 +42,6 @@
              they desire.
         </item>
       </list>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/RHeCos-1.1.xml
+++ b/src/RHeCos-1.1.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>http://ecos.sourceware.org/old-license.html</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Red Hat eCos Public License v1.1</p>
       </titleText>
@@ -429,5 +430,6 @@
          OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
          SUCH DAMAGE.</p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/RPL-1.1.xml
+++ b/src/RPL-1.1.xml
@@ -5,6 +5,7 @@
          <crossRef>http://opensource.org/licenses/RPL-1.1</crossRef>
       </crossRefs>
       <notes>This license has been superseded by the Reciprocal Public License, version 1.5</notes>
+    <text>
       <titleText>
          <p>Reciprocal Public License, version 1.1</p>
       </titleText>
@@ -672,5 +673,6 @@
          QUIET ENJOYMENT, OR NON-INFRINGEMENT. See the Licenses for specific language governing rights and
          limitations under the Licenses.</p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/RPL-1.5.xml
+++ b/src/RPL-1.5.xml
@@ -5,6 +5,7 @@
          <crossRef>http://www.opensource.org/licenses/RPL-1.5</crossRef>
       </crossRefs>
       <notes>This license was released: 15 July 2007</notes>
+    <text>
       <titleText>
          <p>Reciprocal Public License 1.5 (RPL1.5)</p>
          <p>Version 1.5, July 15, 2007</p>
@@ -611,5 +612,6 @@
          <p>The User-Visible Attribution Notice below, when provided, must appear in each user-visible display as
          defined in Section 6.4 (d):</p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/RPSL-1.0.xml
+++ b/src/RPSL-1.0.xml
@@ -25,6 +25,7 @@
     under the RCSL): 
     <alt match=".+" name="testLocation">_____</alt>. 
   </standardLicenseHeader>
+    <text>
       <titleText>
          <p>RealNetworks Public Source License Version 1.0</p>
          <p>(Rev. Date October 28, 2002)</p>
@@ -593,5 +594,6 @@
          and in strict compliance at all times with RealNetworks' third party trademark usage guidelines which
          are posted at www.realnetworks.com/info/helixlogo.html.</p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/RSA-MD.xml
+++ b/src/RSA-MD.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>http://www.faqs.org/rfcs/rfc1321.html</crossRef>
       </crossRefs>
+    <text>
       <copyrightText>
          <p>Copyright (C) 1991-2, RSA Data Security, Inc. Created 1991. All rights reserved.</p>
       </copyrightText>
@@ -22,6 +23,6 @@
          or the suitability of this software for any particular purpose. It is provided "as is" without express
          or implied warranty of any kind.</p>
       <p>These notices must be retained in any copies of any part of this documentation and/or software.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/RSCPL.xml
+++ b/src/RSCPL.xml
@@ -5,6 +5,7 @@
          <crossRef>http://www.opensource.org/licenses/RSCPL</crossRef>
          <crossRef>http://wayback.archive.org/web/20060715140826/http://www.risource.org/RPL/RPL-1.0A.shtml</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Ricoh Source Code Public License 
         <br/>Version 1.0 
@@ -475,5 +476,6 @@
          Inc. are Copyright (C) 1995-1999. All Rights Reserved.</p>
          <p>Contributor(s): ______________________________________."</p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Rdisc.xml
+++ b/src/Rdisc.xml
@@ -4,7 +4,7 @@
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/Rdisc_License</crossRef>
       </crossRefs>
-    
+    <text>
       <p>Rdisc (this program) was developed by Sun Microsystems, Inc. and is provided for unrestricted use
          provided that this legend is included on all tape media and as a part of the software program in whole
          or part. Users may copy or modify Rdisc without charge, and they may freely distribute it.</p>
@@ -22,6 +22,6 @@
         <br/>2550 Garcia Avenue 
         <br/>Mountain View, California 94043 
       </p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Ruby.xml
+++ b/src/Ruby.xml
@@ -8,7 +8,7 @@
          choice has changed over time (from GPL originally, to BSD-2-Clause currently), so one needs to be
          aware of that change. The Ruby License itself is un-versioned, but has varied a bit over the years,
          the last substantive variation being in 2002.</notes>
-    
+    <text>
       <list>
         <item>
             <bullet>1.</bullet>
@@ -87,6 +87,6 @@
              PURPOSE.
         </item>
       </list>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/SAX-PD.xml
+++ b/src/SAX-PD.xml
@@ -4,7 +4,7 @@
       <crossRefs>
          <crossRef>http://www.saxproject.org/copying.html</crossRef>
       </crossRefs>
-    
+    <text>
       <p>Copyright Status</p>
       <p>SAX is free!</p>
       <p>In fact, it's not possible to own a license to SAX, since it's been placed in the public domain.</p>
@@ -41,6 +41,6 @@
       <p>David Megginson, Megginson Technologies Ltd. 
         <br/>2000-05-05 
       </p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/SCEA.xml
+++ b/src/SCEA.xml
@@ -15,6 +15,7 @@
          implied. See the License for the specific language governing permissions and limitations under the
          License.</p>
       </standardLicenseHeader>
+    <text>
       <titleText>
          <p>SCEA Shared Source License 1.0</p>
       </titleText>
@@ -155,5 +156,6 @@
          distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
          implied. See the License for the specific language governing permissions and limitations under the
          License.</p>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/SGI-B-1.0.xml
+++ b/src/SGI-B-1.0.xml
@@ -33,6 +33,7 @@
          </p>
       </standardLicenseHeader>
       <notes>This license was released 25 January 2000</notes>
+    <text>
       <titleText>
          <p>SGI FREE SOFTWARE LICENSE B 
         <br/>(Version 1.0 1/25/2000) 
@@ -325,5 +326,6 @@
             <optional>]</optional>
          </p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/SGI-B-1.1.xml
+++ b/src/SGI-B-1.1.xml
@@ -28,6 +28,7 @@
          parties is as indicated elsewhere herein. All Rights Reserved.</p>
       </standardLicenseHeader>
       <notes>This license was released 22 February 2002</notes>
+    <text>
       <titleText>
          <p>SGI FREE SOFTWARE LICENSE B 
         <br/>(Version 1.1 02/22/2000) 
@@ -334,5 +335,6 @@
             <optional>]</optional>
          </p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/SGI-B-2.0.xml
+++ b/src/SGI-B-2.0.xml
@@ -6,6 +6,7 @@
          <crossRef>http://oss.sgi.com/projects/FreeB/SGIFreeSWLicB.2.0.pdf</crossRef>
       </crossRefs>
       <notes>This license was released 18 Sept 2008</notes>
+    <text>
       <titleText>
          <p>SGI FREE SOFTWARE LICENSE B 
         <br/>(Version 2.0, Sept. 18, 2008) 
@@ -31,6 +32,6 @@
       <p>Except as contained in this notice, the name of Silicon Graphics, Inc. shall not be used in advertising
          or otherwise to promote the sale, use or other dealings in this Software without prior written
          authorization from Silicon Graphics, Inc.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/SISSL-1.2.xml
+++ b/src/SISSL-1.2.xml
@@ -15,6 +15,7 @@
           Reserved. "Contributor(s): 
     <alt match=".+" name="contributor">_____</alt>
       </standardLicenseHeader>
+    <text>
       <titleText>
          <br/>SUN INDUSTRY STANDARDS SOURCE LICENSE
     <p>Version 1.2</p>
@@ -316,5 +317,6 @@
             </item>
          </list>  
       </optional>
+    </text>
    </license>
 </SPDXLicenseCollection>

--- a/src/SISSL.xml
+++ b/src/SISSL.xml
@@ -17,6 +17,7 @@
     <alt match=".+" name="copyright">_____</alt> All Rights Reserved. Contributor(s): 
     <alt match=".+" name="contributor">_____</alt>
       </standardLicenseHeader>
+    <text>
       <titleText>
          <p>Sun Industry Standards Source License - Version 1.1</p>
       </titleText>
@@ -351,5 +352,6 @@
         <br/>http://api.openoffice.org 
       </p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/SMLNJ.xml
+++ b/src/SMLNJ.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>https://www.smlnj.org/license.html</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>STANDARD ML OF NEW JERSEY COPYRIGHT NOTICE, LICENSE AND DISCLAIMER.</p>
       </titleText>
@@ -25,6 +26,6 @@
          consequential damages or any damages whatsoever resulting from loss of use, data or profits, whether
          in an action of contract, negligence or other tortious action, arising out of or in connection with
          the use or performance of this software.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/SMPPL.xml
+++ b/src/SMPPL.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>https://github.com/dcblake/SMP/blob/master/Documentation/License.txt</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Secure Messaging Protocol (SMP) Libraries [ACL, CML, SFL]</p>
       </titleText>
@@ -70,5 +71,6 @@
        <copyrightText>
          <p>Copyright © 1997-2002 National Security Agency</p>
       </copyrightText>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/SNIA.xml
+++ b/src/SNIA.xml
@@ -5,6 +5,7 @@
          <crossRef>https://fedoraproject.org/wiki/Licensing/SNIA_Public_License</crossRef>
       </crossRefs>
       <notes>This is MPL-1.1 with some edits.</notes>
+    <text>
       <titleText>
          <p>STORAGE NETWORKING INDUSTRY ASSOCIATION 
         <br/>PUBLIC LICENSE 
@@ -460,5 +461,6 @@
          <p>Contributor(s): ______________________________________.</p>
          <p>Read more about this license at http://www.snia.org/smi/developers/open_source/</p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/SPL-1.0.xml
+++ b/src/SPL-1.0.xml
@@ -24,6 +24,7 @@
     may use your version of this file under either the SPL or the 
     <alt match=".+" name="licenseName">[____]</alt> License. 
   </standardLicenseHeader>
+    <text>
       <titleText>
          <p>SUN PUBLIC LICENSE Version 1.0</p>
       </titleText>
@@ -525,5 +526,6 @@
          the notices in the Source Code files of the Original Code. You should use the text of this Exhibit A
          rather than the text found in the Original Code Source Code for Your Modifications.]</p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/SWL.xml
+++ b/src/SWL.xml
@@ -5,7 +5,7 @@
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/SWL</crossRef>
       </crossRefs>
-    
+    <text>
       <p>The authors hereby grant permission to use, copy, modify, distribute, and license this software and its
          documentation for any purpose, provided that existing copyright notices are retained in all copies and
          that this notice is included verbatim in any distributions. No written agreement, license, or royalty
@@ -29,6 +29,6 @@
          this license.</p>
       <p>BY INSTALLING THIS SOFTWARE, YOU ACKNOWLEDGE THAT YOU HAVE READ THIS AGREEMENT, THAT YOU UNDERSTAND IT,
          AND THAT YOU AGREE TO BE BOUND BY ITS TERMS AND CONDITIONS.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Saxpath.xml
+++ b/src/Saxpath.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/Saxpath_License</crossRef>
       </crossRefs>
+    <text>
       <copyrightText>
          <p>Copyright (C) 2000-2002 werken digital. 
         <br/>All rights reserved. 
@@ -50,6 +51,6 @@
          CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
          NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
          POSSIBILITY OF SUCH DAMAGE.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Sendmail.xml
+++ b/src/Sendmail.xml
@@ -5,6 +5,7 @@
          <crossRef>http://www.sendmail.com/pdfs/open_source/sendmail_license.pdf</crossRef>
          <crossRef>https://web.archive.org/web/20160322142305/https://www.sendmail.com/pdfs/open_source/sendmail_license.pdf</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>SENDMAIL LICENSE</p>
       </titleText>
@@ -110,5 +111,6 @@
       <optional>
          <p>$Revision: 8.16 $, Last updated $Date: 2010/10/25 23:11:19 $, Document 139848.1</p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/SimPL-2.0.xml
+++ b/src/SimPL-2.0.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>http://www.opensource.org/licenses/SimPL-2.0</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Simple Public License (SimPL)</p>
       </titleText>
@@ -92,6 +93,6 @@
          find helpful. To avoid confusion, however, if you change the terms in any way then you may not call
          your license the Simple Public License or the SimPL (but feel free to acknowledge that your license is
          "based on the Simple Public License").</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Sleepycat.xml
+++ b/src/Sleepycat.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>http://www.opensource.org/licenses/Sleepycat</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>The Sleepycat License <copyrightText>Copyright (c) 1990-1999 Sleepycat Software. All rights reserved.</copyrightText>
          </p>
@@ -108,6 +109,6 @@
          INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
          TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
          ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Spencer-86.xml
+++ b/src/Spencer-86.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/Henry_Spencer_Reg-Ex_Library_License</crossRef>
       </crossRefs>
+    <text>
       <copyrightText>
          <p>Copyright (c) 1986 by University of Toronto. Written by Henry Spencer. Not derived from licensed software.</p>
       </copyrightText>
@@ -26,6 +27,6 @@
              original software.
         </item>
       </list>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Spencer-94.xml
+++ b/src/Spencer-94.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/Henry_Spencer_Reg-Ex_Library_License</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Copyright 1992, 1993, 1994 Henry Spencer. All rights reserved.</p>
       </titleText>
@@ -33,6 +34,6 @@
           This notice may not be removed or altered.
         </item>
       </list>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Spencer-99.xml
+++ b/src/Spencer-99.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>http://www.opensource.apple.com/source/tcl/tcl-5/tcl/generic/regfronts.c</crossRef>
       </crossRefs>
+    <text>
       <copyrightText>
          <p>Copyright (c) 1998, 1999 Henry Spencer. All rights reserved.</p>
       </copyrightText>
@@ -23,6 +24,6 @@
          LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
          LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
          IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/StandardML-NJ.xml
+++ b/src/StandardML-NJ.xml
@@ -6,6 +6,7 @@
       <crossRefs>
          <crossRef>http://www.smlnj.org//license.html</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>STANDARD ML OF NEW JERSEY COPYRIGHT NOTICE, LICENSE AND DISCLAIMER.</p>
       </titleText>
@@ -26,6 +27,6 @@
          consequential damages or any damages whatsoever resulting from loss of use, data or profits, whether
          in an action of contract, negligence or other tortious action, arising out of or in connection with
          the use or performance of this software.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/SugarCRM-1.1.3.xml
+++ b/src/SugarCRM-1.1.3.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>http://www.sugarcrm.com/crm/SPL</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>SUGARCRM PUBLIC LICENSE</p>
       </titleText>
@@ -465,5 +466,6 @@
             </item>
          </list>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/TCL.xml
+++ b/src/TCL.xml
@@ -5,6 +5,7 @@
          <crossRef>http://www.tcl.tk/software/tcltk/license.html</crossRef>
          <crossRef>https://fedoraproject.org/wiki/Licensing/TCL</crossRef>
       </crossRefs>
+    <text>
       <copyrightText>
          <p>This software is copyrighted by 
         <alt match=".+" name="authors">the Regents of the University of California, Sun Microsystems, Inc.,
@@ -34,6 +35,6 @@
          (1) of DFARs. Notwithstanding the foregoing, the authors grant the U.S. Government and others acting
          in its behalf permission to use and distribute the software in accordance with the terms specified in
          this license.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/TCP-wrappers.xml
+++ b/src/TCP-wrappers.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>http://rc.quest.com/topics/openssh/license.php#tcpwrappers</crossRef>
       </crossRefs>
+    <text>
       <copyrightText>
          <p>Copyright 1995 by Wietse Venema. All rights reserved. Some
          individual files may be covered by other copyrights.</p>
@@ -19,5 +20,6 @@
          implied warranties, including, without limitation, the implied
          warranties of merchantibility and fitness for any particular
          purpose.</p>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/TMate.xml
+++ b/src/TMate.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>http://svnkit.com/license.html</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>The TMate Open Source License.</p>
       </titleText>
@@ -57,6 +58,6 @@
          LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
          LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
          IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/TORQUE-1.1.xml
+++ b/src/TORQUE-1.1.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/TORQUEv1.1</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>TORQUE v2.5+ Software License v1.1</p>
       </titleText>
@@ -82,5 +83,6 @@
              should comply with the TORQUE license as well as the OpenPBS license. 
       </p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/TOSL.xml
+++ b/src/TOSL.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/TOSL</crossRef>
       </crossRefs>
+    <text>
       <copyrightText>
          <p>Trusster Open Source License version 1.0a (TRUST) copyright (c) 2006 Mike Mintz and Robert Ekendahl. All
          rights reserved.</p>
@@ -43,6 +44,6 @@
          LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
          LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
          IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/UPL-1.0.xml
+++ b/src/UPL-1.0.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>http://opensource.org/licenses/UPL</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>The Universal Permissive License (UPL), Version 1.0</p>
       </titleText>
@@ -43,6 +44,6 @@
          NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
          WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
          SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Unicode-DFS-2015.xml
+++ b/src/Unicode-DFS-2015.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>https://web.archive.org/web/20151224134844/http://unicode.org/copyright.html</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>UNICODE, INC. LICENSE AGREEMENT - DATA FILES AND SOFTWARE</p>
       </titleText>
@@ -73,5 +74,6 @@
          promote the sale, use or other dealings in these Data Files or
          Software without prior written authorization of the copyright
          holder.</p>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Unicode-DFS-2016.xml
+++ b/src/Unicode-DFS-2016.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>http://www.unicode.org/copyright.html</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>UNICODE, INC. LICENSE AGREEMENT - DATA FILES AND SOFTWARE</p>
       </titleText>
@@ -71,5 +72,6 @@
          promote the sale, use or other dealings in these Data Files or
          Software without prior written authorization of the copyright
          holder.</p>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Unicode-TOU.xml
+++ b/src/Unicode-TOU.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>http://www.unicode.org/copyright.html</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Unicode Terms of Use</p>
       </titleText>
@@ -168,6 +169,6 @@
             </list>
          </item>
       </list>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Unlicense.xml
+++ b/src/Unlicense.xml
@@ -5,7 +5,7 @@
          <crossRef>http://unlicense.org/</crossRef>
       </crossRefs>
       <notes>This is a public domain dedication</notes>
-    
+    <text>
       <p>This is free and unencumbered software released into the public domain.</p>
       <p>Anyone is free to copy, modify, publish, use, compile, sell, or distribute this software, either in
          source code form or as a compiled binary, for any purpose, commercial or non-commercial, and by any
@@ -22,6 +22,6 @@
          OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
          OTHER DEALINGS IN THE SOFTWARE.</p>
       <p>For more information, please refer to &lt;http://unlicense.org/&gt;</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/VOSTROM.xml
+++ b/src/VOSTROM.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/VOSTROM</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>VOSTROM Public License for Open Source</p>
       </titleText>
@@ -76,6 +77,6 @@
          WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, TORT
          (INCLUDING NEGLIGENCE) OR STRICT LIABILITY, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
          PERFORMANCE OF THIS SOFTWARE.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/VSL-1.0.xml
+++ b/src/VSL-1.0.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>http://www.opensource.org/licenses/VSL-1.0</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Vovida Software License v. 1.0</p>
       </titleText>
@@ -54,6 +55,6 @@
          PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
          STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
          SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Vim.xml
+++ b/src/Vim.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>http://vimdoc.sourceforge.net/htmldoc/uganda.html</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>VIM LICENSE</p>
       </titleText>
@@ -118,6 +119,6 @@
              license that they came with, at your option.
         </item>
       </list>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/W3C-19980720.xml
+++ b/src/W3C-19980720.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>http://www.w3.org/Consortium/Legal/copyright-software-19980720.html</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>W3C® SOFTWARE NOTICE AND LICENSE</p>
       </titleText>
@@ -60,5 +61,6 @@
          materials from our site, including specific terms and conditions for packages like libwww, Amaya, and
          Jigsaw. Other questions about this notice can be directed to site-policy@w3.org.</p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/W3C-20150513.xml
+++ b/src/W3C-20150513.xml
@@ -28,6 +28,7 @@ Copyright (c)
          or modifications to the files" to the copyright notice, to
          make clear that the license is compatible with other liberal
          licenses.</notes>
+    <text>
       <p>This work is being provided by the copyright holders under the
          following license.</p>
       <p>License
@@ -79,5 +80,6 @@ Copyright (c)
          advertising or publicity pertaining to the work without
          specific, written prior permission. Title to copyright in this
          work will at all times remain with copyright holders.</p>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/W3C.xml
+++ b/src/W3C.xml
@@ -15,6 +15,7 @@
       </standardLicenseHeader>
       <notes>This license was released: 13 December 2002. The standard header is provided via a link from the original
          license page.</notes>
+    <text>
       <titleText>
          <p>W3C SOFTWARE NOTICE AND LICENSE</p>
       </titleText>
@@ -55,5 +56,6 @@
          as the previous version and is written so as to preserve the Free Software Foundation's assessment of
          GPL compatibility and OSI's certification under the Open Source Definition.</p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/WTFPL.xml
+++ b/src/WTFPL.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>http://sam.zoy.org/wtfpl/COPYING</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE 
         <br/>Version 2, December 2004 
@@ -23,6 +24,6 @@
           You just DO WHAT THE FUCK YOU WANT TO.
         </item>
       </list>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Watcom-1.0.xml
+++ b/src/Watcom-1.0.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>http://www.opensource.org/licenses/Watcom-1.0</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Sybase Open Watcom Public License version 1.0</p>
       </titleText>
@@ -415,5 +416,6 @@
          FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT. Please see the License for the specific
          language governing rights and limitations under the License."</p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Wsuipa.xml
+++ b/src/Wsuipa.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/Wsuipa</crossRef>
       </crossRefs>
+    <text>
       <optional>
          <p>This file was added by Clea F. Rees on 2008/11/30 with the permission of Dean Guenther and pointers to
          this file were added to all source files.</p>
@@ -17,5 +18,6 @@
          <p>The copyright holder is Washington State University. The original author of the fonts is Janene Winter.
          The primary contact (as of 2008) is Dean Guenther.</p>
       </copyrightText>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/X11.xml
+++ b/src/X11.xml
@@ -5,6 +5,7 @@
          <crossRef>http://www.xfree86.org/3.3.6/COPYRIGHT2.html#3</crossRef>
       </crossRefs>
       <notes>This is same as MIT, but with no advertising clause added.</notes>
+    <text>
       <titleText>
          <p>X11 License</p>
       </titleText>
@@ -28,6 +29,6 @@
          otherwise to promote the sale, use or other dealings in this Software without prior written
          authorization from the X Consortium.</p>
       <p>X Window System is a trademark of X Consortium, Inc.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/XFree86-1.1.xml
+++ b/src/XFree86-1.1.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>http://www.xfree86.org/current/LICENSE4.html</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>XFree86 License (version 1.1)</p>
       </titleText>
@@ -53,6 +54,6 @@
          CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
          NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
          POSSIBILITY OF SUCH DAMAGE.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/XSkat.xml
+++ b/src/XSkat.xml
@@ -4,7 +4,7 @@
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/XSkat_License</crossRef>
       </crossRefs>
-    
+    <text>
       <p>This program is free software; you can redistribute it freely. 
         <br/>Use it at your own risk; there is NO WARRANTY. 
       </p>
@@ -25,6 +25,6 @@
              arbitrary suffix.
         </item>
       </list>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Xerox.xml
+++ b/src/Xerox.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/Xerox</crossRef>
       </crossRefs>
+    <text>
       <copyrightText>
          <p>Copyright (c) 1995, 1996 Xerox Corporation. All Rights Reserved.</p>
       </copyrightText>
@@ -18,6 +19,6 @@
          DAMAGES RESULTING FROM THE SOFTWARE OR ITS USE IS EXPRESSLY DISCLAIMED, WHETHER ARISING IN CONTRACT,
          TORT (INCLUDING NEGLIGENCE) OR STRICT LIABILITY, EVEN IF XEROX CORPORATION IS ADVISED OF THE
          POSSIBILITY OF SUCH DAMAGES.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Xnet.xml
+++ b/src/Xnet.xml
@@ -6,6 +6,7 @@
       </crossRefs>
       <notes>This license is the same as MIT, but with a choice of law clause. This License has been voluntarily
          deprecated by its author.</notes>
+    <text>
       <titleText>
          <p>The X.Net, Inc. License</p>
       </titleText>
@@ -27,6 +28,6 @@
          SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</p>
       <p>This agreement shall be governed in all respects by the laws of the State of California and by the laws
          of the United States of America.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/YPL-1.0.xml
+++ b/src/YPL-1.0.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>http://www.zimbra.com/license/yahoo_public_license_1.0.html</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Yahoo! Public License, Version 1.0 (YPL)</p>
       </titleText>
@@ -187,6 +188,6 @@
          party's right to take subsequent action.
       </item>
       </list>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/YPL-1.1.xml
+++ b/src/YPL-1.1.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>http://www.zimbra.com/license/yahoo_public_license_1.1.html</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Yahoo! Public License, Version 1.1 (YPL)</p>
       </titleText>
@@ -189,6 +190,6 @@
           
         </item>
       </list>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/ZPL-1.1.xml
+++ b/src/ZPL-1.1.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>http://old.zope.org/Resources/License/ZPL-1.1</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Zope Public License (ZPL) Version 1.1</p>
       </titleText>
@@ -71,5 +72,6 @@
          <p>This software consists of contributions made by Zope Corporation and many individuals on behalf of Zope
          Corporation. Specific attributions are listed in the accompanying credits file.</p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/ZPL-2.0.xml
+++ b/src/ZPL-2.0.xml
@@ -5,6 +5,7 @@
          <crossRef>http://old.zope.org/Resources/License/ZPL-2.0</crossRef>
          <crossRef>http://opensource.org/licenses/ZPL-2.0</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Zope Public License (ZPL) Version 2.0</p>
       </titleText>
@@ -61,5 +62,6 @@
          <p>This software consists of contributions made by Zope Corporation and many individuals on behalf of Zope
          Corporation. Specific attributions are listed in the accompanying credits file.</p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/ZPL-2.1.xml
+++ b/src/ZPL-2.1.xml
@@ -5,6 +5,7 @@
          <crossRef>http://old.zope.org/Resources/ZPL/</crossRef>
       </crossRefs>
       <notes>This is a generic version of the ZPL 2.0 license</notes>
+    <text>
       <titleText>
          <p>Zope Public License (ZPL) Version 2.1</p>
       </titleText>
@@ -54,6 +55,6 @@
          CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
          NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
          POSSIBILITY OF SUCH DAMAGE.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Zed.xml
+++ b/src/Zed.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/Zed</crossRef>
       </crossRefs>
+    <text>
       <copyrightText>
          <p>(c) Jim Davies, January 1995</p>
       </copyrightText>
@@ -11,6 +12,6 @@
       <p>You may copy and distribute this file freely. Any queries and complaints should be forwarded to
          Jim.Davies@comlab.ox.ac.uk.</p>
       <p>If you make any changes to this file, please do not distribute the results under the name `zed-csp.sty'.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Zend-2.0.xml
+++ b/src/Zend-2.0.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>https://web.archive.org/web/20130517195954/http://www.zend.com/license/2_00.txt</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>The Zend Engine License, version 2.00</p>
       </titleText>
@@ -59,6 +60,6 @@
        ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
        OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
        DAMAGE.</p>
-  
+    </text>
    </license>
 </SPDXLicenseCollection>

--- a/src/Zimbra-1.3.xml
+++ b/src/Zimbra-1.3.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>http://web.archive.org/web/20100302225219/http://www.zimbra.com/license/zimbra-public-license-1-3.html</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Zimbra Public License, Version 1.3 (ZPL)</p>
       </titleText>
@@ -187,8 +188,6 @@
         </item>
 
       </list>
-
-
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Zimbra-1.4.xml
+++ b/src/Zimbra-1.4.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>http://www.zimbra.com/legal/zimbra-public-license-1-4</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Zimbra Public License, Version 1.4 (ZPL)</p>
       </titleText>
@@ -182,6 +183,6 @@
                  take subsequent action.</p>
             </item>
         </list>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Zlib.xml
+++ b/src/Zlib.xml
@@ -5,6 +5,7 @@
          <crossRef>http://www.zlib.net/zlib_license.html</crossRef>
          <crossRef>http://www.opensource.org/licenses/Zlib</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>zlib License</p>
       </titleText>
@@ -32,6 +33,6 @@
           This notice may not be removed or altered from any source distribution.
         </item>
       </list>
-
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/bzip2-1.0.5.xml
+++ b/src/bzip2-1.0.5.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>http://bzip.org/1.0.5/bzip2-manual-1.0.5.html</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>Version 1.0.5 of 10 December 2007</p>
       </titleText>
@@ -52,6 +53,6 @@
          However, I do not have the resources to carry out a patent search. Therefore I cannot give any
          guarantee of the above statement. 
       </p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/bzip2-1.0.6.xml
+++ b/src/bzip2-1.0.6.xml
@@ -6,6 +6,7 @@
          <crossRef>https://github.com/asimonov-im/bzip2/blob/master/LICENSE</crossRef>
       </crossRefs>
       <notes>The bzip2.org website only shows version 1.0.5 of the license.</notes>
+    <text>
       <copyrightText>
          <p>This program, "bzip2", the associated library "libbzip2", and all documentation, are
          copyright (C) 1996-2010 Julian R Seward. All rights reserved.</p>
@@ -45,6 +46,6 @@
          OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
          SUCH DAMAGE.</p>
       <p>Julian Seward, jseward@bzip.org bzip2/libbzip2 version 1.0.6 of 6 September 2010</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/curl.xml
+++ b/src/curl.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>https://github.com/bagder/curl/blob/master/COPYING</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>COPYRIGHT AND PERMISSION NOTICE</p>
       </titleText>
@@ -24,6 +25,6 @@
       <p>Except as contained in this notice, the name of a copyright holder shall not be used in advertising or
          otherwise to promote the sale, use or other dealings in this Software without prior written
          authorization of the copyright holder.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/diffmark.xml
+++ b/src/diffmark.xml
@@ -4,7 +4,7 @@
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/diffmark</crossRef>
       </crossRefs>
-    
+    <text>
       <list>
         <item>
             <bullet>1.</bullet>
@@ -15,6 +15,6 @@
           I refuse any responsibility for the consequences
         </item>
       </list>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/dvipdfm.xml
+++ b/src/dvipdfm.xml
@@ -4,10 +4,10 @@
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/dvipdfm</crossRef>
       </crossRefs>
-    
+    <text>
       <p>A modified version of this file may be distributed, but it should be distributed with a *different* name.
          Changed files must be distributed *together with a complete and unchanged* distribution of these
          files.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/eCos-2.0.xml
+++ b/src/eCos-2.0.xml
@@ -5,6 +5,7 @@
          <crossRef>http://www.gnu.org/licenses/ecos-license.html</crossRef>
       </crossRefs>
       <notes>DEPRECATED: This is really GPL-2.0 or later with an exception. Use License Expression Syntax and Exceptions list to create equivalent license.</notes>
+    <text>
       <titleText>The eCos license version 2.0</titleText>
      
 	     <p>This file is part of eCos, the Embedded Configurable Operating System. Copyright (C) 1998, 1999, 2000, 2001, 2002 Red Hat, Inc.</p>
@@ -18,5 +19,6 @@
       <optional>
 	        <p>####ECOSGPLCOPYRIGHTEND####</p>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/eGenix.xml
+++ b/src/eGenix.xml
@@ -5,6 +5,7 @@
          <crossRef>http://www.egenix.com/products/eGenix.com-Public-License-1.1.0.pdf</crossRef>
          <crossRef>https://fedoraproject.org/wiki/Licensing/eGenix.com_Public_License_1.1.0</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>EGENIX.COM PUBLIC LICENSE AGREEMENT 
         <br/>Version 1.1.0 
@@ -111,6 +112,6 @@
         <br/>D-40764 Langenfeld 
         <br/>Germany 
       </p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/exceptions/389-exception.xml
+++ b/src/exceptions/389-exception.xml
@@ -5,6 +5,7 @@
          <crossRef>http://directory.fedoraproject.org/wiki/GPL_Exception_License_Text</crossRef>
       </crossRefs>
       <notes>Specified to be associated with GPL-2.0</notes>
+    <text>
       <p>This Program is free software; you can redistribute it and/or
        modify it under the terms of the GNU General Public License as
        published by the Free Software Foundation; version 2 of the
@@ -39,5 +40,6 @@
        to provide this exception without modification, you must
        delete this exception statement from your version and license
        this file solely under the GPL without exception.</p>
+    </text>
   </exception>
 </SPDXLicenseCollection>

--- a/src/exceptions/Autoconf-exception-2.0.xml
+++ b/src/exceptions/Autoconf-exception-2.0.xml
@@ -7,7 +7,7 @@
       </crossRefs>
       <notes>Typically used with GPL-2.0
   </notes>
-    
+    <text>
       <p>As a special exception, the Free Software Foundation gives
          unlimited permission to copy, distribute and modify the
          configure scripts that are the output of Autoconf. You need
@@ -35,6 +35,6 @@
          portions to the data portions.) If your modification has such
          potential, you must delete any notice of this special
          exception to the GPL from your modified version.</p>
-    
+    </text>
   </exception>
 </SPDXLicenseCollection>

--- a/src/exceptions/Autoconf-exception-3.0.xml
+++ b/src/exceptions/Autoconf-exception-3.0.xml
@@ -5,6 +5,7 @@
          <crossRef>http://www.gnu.org/licenses/autoconf-exception-3.0.html</crossRef>
       </crossRefs>
       <notes>Typically used with GPL-3.0</notes>
+    <text>
       <titleText>
          <p>AUTOCONF CONFIGURE SCRIPT EXCEPTION
         <br/>Version 3.0, 18 August 2009</p>
@@ -60,5 +61,6 @@
             copyleft requirements of the license of Autoconf.</p>
          </item>
       </list>
+    </text>
   </exception>
 </SPDXLicenseCollection>

--- a/src/exceptions/Bison-exception-2.2.xml
+++ b/src/exceptions/Bison-exception-2.2.xml
@@ -6,6 +6,7 @@
       </crossRefs>
       <notes>Typically used with GPL-2.0 or GPL-3.0
   </notes>
+    <text>
       <titleText>
          <p>Bison Exception</p>
       </titleText>
@@ -21,5 +22,6 @@
          License without this special exception.</p>
       <p>This special exception was added by the Free Software Foundation
          in version 2.2 of Bison.</p>
+    </text>
   </exception>
 </SPDXLicenseCollection>

--- a/src/exceptions/Bootloader-exception.xml
+++ b/src/exceptions/Bootloader-exception.xml
@@ -4,7 +4,7 @@
       <crossRefs>
          <crossRef>https://github.com/pyinstaller/pyinstaller/blob/develop/COPYING.txt</crossRef>
       </crossRefs>
-  
+    <text>
       <titleText>
          <p>Bootloader Exception<alt match="-*" name="titleUnderline"/></p>
       </titleText>
@@ -15,5 +15,6 @@ those combinations without any restriction coming from the use of those
 files. (The General Public License restrictions do apply in other respects;
 for example, they cover modification of the files, and distribution when
 not linked into a <alt name="combined" match="combined|combine">combined</alt> executable.)</p>
+    </text>
   </exception>
 </SPDXLicenseCollection>

--- a/src/exceptions/CLISP-exception-2.0.xml
+++ b/src/exceptions/CLISP-exception-2.0.xml
@@ -5,6 +5,7 @@
          <crossRef>http://sourceforge.net/p/clisp/clisp/ci/default/tree/COPYRIGHT</crossRef>
       </crossRefs>
       <notes>Typically used with GPL-2.0</notes>
+    <text>
       <p>Summary:</p>
       <p>This program is free software; you can redistribute it and/or
        modify it under the terms of the GNU General Public License
@@ -55,5 +56,6 @@
        CLISP through dynamic linking is not exempted from this
        copyright. I.e. such code, when distributed for use with
        CLISP, must be distributed under the GPL.</p>
+    </text>
   </exception>
 </SPDXLicenseCollection>

--- a/src/exceptions/Classpath-exception-2.0.xml
+++ b/src/exceptions/Classpath-exception-2.0.xml
@@ -5,6 +5,7 @@
          <crossRef>http://www.gnu.org/software/classpath/license.html</crossRef>
          <crossRef>https://fedoraproject.org/wiki/Licensing/GPL_Classpath_Exception</crossRef>
       </crossRefs>
+    <text>
       <p>Linking this library statically or dynamically with other modules
          is making a combined work based on this library. Thus, the
          terms and conditions of the GNU General Public License cover
@@ -21,5 +22,6 @@
          extend this exception to your version of the library, but you
          are not obligated to do so. If you do not wish to do so,
          delete this exception statement from your version.</p>
+    </text>
   </exception>
 </SPDXLicenseCollection>

--- a/src/exceptions/DigiRule-FOSS-exception.xml
+++ b/src/exceptions/DigiRule-FOSS-exception.xml
@@ -5,6 +5,7 @@
          <crossRef>http://www.digirulesolutions.com/drupal/foss</crossRef>
       </crossRefs>
       <notes>Typically used with GPL-2.0</notes>
+    <text>
       <titleText>
          <p>DigiRule Solutions’s FOSS License Exception Terms and Conditions</p>
       </titleText>
@@ -108,5 +109,6 @@
         <br/>Zlib/libpng License -
         <br/>Zope Public License 2.0
       </p>
+    </text>
   </exception>
 </SPDXLicenseCollection>

--- a/src/exceptions/FLTK-exception.xml
+++ b/src/exceptions/FLTK-exception.xml
@@ -5,6 +5,7 @@
          <crossRef>http://www.fltk.org/COPYING.php</crossRef>
       </crossRefs>
       <notes>Specified to be associated with LGPL-2.0. On Fedora List as "FLTK License".</notes>
+    <text>
       <p>The FLTK library and included programs are provided under the
          terms of the GNU Library General Public License (LGPL) with
          the following exceptions:</p>
@@ -33,5 +34,6 @@
          documentation to satisfy this requirement:</p>
       <p>[program/widget] is based in part on the work of the FLTK project
          (http://www.fltk.org).</p>
+    </text>
   </exception>
 </SPDXLicenseCollection>

--- a/src/exceptions/Fawkes-Runtime-exception.xml
+++ b/src/exceptions/Fawkes-Runtime-exception.xml
@@ -6,6 +6,7 @@
       </crossRefs>
       <notes>Combines the Classpath exception with the Macros and Inline Functions
          exception.</notes>
+    <text>
       <p>Linking this library statically or dynamically with other modules
          is making a combined work based on this library. Thus, the
          terms and conditions of the GNU General Public License cover
@@ -29,5 +30,6 @@
          License. This exception does not however invalidate any other
          reasons why the executable file might be covered by the GNU
          General Public License.</p>
+    </text>
   </exception>
 </SPDXLicenseCollection>

--- a/src/exceptions/Font-exception-2.0.xml
+++ b/src/exceptions/Font-exception-2.0.xml
@@ -5,6 +5,7 @@
          <crossRef>http://www.gnu.org/licenses/gpl-faq.html#FontException</crossRef>
       </crossRefs>
       <notes>Typically used with GPL-2.0  </notes>
+    <text>
       <p>As a special exception, if you create a document which uses this
          font, and embed this font or unaltered portions of this font
          into the document, this font does not by itself cause the
@@ -15,5 +16,6 @@
          exception to your version of the font, but you are not
          obligated to do so. If you do not wish to do so, delete this
          exception statement from your version.</p>
+    </text>
   </exception>
 </SPDXLicenseCollection>

--- a/src/exceptions/GCC-exception-2.0.xml
+++ b/src/exceptions/GCC-exception-2.0.xml
@@ -7,7 +7,7 @@
       <notes>Typically used with GPL-2.0+.  Sometimes also referred to a
          "linking exception."  
   </notes>
-    
+    <text>
       <p>In addition to the permissions in the GNU
         <optional>Library</optional> General Public License, the Free
         Software Foundation gives you unlimited permission to link the
@@ -21,5 +21,6 @@
         example, they cover modification of the file, and distribution
         when not linked into
         <alt name="anotherProgram" match="another program|a combined? executable">another program</alt>.)</p>
+    </text>
   </exception>
 </SPDXLicenseCollection>

--- a/src/exceptions/GCC-exception-3.1.xml
+++ b/src/exceptions/GCC-exception-3.1.xml
@@ -6,6 +6,7 @@
       </crossRefs>
       <notes>Typically used with GPL-3.0
   </notes>
+    <text>
       <titleText>
          <p>GCC RUNTIME LIBRARY EXCEPTION</p>
          <p>Version 3.1, 31 March 2009</p>
@@ -91,6 +92,6 @@
       <p>The availability of this Exception does not imply any general
          presumption that third-party software is unaffected by the
          copyleft requirements of the license of GCC.</p>
-    
+    </text>
   </exception>
 </SPDXLicenseCollection>

--- a/src/exceptions/LZMA-exception.xml
+++ b/src/exceptions/LZMA-exception.xml
@@ -6,6 +6,7 @@
       </crossRefs>
       <notes>Used by the LZMA compression module for NSIS to apply an exception to
          CPL-1.0</notes>
+    <text>
 	  <optional>I.6 Special exception for LZMA compression module</optional>
       <titleText>
          <optional><p>LZMA exception</p></optional>
@@ -18,5 +19,6 @@
        1.0. Any modifications or additions to files from the LZMA
        compression module for NSIS, however, are subject to the terms
        of the Common Public License version 1.0.</p>
+    </text>
   </exception>
 </SPDXLicenseCollection>

--- a/src/exceptions/Libtool-exception.xml
+++ b/src/exceptions/Libtool-exception.xml
@@ -4,10 +4,12 @@
       <crossRefs>
          <crossRef>http://git.savannah.gnu.org/cgit/libtool.git/tree/m4/libtool.m4</crossRef>
       </crossRefs>
+    <text>
       <p>As a special exception to the GNU General Public License, if you
          distribute this file as part of a program or library that is
          built using GNU Libtool, you may include this file under the
          same distribution terms that you use for the rest of that
          program.</p>
+    </text>
   </exception>
 </SPDXLicenseCollection>

--- a/src/exceptions/Linux-syscall-note.xml
+++ b/src/exceptions/Linux-syscall-note.xml
@@ -5,6 +5,7 @@
          <crossRef>https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/COPYING</crossRef>
       </crossRefs>
       <notes>This note is used with the Linux kernel to clarify how user space API files should be treated.</notes>
+    <text>
       <p> NOTE! This copyright does *not* cover user programs that use kernel
          services by normal system calls - this is merely considered normal use
          of the kernel, and does *not* fall under the heading of "derived work".
@@ -17,5 +18,6 @@
       v2.2 or v3.x or whatever), unless explicitly otherwise stated.</p>
 
       <p>Linus Torvalds</p>
+    </text>
   </exception>
 </SPDXLicenseCollection>

--- a/src/exceptions/Nokia-Qt-exception-1.1.xml
+++ b/src/exceptions/Nokia-Qt-exception-1.1.xml
@@ -5,6 +5,7 @@
          <crossRef>https://www.keepassx.org/dev/projects/keepassx/repository/revisions/b8dfb9cc4d5133e0f09cd7533d15a4f1c19a40f2/entry/LICENSE.NOKIA-LGPL-EXCEPTION</crossRef>
       </crossRefs>
       <notes>Typically used by Nokia Qt to apply an exception to LGPL-2.1</notes>
+    <text>
       <titleText>
          <p>Nokia Qt LGPL Exception version 1.1</p>
       </titleText>
@@ -56,5 +57,6 @@
       </list>
       <p>Furthermore, you are not required to apply this additional
        permission to a modified version of the Library.</p>
+    </text>
   </exception>
 </SPDXLicenseCollection>

--- a/src/exceptions/OCCT-exception-1.0.xml
+++ b/src/exceptions/OCCT-exception-1.0.xml
@@ -6,6 +6,7 @@
       </crossRefs>
       <notes>Open CASCADE Technology version 6.7.0 and later are governed by (LGPL-2.1 with this exception.) 
     A specific license (OCCT-PL) is applied to Open CASCADE Technology version 6.6.0 and earlier.</notes>
+    <text>
       <titleText>
          <p>Open CASCADE Exception (version 1.0) to GNU LGPL version 2.1.</p>
       </titleText>
@@ -19,5 +20,6 @@
          you give prominent notice in supporting documentation to this
          code that it makes use of or is based on facilities provided
          by the Open CASCADE Technology software.</p>
+    </text>
   </exception>
 </SPDXLicenseCollection>

--- a/src/exceptions/Qwt-exception-1.0.xml
+++ b/src/exceptions/Qwt-exception-1.0.xml
@@ -5,6 +5,7 @@
          <crossRef>http://qwt.sourceforge.net/qwtlicense.html</crossRef>
       </crossRefs>
       <notes>Specified to be associated with LGPL-2.1.  On Fedora List as "Qwt License 1.0".</notes>
+    <text>
       <titleText>
          <p>Qwt License Version 1.0,
         <br/>January 1, 2003
@@ -45,5 +46,6 @@
          documentation to satisfy this requirement: [program/widget] is
          based in part on the work of the Qwt project
          (http://qwt.sf.net)."</p>
+    </text>
   </exception>
 </SPDXLicenseCollection>

--- a/src/exceptions/WxWindows-exception-3.1.xml
+++ b/src/exceptions/WxWindows-exception-3.1.xml
@@ -6,6 +6,7 @@
       </crossRefs>
       <notes>Typically used with GPL-2.0+
   </notes>
+    <text>
       <p>EXCEPTION NOTICE</p>
       <list>
         <item>
@@ -47,5 +48,6 @@
              accordingly.
         </item>
       </list>
+    </text>
   </exception>
 </SPDXLicenseCollection>

--- a/src/exceptions/eCos-exception-2.0.xml
+++ b/src/exceptions/eCos-exception-2.0.xml
@@ -6,6 +6,7 @@
       </crossRefs>
       <notes>Typically used with GPL-2.0. Similar to Macro and Inlines Functions Exception
 </notes>
+    <text>
       <p>As a special exception, if other files instantiate templates or
          use macros or inline functions from this file, or you compile
          this file and link it with other works to produce a work based
@@ -17,5 +18,6 @@
       <p>This exception does not invalidate any other reasons why a work
          based on this file might be covered by the GNU General Public
          License.</p>
+    </text>
   </exception>
 </SPDXLicenseCollection>

--- a/src/exceptions/freertos-exception-2.0.xml
+++ b/src/exceptions/freertos-exception-2.0.xml
@@ -6,6 +6,7 @@
       </crossRefs>
       <notes>Used with GPL-2.0, as specified at
          http://www.freertos.org/license.txt</notes>
+    <text>
       <p>Any FreeRTOS source code, whether modified or in its original
        release form, or whether in whole or in part, can only be
        distributed by you under the terms of the GNU General Public
@@ -45,5 +46,6 @@
            is intended to ensure information accuracy).</p>
          </item>
       </list>
+    </text>
   </exception>
 </SPDXLicenseCollection>

--- a/src/exceptions/gnu-javamail-exception.xml
+++ b/src/exceptions/gnu-javamail-exception.xml
@@ -5,11 +5,13 @@
          <crossRef>http://www.gnu.org/software/classpathx/javamail/javamail.html</crossRef>
       </crossRefs>
       <notes>Typically used with GPL (any version)</notes>
+    <text>
       <p>As a special exception, if you link this library with other files
          to produce an executable, this library does not by itself
          cause the resulting executable to be covered by the GNU
          General Public License. This exception does not however
          invalidate any other reasons why the executable file might be
          covered by the GNU General Public License.</p>
+    </text>
   </exception>
 </SPDXLicenseCollection>

--- a/src/exceptions/i2p-gpl-java-exception.xml
+++ b/src/exceptions/i2p-gpl-java-exception.xml
@@ -5,6 +5,7 @@
          <crossRef>http://geti2p.net/en/get-involved/develop/licenses#java_exception</crossRef>
       </crossRefs>
       <notes>Typically used with GPL-2.0+</notes>
+    <text>
       <p>In addition, as a special exception, 
         <alt match=".+" name="licensor">XXXX</alt> gives permission to
         link the code of this program with the proprietary Java
@@ -17,5 +18,6 @@
         wish to do so, delete this exception statement from your
         version.
       </p>
+    </text>
   </exception>
 </SPDXLicenseCollection>

--- a/src/exceptions/mif-exception.xml
+++ b/src/exceptions/mif-exception.xml
@@ -7,6 +7,7 @@
       </crossRefs>
       <notes>Typically used with GPL-2.0 for older versions of GCC. This is similar to
          the eCos Exception.</notes>
+    <text>
       <p>As a special exception, you may use this file as part of a free
          software library without restriction. Specifically, if other
          files instantiate templates or use macros or inline functions
@@ -16,5 +17,6 @@
          General Public License. This exception does not however
          invalidate any other reasons why the executable file might be
          covered by the GNU General Public License.</p>
+    </text>
   </exception>
 </SPDXLicenseCollection>

--- a/src/exceptions/openvpn-openssl-exception.xml
+++ b/src/exceptions/openvpn-openssl-exception.xml
@@ -5,6 +5,7 @@
          <crossRef>http://openvpn.net/index.php/license.html</crossRef>
       </crossRefs>
       <notes>Typically used with GPL 2.0</notes>
+    <text>
       <titleText>
          <p>Special exception for linking OpenVPN with OpenSSL:</p>
       </titleText>
@@ -18,5 +19,6 @@
          exception to your version of the file, but you are not
          obligated to do so. If you do not wish to do so, delete this
          exception statement from your version.</p>
+    </text>
   </exception>
 </SPDXLicenseCollection>

--- a/src/exceptions/u-boot-exception-2.0.xml
+++ b/src/exceptions/u-boot-exception-2.0.xml
@@ -5,6 +5,7 @@
          <crossRef>http://git.denx.de/?p=u-boot.git;a=blob;f=Licenses/Exceptions</crossRef>
       </crossRefs>
       <notes>Typically used with GPL-2.0+</notes>
+      <text>
       <titleText>
          <p>The U-Boot License Exception:</p>
       </titleText>
@@ -21,5 +22,6 @@
          heading of "derived work".
         <br/>-- Wolfgang Denk
       </p>
+      </text>
   </exception>
 </SPDXLicenseCollection>

--- a/src/gSOAP-1.3b.xml
+++ b/src/gSOAP-1.3b.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>http://www.cs.fsu.edu/~engelen/license.html</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>gSOAP Public License</p>
          <p>Version 1.3b</p>
@@ -485,5 +486,6 @@
             </item>
         </list>
       </optional>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/gnuplot.xml
+++ b/src/gnuplot.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/Gnuplot</crossRef>
       </crossRefs>
+    <text>
       <copyrightText>
          <p>Copyright 1986 - 1993, 1998, 2004 Thomas Williams, Colin Kelley</p>
       </copyrightText>
@@ -39,6 +40,6 @@
          distributions.</p>
       <p>This software is provided "as is" without express or implied warranty to the extent permitted
          by applicable law.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/iMatix.xml
+++ b/src/iMatix.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>http://legacy.imatix.com/html/sfl/sfl4.htm#license</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>The SFL License Agreement</p>
       </titleText>
@@ -76,6 +77,6 @@
              the quality and performance of the Product is with you. Should the Product prove defective, the
              full cost of repair, servicing, or correction lies with you.</item>
          </list>
-      
+    </text>
     </license>
 </SPDXLicenseCollection>

--- a/src/libtiff.xml
+++ b/src/libtiff.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/libtiff</crossRef>
       </crossRefs>
+    <text>
       <copyrightText>
          <p>Copyright (c) 1988-1997 Sam Leffler</p>
          <p>Copyright (c) 1991-1997 Silicon Graphics, Inc.</p>
@@ -20,6 +21,6 @@
          CONSEQUENTIAL DAMAGES OF ANY KIND, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR
          PROFITS, WHETHER OR NOT ADVISED OF THE POSSIBILITY OF DAMAGE, AND ON ANY THEORY OF LIABILITY, ARISING
          OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/mpich2.xml
+++ b/src/mpich2.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/MIT</crossRef>
       </crossRefs>
+    <text>
       <copyrightText>
          <p>COPYRIGHT</p>
       </copyrightText>
@@ -29,6 +30,6 @@
          employees, makes any warranty express or implied, or assumes any legal liability or responsibility for
          the accuracy, completeness, or usefulness of any information, apparatus, product, or process
          disclosed, or represents that its use would not infringe privately owned rights.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/psfrag.xml
+++ b/src/psfrag.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/psfrag</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>psfrag.dtx</p>
       </titleText>
@@ -16,6 +17,6 @@
          implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. Don't come complaining to us if
          you modify this file and it doesn't work! If this file is modified by anyone but the authors, those
          changes and their authors must be explicitly stated HERE.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/psutils.xml
+++ b/src/psutils.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/psutils</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>PS Utilities Package</p>
       </titleText>
@@ -51,6 +52,6 @@
       </list>
       <p>Basically, I don't mind how you use the programs so long as you acknowledge the author, and give people
          the originals if they want them.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/wxWindows.xml
+++ b/src/wxWindows.xml
@@ -8,6 +8,7 @@
      <p>DEPRECATED: Use License Expression Syntax and Exceptions list to create equivalent license.</p>
      <p>Typically used with GPL-2.0+.</p>
   </notes>
+    <text>
       <p>EXCEPTION NOTICE</p>
       <list>
         <item>
@@ -49,5 +50,6 @@
              accordingly.
         </item>
       </list>
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/xinetd.xml
+++ b/src/xinetd.xml
@@ -4,13 +4,13 @@
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/Xinetd_License</crossRef>
       </crossRefs>
+    <text>
       <optional>
          <p>ORIGINAL LICENSE: This software is</p>
       </optional>
       <copyrightText>
          <p>(c) Copyright 1992 by Panagiotis Tsirigotis</p>
       </copyrightText>
-    
       <p>The author (Panagiotis Tsirigotis) grants permission to use, copy, and distribute this software and its
          documentation for any purpose and without fee, provided that the above copyright notice extant in
          files in this distribution is not removed from files included in any redistribution and that this
@@ -52,6 +52,6 @@
         <p>So, if you want, you may use any 2.N.* (N &gt;= 3) version string for future xinetd versions that you
            release. Note that I am excluding the 2.2.* line; using that would only create confusion. Naming the
            next release 2.3.0 would put to rest the confusion about 2.2.1 and 2.1.8.*.</p>
-     
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/xpp.xml
+++ b/src/xpp.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/xpp</crossRef>
       </crossRefs>
+    <text>
       <titleText>
          <p>LICENSE FOR THE Extreme! Lab PullParser</p>
       </titleText>
@@ -57,6 +58,6 @@
          "WORMS", OR OTHER HARMFUL CODE. LICENSEE ASSUMES THE ENTIRE RISK AS TO THE PERFORMANCE OF SOFTWARE
          AND/OR ASSOCIATED MATERIALS, AND TO THE PERFORMANCE AND VALIDITY OF INFORMATION GENERATED USING
          SOFTWARE.</p>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/zlib-acknowledgement.xml
+++ b/src/zlib-acknowledgement.xml
@@ -5,12 +5,12 @@
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/ZlibWithAcknowledgement</crossRef>
       </crossRefs>
+    <text>
       <copyrightText>
          <p>Copyright (c) 2002-2007 Charlie Poole</p>
          <p>Copyright (c) 2002-2004 James W. Newkirk, Michael C. Two, Alexei A. Vorontsov</p>
          <p>Copyright (c) 2000-2002 Philip A. Craig</p>
       </copyrightText>
-    
       <p>This software is provided 'as-is', without any express or implied warranty. In no event will the authors
          be held liable for any damages arising from the use of this software.</p>
       <p>Permission is granted to anyone to use this software for any purpose, including commercial applications,
@@ -34,6 +34,6 @@
           This notice may not be removed or altered from any source distribution.
         </item>
       </list>
-    
+    </text>
   </license>
 </SPDXLicenseCollection>


### PR DESCRIPTION
As it stands, there's not an easy way to extract the license text from the XML format without removing `<crossRefs>`, `<notes>`, `<standardLicenseHeader>`, and other siblings.  With this change (which, if accepted, I still have to propagate into `src/`) we collect it in `<text>`, just like we already collect the header text in `<standardLicenseHeader>`.

This is a WIP, because of the pending `src/` migration.  If this PR gets a green light, I'll go ahead and migrate `src/` before we merge it.