### PR TITLE
HPND: Drop redundant <optional> for related entities

### DIFF
--- a/src/HPND.xml
+++ b/src/HPND.xml
@@ -30,9 +30,7 @@
          <optional>the</optional> copyright notice 
          and this permission notice appear in supporting documentation<optional>, and that the name <optional>of</optional> 
             <alt match=".*" name="copyrightHolder0">&lt;copyright holder&gt;</alt> 
-            <optional>
-               <alt match=".*" name="orRelated">&lt;or related entities&gt;</alt>
-            </optional> 
+            <alt match=".*" name="orRelated">&lt;or related entities&gt;</alt>
          not be used in advertising or publicity pertaining to distribution of the software without specific, written
          prior permission</optional>. <optional>
             <alt match=".*" name="copyrightHolder1">&lt;copyright holder&gt;</alt> makes no representations 


### PR DESCRIPTION
The wrapping `<optional>` is redundant since the “or” moved inside the `<alt>` tag in 143940d2 (#89).

This is somewhat related to #457, but I'm only unwinding one level of nesting, and HPND has more than that.  Still, removing one redundant `<optional>` is a step in the right direction, regardless of how #462 shakes out.