### PR TITLE
GPL-2.0: Mark postal-code commas as optional

### DIFF
--- a/src/GPL-2.0.xml
+++ b/src/GPL-2.0.xml
@@ -16,7 +16,7 @@
     Public License for more details. </p>
          <p>You should have received a copy of the GNU General Public License along with
     this program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
-    02110-1301, USA.</p>
+    02110-1301<optional>,</optional> USA.</p>
       </standardLicenseHeader>
       <notes>This license was released: June 1991 This refers to when this GPL 2.0 only is being used (as opposed to GPLv2
          or later).</notes>
@@ -26,7 +26,7 @@
       </p>
       </titleText>
       <p>Copyright (C) 1989, 1991 Free Software Foundation, Inc.
-        <br/>51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+        <br/>51 Franklin Street, Fifth Floor, Boston, MA 02110-1301<optional>,</optional> USA
       </p>
       <p>Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is
          not allowed.</p>
@@ -289,7 +289,7 @@
          the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
          Public License for more details.</p>
          <p>You should have received a copy of the GNU General Public License along with this program; if not, write
-         to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+         to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301<optional>,</optional> USA.
          Also add information on how to contact you by electronic and paper mail.</p>
          <p>If the program is interactive, make it output a short notice like this when it starts in an interactive
          mode:</p>


### PR DESCRIPTION
Upstream is not consistent about this:

```console
$ curl -s https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html | grep USA
51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
$ curl -s https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt | grep USA
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
```

so support both forms.  I've stuck with our old comma version as canonical.

[Reported][1] by @1138-4EB.

[1]: https://github.com/benbalter/licensee/issues/247#issuecomment-351756955