### PR TITLE
ISC title variations

### DIFF
--- a/src/ISC.xml
+++ b/src/ISC.xml
@@ -6,7 +6,7 @@
          <crossRef>http://www.opensource.org/licenses/ISC</crossRef>
       </crossRefs>
       <titleText>
-         <p><alt match="(The )?ISC License( \(ISC[L]?\))?:?"></alt></p>
+         <p><alt match="(The )?ISC License( \(ISC[L]?\))?:?">ISC License</alt></p>
       </titleText>
       <copyrightText>
          <p>Copyright (c) <alt match=".+" name="copyright">2004-2010 by Internet Systems Consortium, Inc. ("ISC")

--- a/src/ISC.xml
+++ b/src/ISC.xml
@@ -6,7 +6,7 @@
          <crossRef>http://www.opensource.org/licenses/ISC</crossRef>
       </crossRefs>
       <titleText>
-         <p><alt match="The " name="titleThe"></alt>ISC License<alt match=" \(ISC[L]{0,1}\)" name="titleID"></alt><alt match=":" name="titleColon"></alt></p>
+         <p><alt match="(The )?ISC License( \(ISC[L]?\))?:?"></alt></p>
       </titleText>
       <copyrightText>
          <p>Copyright (c) <alt match=".+" name="copyright">2004-2010 by Internet Systems Consortium, Inc. ("ISC")

--- a/src/ISC.xml
+++ b/src/ISC.xml
@@ -6,7 +6,7 @@
          <crossRef>http://www.opensource.org/licenses/ISC</crossRef>
       </crossRefs>
       <titleText>
-         <p><alt match="The " name="titleThe"></alt>ISC License<alt match=" (ISC)" name="titleID"></alt><alt match=":" name="titleColon"></alt></p>
+         <p><alt match="The " name="titleThe"></alt>ISC License<alt match=" \(ISC[L]{0,1}\)" name="titleID"></alt><alt match=":" name="titleColon"></alt></p>
       </titleText>
       <copyrightText>
          <p>Copyright (c) <alt match=".+" name="copyright">2004-2010 by Internet Systems Consortium, Inc. ("ISC")

--- a/src/ISC.xml
+++ b/src/ISC.xml
@@ -6,7 +6,7 @@
          <crossRef>http://www.opensource.org/licenses/ISC</crossRef>
       </crossRefs>
       <titleText>
-         <p>ISC License:</p>
+         <p><alt match="The " name="titleThe"></alt>ISC License<alt match=" (ISC)" name="titleID"></alt><alt match=":" name="titleColon"></alt></p>
       </titleText>
       <copyrightText>
          <p>Copyright (c) <alt match=".+" name="copyright">2004-2010 by Internet Systems Consortium, Inc. ("ISC")


### PR DESCRIPTION
The colon in `ISC License:` is probably copied from https://www.isc.org/downloads/software-support-policy/isc-license/ where it is part of a longer string that is more clearly not even supposed to be included in the text ("Text of the ISC License:") so I think it makes sense to support matching the colon but not have it be canonical -- not sure I've seen it in the wild.

I have seen `The ISC License` plenty, eg one of the most starred ISC repos on github.com -- https://github.com/isaacs/node-glob/blob/master/LICENSE

I have also seen `ISC License (ISC)`, probably because that's what seems to be on https://opensource.org/licenses/isc-license.txt if you take the heading to be part of the license text, which people often do.

Note the version at https://choosealicense.com/licenses/isc/ just has `ISC License` and that version is of course popular.

So I'm proposing that `ISC License` be canonical, optionally preceded by `The`, optionally followed by `(ISC)`, optionally followed by`:`.

Separately, I also think it would be a good idea to make ISC not the canonical copyright holder. The license is now very widely used generally with the disclaimer fields as `AUTHOR` and, and starting with a fill-in copyright line like MIT (see above links). If there's any interest I could add here or make a new PR to cover these non-title aspects.

cc @waldyrious as an ISC expert