### PR TITLE
Add optional tags to match previous text for the LZMA exception

### DIFF
--- a/src/exceptions/LZMA-exception.xml
+++ b/src/exceptions/LZMA-exception.xml
@@ -6,8 +6,9 @@
       </crossRefs>
       <notes>Used by the LZMA compression module for NSIS to apply an exception to
          CPL-1.0</notes>
+	  <optional>I.6 Special exception for LZMA compression module</optional>
       <titleText>
-         <p>LZMA exception</p>
+         <optional><p>LZMA exception</p></optional>
       </titleText>
       <p>Igor Pavlov and Amir Szekely, the authors of the LZMA compression
        module for NSIS, expressly permit you to statically or


### PR DESCRIPTION
Signed-off-by: Gary O'Neall <gary@sourceauditor.com>

Allows for matching of the text used in license list version 2.6.

Note - Optional tags were put around the title text.  We could automatically wrap optional tags for the templates around the title text elements, but this is not currently supported by the license list generator tools.