### PR TITLE
EUPL-1.1 fix URL to official license text

### DIFF
--- a/src/EUPL-1.1.xml
+++ b/src/EUPL-1.1.xml
@@ -4,7 +4,7 @@
             name="European Union Public License 1.1">
       <crossRefs>
          <crossRef>https://joinup.ec.europa.eu/software/page/eupl/licence-eupl</crossRef>
-         <crossRef>https://joinup.ec.europa.eu/system/files/EN/EUPL%20v.1.1%20-%20Licence.pdf</crossRef>
+         <crossRef>https://joinup.ec.europa.eu/sites/default/files/custom-page/attachment/eupl1.1.-licence-en_0.pdf</crossRef>
          <crossRef>http://www.opensource.org/licenses/EUPL-1.1</crossRef>
       </crossRefs>
       <notes>This license was released: 16 May 2008 This license is available in the 22 official languages of the EU. The


### PR DESCRIPTION
It seems that the URL to the official EUPL-1.1 text has changed after EUPL-1.2 was published.

This PR fixes the URL to point to the new location of the official text of the EUPL-1.1.