### PR TITLE
Bootloader-exception: Hyphen-rule and “combine” → “combined” fixes

### DIFF
--- a/src/exceptions/Bootloader-exception
+++ b/src/exceptions/Bootloader-exception
@@ -14,6 +14,6 @@ and related files into combinations with other programs, and to distribute
 those combinations without any restriction coming from the use of those
 files. (The General Public License restrictions do apply in other respects;
 for example, they cover modification of the files, and distribution when
-not linked into a combine executable.)</p>
+not linked into a <alt name="combined" match="combined|combine">combined</alt>.)</p>
   </exception>
 </SPDXLicenseCollection>

--- a/src/exceptions/Bootloader-exception
+++ b/src/exceptions/Bootloader-exception
@@ -5,8 +5,9 @@
          <crossRef>https://github.com/pyinstaller/pyinstaller/blob/develop/COPYING.txt</crossRef>
       </crossRefs>
   
-      <titleText>Bootloader Exception</titleText>
-<optional>--------------------</optional>
+      <titleText>
+         <p>Bootloader Exception<alt match="-*" name="titleUnderline"/></p>
+      </titleText>
 <p>In addition to the permissions in the GNU General Public License, the
 authors give you unlimited permission to link or embed compiled bootloader
 and related files into combinations with other programs, and to distribute


### PR DESCRIPTION
Fixes for the in-flight #512.