### PR TITLE
OSET-PL-2.1: Fix "cross- claims" empty alt element

### DIFF
--- a/src/OSET-PL-2.1.xml
+++ b/src/OSET-PL-2.1.xml
@@ -393,7 +393,7 @@
 		                <bullet>5.2</bullet> Patent Infringement Claims<br/>
 			  If You initiate litigation against any entity by asserting
 			  a patent infringement claim (excluding declaratory judgment actions,
-			  counter-claims, and <alt match="cross- claims|cross-claims" name="extraSpace"/>) alleging that a Contributor Version
+			  counter-claims, and <alt match="cross- claims|cross-claims" name="crossClaimsSpace">cross-claims</alt>) alleging that a Contributor Version
 			  directly or indirectly infringes any patent,
 			  then the rights granted to You by any and all Contributors
 			  for the Covered Software under Section 2.1 of this License


### PR DESCRIPTION
The recent change in bf1be461 (#480) forgot to add the canonical text to the `<alt>` element, now that the scope of the match has grown to include canonical text.  I've also updated the name to match the expanded match scope.

I think this should be part of the “immediate release” milestone.