### PR TITLE
gulpfile: Validate exceptions

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -47,7 +47,7 @@ function validate(file) {
 }
 
 function validateall(callback) {
-	glob('./'+srcdir+'**/*.xml', function(err, files) {
+	glob('./'+srcdir+'/**/*.xml', function(err, files) {
 		if (!files) {
 			return;
 		}


### PR DESCRIPTION
The previous glob (`./src**/*.xml`) was not matching `src/exceptions/*.xml`.  The new glob (`./src/**/*.xml`) does.  From [here][1]:

> * `**` If a "globstar" is alone in a path portion, then it matches zero or more directories and subdirectories searching for matches.  It does not crawl symlinked directories.

[1]: https://github.com/isaacs/node-glob/blob/v7.1.2/README.md#glob-primer