### PR TITLE
Add optional "Creative Commons Legal Code" to title

### DIFF
--- a/src/CC0-1.0.xml
+++ b/src/CC0-1.0.xml
@@ -6,6 +6,9 @@
          <crossRef>http://creativecommons.org/publicdomain/zero/1.0/legalcode</crossRef>
       </crossRefs>
       <titleText>
+         <optional>
+            <p>Creative Commons Legal Code</p>
+         </optional>
          <p>Creative Commons CC0 1.0 Universal</p>
       </titleText>
       <optional>

--- a/src/CC0-1.0.xml
+++ b/src/CC0-1.0.xml
@@ -7,9 +7,9 @@
       </crossRefs>
       <titleText>
          <optional>
-            <p>Creative Commons Legal Code</p>
+            <p>Creative Commons<optional> Legal Code</optional></p>
          </optional>
-         <p>Creative Commons CC0 1.0 Universal</p>
+         <p>CC0 1.0 Universal</p>
       </titleText>
       <optional>
          <p>CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE LEGAL SERVICES. DISTRIBUTION OF THIS


### PR DESCRIPTION
In order to match canonical text which includes the line https://creativecommons.org/publicdomain/zero/1.0/legalcode.txt

ref #434