### PR TITLE
Add angle brackets missing from LGPL-2.1 how-to trailer

### DIFF
--- a/src/LGPL-2.1.xml
+++ b/src/LGPL-2.1.xml
@@ -421,8 +421,8 @@
          <p>To apply these terms, attach the following notices to the library. It is safest to attach them to the
          start of each source file to most effectively convey the exclusion of warranty; and each file should
          have at least the "copyright" line and a pointer to where the full notice is found.</p>
-         <p>one line to give the library's name and an idea of what it does. 
-        <br/>Copyright (C) year name of author 
+         <p>&lt;one line to give the library's name and an idea of what it does.&gt;
+        <br/>Copyright (C) &lt;year&gt; &lt;name of author&gt;
       </p>
          <p>This library is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser
          General Public License as published by the Free Software Foundation; either version 2.1 of the
@@ -439,7 +439,7 @@
         <br/>the library `Frob' (a library for tweaking knobs) written 
         <br/>by James Random Hacker. 
       </p>
-         <p>signature of Ty Coon, 1 April 1990 
+         <p>&lt;signature of Ty Coon&gt;, 1 April 1990 
         <br/>Ty Coon, President of Vice 
         <br/>That's all there is to it! 
       </p>

--- a/src/LGPL-2.1.xml
+++ b/src/LGPL-2.1.xml
@@ -6,14 +6,14 @@
          <crossRef>http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</crossRef>
          <crossRef>http://www.opensource.org/licenses/LGPL-2.1</crossRef>
       </crossRefs>
-      <standardLicenseHeader> Copyright (C) 
-    <alt match=".+" name="copyright">year name of author</alt> 
+      <standardLicenseHeader> Copyright (C)
+    <alt match=".+" name="copyright">year name of author</alt>
          <p>This library is free software; you can redistribute
     it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software
-    Foundation; version 2.1.</p> 
+    Foundation; version 2.1.</p>
          <p>This library is distributed in the hope that it will be useful, but WITHOUT ANY
     WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-    Lesser General Public License for more details.</p> 
+    Lesser General Public License for more details.</p>
          <p>You should have received a copy of the GNU Lesser General Public
     License along with this library; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth
     Floor, Boston, MA 02110-1301 USA </p>
@@ -24,8 +24,8 @@
          <p>GNU LESSER GENERAL PUBLIC LICENSE</p>
          <p>Version 2.1, February 1999</p>
       </titleText>
-      <p>Copyright (C) 1991, 1999 Free Software Foundation, Inc. 
-        <br/>51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA 
+      <p>Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+        <br/>51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
       </p>
       <p>Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is
          not allowed.</p>
@@ -158,7 +158,7 @@
                event an application does not supply such function or table, the facility still operates,
                and performs whatever part of its purpose remains meaningful.
             </item>
-            </list>       
+            </list>
             <p>(For example, a function in a library to compute square roots has a purpose that is entirely
                well-defined independent of the application. Therefore, Subsection 2d requires that any
                application-supplied function or table used by this function must be optional: if the
@@ -421,8 +421,8 @@
          <p>To apply these terms, attach the following notices to the library. It is safest to attach them to the
          start of each source file to most effectively convey the exclusion of warranty; and each file should
          have at least the "copyright" line and a pointer to where the full notice is found.</p>
-         <p>&lt;one line to give the library's name and an idea of what it does.&gt;
-        <br/>Copyright (C) &lt;year&gt; &lt;name of author&gt;
+         <p><optional>&lt;</optional>one line to give the library's name and an idea of what it does.<optional>&gt;</optional>
+        <br/>Copyright (C) <optional>&lt;</optional>year<optional>&gt;</optional> <optional>&lt;</optional>name of author<optional>&gt;</optional>
       </p>
          <p>This library is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser
          General Public License as published by the Free Software Foundation; either version 2.1 of the
@@ -435,13 +435,13 @@
          USA Also add information on how to contact you by electronic and paper mail.</p>
          <p>You should also get your employer (if you work as a programmer) or your school, if any, to sign a
          "copyright disclaimer" for the library, if necessary. Here is a sample; alter the names:</p>
-         <p>Yoyodyne, Inc., hereby disclaims all copyright interest in 
-        <br/>the library `Frob' (a library for tweaking knobs) written 
-        <br/>by James Random Hacker. 
+         <p>Yoyodyne, Inc., hereby disclaims all copyright interest in
+        <br/>the library `Frob' (a library for tweaking knobs) written
+        <br/>by James Random Hacker.
       </p>
-         <p>&lt;signature of Ty Coon&gt;, 1 April 1990 
-        <br/>Ty Coon, President of Vice 
-        <br/>That's all there is to it! 
+         <p><optional>&lt;</optional>signature of Ty Coon<optional>&gt;</optional>, 1 April 1990 
+        <br/>Ty Coon, President of Vice
+        <br/>That's all there is to it!
       </p>
       </optional>
   </license>


### PR DESCRIPTION
cf https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt

(GPL-2.0 has the same issue.)