### PR TITLE
LPPL-1.3a: Remove percent from "pig.ins % and"

### DIFF
--- a/src/LPPL-1.3a.xml
+++ b/src/LPPL-1.3a.xml
@@ -12,7 +12,7 @@
     is part of all distributions of LaTeX version 2003/12/01 or later. This work has the LPPL maintenance status
     "maintained". This Current Maintainer of this work is 
     <alt match=".+" name="maintainer">M. Y. Name</alt>. This work consists of 
-    <alt match=".+" name="the work">pig.dtx and pig.ins % and the derived file pig.sty</alt>. 
+    <alt match=".+" name="the work">pig.dtx and pig.ins and the derived file pig.sty</alt>.
   </standardLicenseHeader>
       <notes>This license was released 1 Oct 2004</notes>
       <titleText>


### PR DESCRIPTION
This is an artifact from unwinding upstream's [comments][1]:

```
    % This work consists of the files pig.dtx and pig.ins
    % and the derived file pig.sty.
```

and forgetting to remove the comment character.  The typo dates back to ad98f3bd (#114).

The typo was also present in the released v2.6:

```console
$ curl -s https://raw.githubusercontent.com/spdx/license-list-data/v2.6/json/details/LPPL-1.3a.json |
>   jq -r .standardLicenseHeader | grep 'pig\.ins'
This work consists of <<var;name=the work;original=pig.dtx and pig.ins % and the derived file pig.sty;match=.+>>.
```

But since this text is already inside a wildcard `<alt>` we can remove the percent without needing a new `<alt>` to cover folks using the typo'ed version.

[1]: https://www.latex-project.org/lppl/lppl-1-3a.txt