### PR TITLE
Change alt text match to use whole tokens 

### DIFF
--- a/src/OSET-PL-2.1.xml
+++ b/src/OSET-PL-2.1.xml
@@ -393,7 +393,7 @@
 		                <bullet>5.2</bullet> Patent Infringement Claims<br/>
 			  If You initiate litigation against any entity by asserting
 			  a patent infringement claim (excluding declaratory judgment actions,
-			  counter-claims, and cross-<alt match=" ?" name="extraSpace"/>claims) alleging that a Contributor Version
+			  counter-claims, and <alt match="cross- claims|cross-claims" name="extraSpace"/>) alleging that a Contributor Version
 			  directly or indirectly infringes any patent,
 			  then the rights granted to You by any and all Contributors
 			  for the Covered Software under Section 2.1 of this License


### PR DESCRIPTION
so that the matching tools can more efficiently match the pattern in license OSL 2.1

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>