### PR TITLE
CC-BY-ND-2.0: Return to CC-BY-ND-2.0 (had CC-BY-ND-3.0 text)

### DIFF
--- a/src/CC-BY-ND-2.0.xml
+++ b/src/CC-BY-ND-2.0.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isOsiApproved="false" licenseId="CC-BY-ND-3.0"
-            name="Creative Commons Attribution No Derivatives 3.0">
+   <license isOsiApproved="false" licenseId="CC-BY-ND-2.0"
+            name="Creative Commons Attribution No Derivatives 2.0">
       <crossRefs>
-         <crossRef>http://creativecommons.org/licenses/by-nd/3.0/legalcode</crossRef>
+         <crossRef>https://creativecommons.org/licenses/by-nd/2.0/legalcode</crossRef>
       </crossRefs>
       <titleText>
-         <p>Creative Commons Attribution-NoDerivs 3.0 Unported</p>
+         <p>Creative Commons Attribution-NoDerivs 2.0</p>
       </titleText>
       <optional>
          <p>CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE LEGAL SERVICES. DISTRIBUTION OF THIS
@@ -21,8 +21,8 @@
          LAW. ANY USE OF THE WORK OTHER THAN AS AUTHORIZED UNDER THIS LICENSE OR COPYRIGHT LAW IS
          PROHIBITED.</p>
       <p>BY EXERCISING ANY RIGHTS TO THE WORK PROVIDED HERE, YOU ACCEPT AND AGREE TO BE BOUND BY THE TERMS OF THIS
-         LICENSE. TO THE EXTENT THIS LICENSE MAY BE CONSIDERED TO BE A CONTRACT, THE LICENSOR GRANTS YOU THE
-         RIGHTS CONTAINED HERE IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND CONDITIONS.</p>
+         LICENSE. THE LICENSOR GRANTS YOU THE RIGHTS CONTAINED HERE IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH
+         TERMS AND CONDITIONS.</p>
       <list>
         <item>
             <bullet>1.</bullet>
@@ -30,98 +30,51 @@
         <list>
                <item>
                   <bullet>a.</bullet>
-            "Adaptation" means a work based upon the Work, or upon the Work and other
-               pre-existing works, such as a translation, adaptation, derivative work, arrangement of
-               music or other alterations of a literary or artistic work, or phonogram or performance and
-               includes cinematographic adaptations or any other form in which the Work may be recast,
-               transformed, or adapted including in any form recognizably derived from the original,
-               except that a work that constitutes a Collection will not be considered an Adaptation for
-               the purpose of this License. For the avoidance of doubt, where the Work is a musical work,
-               performance or phonogram, the synchronization of the Work in timed-relation with a moving
-               image ("synching") will be considered an Adaptation for the purpose of this
-               License.
+            "Collective Work" means a work, such as a periodical issue, anthology or encyclopedia, in
+               which the Work in its entirety in unmodified form, along with a number of other
+               contributions, constituting separate and independent works in themselves, are assembled
+               into a collective whole. A work that constitutes a Collective Work will not be considered
+               a Derivative Work (as defined below) for the purposes of this License.
           </item>
                <item>
                   <bullet>b.</bullet>
-            "Collection" means a collection of literary or artistic works, such as
-               encyclopedias and anthologies, or performances, phonograms or broadcasts, or other works
-               or subject matter other than works listed in Section 1(f) below, which, by reason of the
-               selection and arrangement of their contents, constitute intellectual creations, in which
-               the Work is included in its entirety in unmodified form along with one or more other
-               contributions, each constituting separate and independent works in themselves, which
-               together are assembled into a collective whole. A work that constitutes a Collection will
-               not be considered an Adaptation (as defined above) for the purposes of this License.
+            "Derivative Work" means a work based upon the Work or upon the Work and other
+               pre-existing works, such as a translation, musical arrangement, dramatization,
+               fictionalization, motion picture version, sound recording, art reproduction, abridgment,
+               condensation, or any other form in which the Work may be recast, transformed, or adapted,
+               except that a work that constitutes a Collective Work will not be considered a Derivative
+               Work for the purpose of this License. For the avoidance of doubt, where the Work is a
+               musical composition or sound recording, the synchronization of the Work in timed-relation
+               with a moving image ("synching") will be considered a Derivative Work for the purpose of
+               this License.
           </item>
                <item>
                   <bullet>c.</bullet>
-            "Distribute" means to make available to the public the original and copies of the
-               Work through sale or other transfer of ownership.
+            "Licensor" means the individual or entity that offers the Work under the terms of this
+               License.
           </item>
                <item>
                   <bullet>d.</bullet>
-            "Licensor" means the individual, individuals, entity or entities that offer(s) the
-               Work under the terms of this License.
+            "Original Author" means the individual or entity who created the Work.
           </item>
                <item>
                   <bullet>e.</bullet>
-            "Original Author" means, in the case of a literary or artistic work, the
-               individual, individuals, entity or entities who created the Work or if no individual or
-               entity can be identified, the publisher; and in addition (i) in the case of a performance
-               the actors, singers, musicians, dancers, and other persons who act, sing, deliver,
-               declaim, play in, interpret or otherwise perform literary or artistic works or expressions
-               of folklore; (ii) in the case of a phonogram the producer being the person or legal entity
-               who first fixes the sounds of a performance or other sounds; and, (iii) in the case of
-               broadcasts, the organization that transmits the broadcast.
+            "Work" means the copyrightable work of authorship offered under the terms of this License.
           </item>
                <item>
                   <bullet>f.</bullet>
-            "Work" means the literary and/or artistic work offered under the terms of this
-               License including without limitation any production in the literary, scientific and
-               artistic domain, whatever may be the mode or form of its expression including digital
-               form, such as a book, pamphlet and other writing; a lecture, address, sermon or other work
-               of the same nature; a dramatic or dramatico-musical work; a choreographic work or
-               entertainment in dumb show; a musical composition with or without words; a cinematographic
-               work to which are assimilated works expressed by a process analogous to cinematography; a
-               work of drawing, painting, architecture, sculpture, engraving or lithography; a
-               photographic work to which are assimilated works expressed by a process analogous to
-               photography; a work of applied art; an illustration, map, plan, sketch or
-               three-dimensional work relative to geography, topography, architecture or science; a
-               performance; a broadcast; a phonogram; a compilation of data to the extent it is protected
-               as a copyrightable work; or a work performed by a variety or circus performer to the
-               extent it is not otherwise considered a literary or artistic work.
-          </item>
-               <item>
-                  <bullet>g.</bullet>
             "You" means an individual or entity exercising rights under this License who has
                not previously violated the terms of this License with respect to the Work, or who has
                received express permission from the Licensor to exercise rights under this License
                despite a previous violation.
           </item>
-               <item>
-                  <bullet>h.</bullet>
-            "Publicly Perform" means to perform public recitations of the Work and to
-               communicate to the public those public recitations, by any means or process, including by
-               wire or wireless means or public digital performances; to make available to the public
-               Works in such a way that members of the public may access these Works from a place and at
-               a place individually chosen by them; to perform the Work to the public by any means or
-               process and the communication to the public of the performances of the Work, including by
-               public digital performance; to broadcast and rebroadcast the Work by any means including
-               signs, sounds or images.
-          </item>
-               <item>
-                  <bullet>i.</bullet>
-            "Reproduce" means to make copies of the Work by any means including without
-               limitation by sound or visual recordings and the right of fixation and reproducing
-               fixations of the Work, including storage of a protected performance or phonogram in
-               digital form or other electronic medium.
-          </item>
             </list>
         </item>
         <item>
             <bullet>2.</bullet>
-          Fair Dealing Rights. Nothing in this License is intended to reduce, limit, or restrict any uses
-             free from copyright or rights arising from limitations or exceptions that are provided for in
-             connection with the copyright protection under copyright law or other applicable laws.
+          Fair Use Rights. Nothing in this license is intended to reduce, limit, or restrict any rights
+             arising from fair use, first sale or other limitations on the exclusive rights of the
+             copyright owner under copyright law or other applicable laws.
         </item>
         <item>
             <bullet>3.</bullet>
@@ -131,102 +84,89 @@
         <list>
                <item>
                   <bullet>a.</bullet>
-            to Reproduce the Work, to incorporate the Work into one or more Collections, and to Reproduce
-               the Work as incorporated in the Collections; and,
+            to reproduce the Work, to incorporate the Work into one or more Collective Works, and to
+               reproduce the Work as incorporated in the Collective Works;
           </item>
                <item>
                   <bullet>b.</bullet>
-            to Distribute and Publicly Perform the Work including as incorporated in Collections.
+            to distribute copies or phonorecords of, display publicly, perform publicly, and perform
+               publicly by means of a digital audio transmission the Work including as incorporated in
+               Collective Works.
           </item>
                <item>
                   <bullet>c.</bullet>
-            For the avoidance of doubt:
+            For the avoidance of doubt, where the work is a musical composition:
           <list>
                      <item>
                         <bullet>i.</bullet>
-              Non-waivable Compulsory License Schemes. In those jurisdictions in which the right to
-                 collect royalties through any statutory or compulsory licensing scheme cannot be
-                 waived, the Licensor reserves the exclusive right to collect such royalties for any
-                 exercise by You of the rights granted under this License;
+              Performance Royalties Under Blanket Licenses. Licensor waives the exclusive right to
+                 collect, whether individually or via a performance rights society (e.g. ASCAP, BMI, SESAC),
+                 royalties for the public performance or public digital performance (e.g. webcast) of the
+                 Work.
             </item>
                      <item>
                         <bullet>ii.</bullet>
-              Waivable Compulsory License Schemes. In those jurisdictions in which the right to collect
-                 royalties through any statutory or compulsory licensing scheme can be waived, the
-                 Licensor waives the exclusive right to collect such royalties for any exercise by You
-                 of the rights granted under this License; and,
-            </item>
-                     <item>
-                        <bullet>iii.</bullet>
-              Voluntary License Schemes. The Licensor waives the right to collect royalties, whether
-                 individually or, in the event that the Licensor is a member of a collecting society
-                 that administers voluntary licensing schemes, via that society, from any exercise by
-                 You of the rights granted under this License.
+              Mechanical Rights and Statutory Royalties. Licensor waives the exclusive right to collect,
+                 whether individually or via a music rights society or designated agent (e.g. Harry Fox
+                 Agency), royalties for any phonorecord You create from the Work ("cover version") and
+                 distribute, subject to the compulsory license created by 17 USC Section 115 of the US
+                 Copyright Act (or the equivalent in other jurisdictions).
             </item>
                   </list>
                </item>
+               <item>
+                  <bullet>d.</bullet>
+            Webcasting Rights and Statutory Royalties. For the avoidance of doubt, where the Work is a
+               sound recording, Licensor waives the exclusive right to collect, whether individually or
+               via a performance-rights society (e.g. SoundExchange), royalties for the public digital
+               performance (e.g. webcast) of the Work, subject to the compulsory license created by 17
+               USC Section 114 of the US Copyright Act (or the equivalent in other jurisdictions).
+          </item>
             </list>
          </item>    
          <item><p>The above rights may be exercised in all media and formats whether now known or hereafter
          devised. The above rights include the right to make such modifications as are
          technically necessary to exercise the rights in other media and formats, but otherwise
-         you have no rights to make Adaptations. Subject to Section 8(f), all rights not
-         expressly granted by Licensor are hereby reserved.</p>
+         you have no rights to make Derivative Works. All rights not expressly granted by Licensor are
+         hereby reserved.</p>
 		 </item>
 
         <item>
             <bullet>4.</bullet>
-          Restrictions. The license granted in Section 3 above is expressly made subject to and limited by
-             the following restrictions:
+          Restrictions.<optional> </optional>The license granted in Section 3 above is expressly made
+             subject to and limited by the following restrictions:
         <list>
                <item>
                   <bullet>a.</bullet>
-            You may Distribute or Publicly Perform the Work only under the terms of this License. You
-               must include a copy of, or the Uniform Resource Identifier (URI) for, this License with
-               every copy of the Work You Distribute or Publicly Perform. You may not offer or impose any
-               terms on the Work that restrict the terms of this License or the ability of the recipient
-               of the Work to exercise the rights granted to that recipient under the terms of the
-               License. You may not sublicense the Work. You must keep intact all notices that refer to
-               this License and to the disclaimer of warranties with every copy of the Work You
-               Distribute or Publicly Perform. When You Distribute or Publicly Perform the Work, You may
-               not impose any effective technological measures on the Work that restrict the ability of a
-               recipient of the Work from You to exercise the rights granted to that recipient under the
-               terms of the License. This Section 4(a) applies to the Work as incorporated in a
-               Collection, but this does not require the Collection apart from the Work itself to be made
-               subject to the terms of this License. If You create a Collection, upon notice from any
-               Licensor You must, to the extent practicable, remove from the Collection any credit as
-               required by Section 4(b), as requested.
+            You may distribute, publicly display, publicly perform, or publicly digitally perform the
+               Work only under the terms of this License, and You must include a copy of, or the Uniform
+               Resource Identifier for, this License with every copy or phonorecord of the Work You
+               distribute, publicly display, publicly perform, or publicly digitally perform. You may not
+               offer or impose any terms on the Work that alter or restrict the terms of this License or
+               the recipients' exercise of the rights granted hereunder. You may not sublicense the Work.
+               You must keep intact all notices that refer to this License and to the disclaimer of
+               warranties. You may not distribute, publicly display, publicly perform, or publicly
+               digitally perform the Work with any technological measures that control access or use of
+               the Work in a manner inconsistent with the terms of this License Agreement. The above
+               applies to the Work as incorporated in a Collective Work, but this does not require the
+               Collective Work apart from the Work itself to be made subject to the terms of this
+               License. If You create a Collective Work, upon notice from any Licensor You must, to the
+               extent practicable, remove from the Collective Work any reference to such Licensor or
+               the Original Author, as requested.
           </item>
                <item>
                   <bullet>b.</bullet>
-            If You Distribute, or Publicly Perform the Work or Collections, You must, unless a request
-               has been made pursuant to Section 4(a), keep intact all copyright notices for the Work and
-               provide, reasonable to the medium or means You are utilizing: (i) the name of the Original
-               Author (or pseudonym, if applicable) if supplied, and/or if the Original Author and/or
-               Licensor designate another party or parties (e.g., a sponsor institute, publishing entity,
-               journal) for attribution ("Attribution Parties") in Licensor's copyright
-               notice, terms of service or by other reasonable means, the name of such party or parties;
-               (ii) the title of the Work if supplied; (iii) to the extent reasonably practicable, the
-               URI, if any, that Licensor specifies to be associated with the Work, unless such URI does
-               not refer to the copyright notice or licensing information for the Work. The credit
-               required by this Section 4(b) may be implemented in any reasonable manner; provided,
-               however, that in the case of a Collection, at a minimum such credit will appear, if a
-               credit for all contributing authors of the Collection appears, then as part of these
-               credits and in a manner at least as prominent as the credits for the other contributing
-               authors. For the avoidance of doubt, You may only use the credit required by this Section
-               for the purpose of attribution in the manner set out above and, by exercising Your rights
-               under this License, You may not implicitly or explicitly assert or imply any connection
-               with, sponsorship or endorsement by the Original Author, Licensor and/or Attribution
-               Parties, as appropriate, of You or Your use of the Work, without the separate, express
-               prior written permission of the Original Author, Licensor and/or Attribution Parties.
-          </item>
-               <item>
-                  <bullet>c.</bullet>
-            Except as otherwise agreed in writing by the Licensor or as may be otherwise permitted by
-               applicable law, if You Reproduce, Distribute or Publicly Perform the Work either by itself
-               or as part of any Collections, You must not distort, mutilate, modify or take other
-               derogatory action in relation to the Work which would be prejudicial to the Original
-               Author's honor or reputation.
+            If you distribute, publicly display, publicly perform, or publicly digitally perform the
+               Work or Collective Works, You must keep intact all copyright notices for the Work and
+               give the Original Author credit reasonable to the medium or means You are utilizing by
+               conveying the name (or pseudonym if applicable) of the Original Author if supplied; the
+               title of the Work if supplied; and to the extent reasonably practicable, the Uniform
+               Resource Identifier, if any, that Licensor specifies to be associated with the Work,
+               unless such URI does not refer to the copyright notice or licensing information for the
+               Work. Such credit may be implemented in any reasonable manner; provided, however, that
+               in the case of a Collective Work, at a minimum such credit will appear where any other
+               comparable authorship credit appears and in a manner at least as prominent as such other
+               comparable authorship credit.
           </item>
             </list>
         </item>
@@ -234,7 +174,7 @@
             <bullet>5.</bullet>
           Representations, Warranties and Disclaimer
           <p>UNLESS OTHERWISE MUTUALLY AGREED TO BY THE PARTIES IN WRITING, LICENSOR OFFERS THE WORK AS-IS AND
-             MAKES NO REPRESENTATIONS OR WARRANTIES OF ANY KIND CONCERNING THE WORK, EXPRESS, IMPLIED,
+             MAKES NO REPRESENTATIONS OR WARRANTIES OF ANY KIND CONCERNING THE MATERIALS, EXPRESS, IMPLIED,
              STATUTORY OR OTHERWISE, INCLUDING, WITHOUT LIMITATION, WARRANTIES OF TITLE, MERCHANTIBILITY,
              FITNESS FOR A PARTICULAR PURPOSE, NONINFRINGEMENT, OR THE ABSENCE OF LATENT OR OTHER DEFECTS,
              ACCURACY, OR THE PRESENCE OF ABSENCE OF ERRORS, WHETHER OR NOT DISCOVERABLE. SOME
@@ -255,10 +195,10 @@
                <item>
                   <bullet>a.</bullet>
             This License and the rights granted hereunder will terminate automatically upon any breach by
-               You of the terms of this License. Individuals or entities who have received Collections
-               from You under this License, however, will not have their licenses terminated provided
-               such individuals or entities remain in full compliance with those licenses. Sections 1, 2,
-               5, 6, 7, and 8 will survive any termination of this License.
+               You of the terms of this License. Individuals or entities who have received Collective
+               Works from You under this License, however, will not have their licenses terminated
+               provided such individuals or entities remain in full compliance with those licenses.
+               Sections 1, 2, 5, 6, 7, and 8 will survive any termination of this License.
           </item>
                <item>
                   <bullet>b.</bullet>
@@ -278,7 +218,7 @@
         <list>
                <item>
                   <bullet>a.</bullet>
-            Each time You Distribute or Publicly Perform the Work or a Collection, the Licensor offers to
+            Each time You distribute or publicly digitally perform the Work, the Licensor offers to
                the recipient a license to the Work on the same terms and conditions as the license
                granted to You under this License.
           </item>
@@ -303,24 +243,9 @@
                may appear in any communication from You. This License may not be modified without the
                mutual written agreement of the Licensor and You.
           </item>
-               <item>
-                  <bullet>e.</bullet>
-            The rights granted under, and the subject matter referenced, in this License were drafted
-               utilizing the terminology of the Berne Convention for the Protection of Literary and
-               Artistic Works (as amended on September 28, 1979), the Rome Convention of 1961, the WIPO
-               Copyright Treaty of 1996, the WIPO Performances and Phonograms Treaty of 1996 and the
-               Universal Copyright Convention (as revised on July 24, 1971). These rights and subject
-               matter take effect in the relevant jurisdiction in which the License terms are sought to
-               be enforced according to the corresponding provisions of the implementation of those
-               treaty provisions in the applicable national law. If the standard suite of rights granted
-               under applicable copyright law includes additional rights not granted under this License,
-               such additional rights are deemed to be included in the License; this License is not
-               intended to restrict the license of any rights under applicable law.
-          </item>
             </list>
         </item>
       </list>
-      <p>Creative Commons Notice</p>
       <p>Creative Commons is not a party to this License, and makes no warranty whatsoever in connection with the
          Work. Creative Commons will not be liable to You or any party on any legal theory for any damages
          whatsoever, including without limitation any general, special, incidental or consequential damages
@@ -328,13 +253,11 @@
          Commons has expressly identified itself as the Licensor hereunder, it shall have all rights and
          obligations of Licensor.</p>
       <p>Except for the limited purpose of indicating to the public that the Work is licensed under the CCPL,
-         Creative Commons does not authorize the use by either party of the trademark "Creative
-         Commons" or any related trademark or logo of Creative Commons without the prior written consent
-         of Creative Commons. Any permitted use will be in compliance with Creative Commons' then-current
-         trademark usage guidelines, as may be published on its website or otherwise made available upon
-         request from time to time. For the avoidance of doubt, this trademark restriction does not form part
-         of this License.</p>
-      <p>Creative Commons may be contacted at http://creativecommons.org/.</p>
+         neither party will use the trademark "Creative Commons" or any related trademark or logo of
+         Creative Commons without the prior written consent of Creative Commons. Any permitted use will
+         be in compliance with Creative Commons' then-current trademark usage guidelines, as may be
+         published on its website or otherwise made available upon request from time to time.</p>
+      <p>Creative Commons may be contacted at http<optional>s</optional>://creativecommons.org/.</p>
     
   </license>
 </SPDXLicenseCollection>

--- a/src/CC-BY-ND-4.0.xml
+++ b/src/CC-BY-ND-4.0.xml
@@ -420,13 +420,15 @@
         </list>
       <p>Creative Commons is not a party to its public licenses. Notwithstanding, Creative Commons may elect to
          apply one of its public licenses to material it publishes and in those instances will be considered
-         the “Licensor.” Except for the limited purpose of indicating that material is shared under a Creative
-         Commons public license or as otherwise permitted by the Creative Commons policies published at
-         creativecommons.org/policies, Creative Commons does not authorize the use of the trademark “Creative
-         Commons” or any other trademark or logo of Creative Commons without its prior written consent
-         including, without limitation, in connection with any unauthorized modifications to any of its public
-         licenses or any other arrangements, understandings, or agreements concerning use of licensed material.
-         For the avoidance of doubt, this paragraph does not form part of the public licenses. 
+         the “Licensor.” <optional>The text of the Creative Commons public licenses is dedicated to the public
+         domain under the CC0 Public Domain Dedication.</optional> Except for the limited purpose of indicating
+         that material is shared under a Creative Commons public license or as otherwise permitted by the
+         Creative Commons policies published at creativecommons.org/policies, Creative Commons does not
+         authorize the use of the trademark “Creative Commons” or any other trademark or logo of Creative
+         Commons without its prior written consent including, without limitation, in connection with any
+         unauthorized modifications to any of its public licenses or any other arrangements, understandings, or
+         agreements concerning use of licensed material. For the avoidance of doubt, this paragraph does not
+         form part of the public licenses.
         <br/>Creative Commons may be contacted at creativecommons.org. </p>
     </license>
 </SPDXLicenseCollection>


### PR DESCRIPTION
The initial entry in this repo had the 2.0 text, but f12d5fea (#27) injected the 3.0 wording my mistake.  This commit returns us to the current upstream wording for the 2.0 license.

I've also (optionally) included the new CC0 dedication in upstream's `CC-BY-ND-4.0` so the whole `CC-BY-ND-*` series matches upstream (using my comparison procedure from [here][1]).

More details in the commit messages, if folks are curious about any particular change.

Fixes #448.

[1]: https://lists.spdx.org/pipermail/spdx-legal/2017-August/002099.html