### PR TITLE
ClArtistic: Make the trailing “The End” optional

### DIFF
--- a/src/ClArtistic.xml
+++ b/src/ClArtistic.xml
@@ -2,6 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="false" licenseId="ClArtistic" name="Clarified Artistic License">
       <crossRefs>
+         <crossRef>http://gianluca.dellavedova.org/2011/01/03/clarified-artistic-license/</crossRef>
          <crossRef>http://www.ncftp.com/ncftp/doc/LICENSE.txt</crossRef>
       </crossRefs>
       <titleText>

--- a/src/ClArtistic.xml
+++ b/src/ClArtistic.xml
@@ -152,6 +152,6 @@
              PARTICULAR PURPOSE.
         </item>
       </list>
-      <p>The End</p>
+      <optional><p>The End</p></optional>
   </license>
 </SPDXLicenseCollection>


### PR DESCRIPTION
The trailing “The End” was part of the initial [SPDX][1] [submission][2] and is still in [the 3.2.6 NcFTP `doc/LICENSE.txt`][3].  However, it's not present in [the canonical upstream][4].

Also link to [gianluca.dellavedova.org][5], which claims to be the canonical upstream and is [linked by the FSF][6].

[1]: https://lists.spdx.org/pipermail/spdx/2010-August/000008.html
[2]: http://www.ncftp.com/ncftp/doc/LICENSE.txt
[3]: ftp://ftp.mirrorservice.org/sites/ftp.ncftp.com/ncftp/ncftp-3.2.6-src.tar.xz
[4]: http://gianluca.dellavedova.org/2011/01/03/clarified-artistic-license/
[5]: http://gianluca.dellavedova.org/2011/01/03/clarified-artistic-license/
[6]: https://www.gnu.org/licenses/license-list.html#ClarifiedArtistic