### PR TITLE
Add optional tags

### DIFF
--- a/src/Multics.xml
+++ b/src/Multics.xml
@@ -30,9 +30,9 @@
 	  <optional>
 	  .
 	  </optional>
-	  <optional>
+	  <alt match="-*" name="divider">
 	  -----------------------------------------------------------
-	  </optional>
+	  </alt>
       <p>Permission to use, copy, modify, and distribute these programs and their documentation for any purpose
          and without fee is hereby granted, provided that the below copyright notice and historical background
          appear in all copies and that both the copyright notice and historical background and this permission

--- a/src/Multics.xml
+++ b/src/Multics.xml
@@ -27,6 +27,12 @@
          successor in interest by change in name only to Honeywell Bull Inc. and Honeywell Information Systems
          Inc.</p>
       </optional>
+	  <optional>
+	  .
+	  </optional>
+	  <optional>
+	  -----------------------------------------------------------
+	  </optional>
       <p>Permission to use, copy, modify, and distribute these programs and their documentation for any purpose
          and without fee is hereby granted, provided that the below copyright notice and historical background
          appear in all copies and that both the copyright notice and historical background and this permission


### PR DESCRIPTION
 so that the OSI referenced license at https://opensource.org/licenses/Multics will match

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>