### PR TITLE
GCC-exception-2.0: Match assorted upstream versions

### DIFF
--- a/src/exceptions/GCC-exception-2.0.xml
+++ b/src/exceptions/GCC-exception-2.0.xml
@@ -8,14 +8,18 @@
          "linking exception."  
   </notes>
     
-      <p>In addition to the permissions in the GNU General Public License,
-         the Free Software Foundation gives you unlimited permission to
-         link the compiled version of this file into combinations with
-         other programs, and to distribute those combinations without
-         any restriction coming from the use of this file. (The General
-         Public License restrictions do apply in other respects; for
-         example, they cover modification of the file, and distribution
-         when not linked into a combine executable.)</p>
-    
+      <p>In addition to the permissions in the GNU
+        <optional>Library</optional> General Public License, the Free
+        Software Foundation gives you unlimited permission to link the
+        compiled version of this file<optional> into
+        combinations</optional> with other programs, and to distribute
+        those
+        <alt name="programs" match="programs|combinations">programs</alt>
+        without any restriction coming from the use of this file.  (The
+        <alt name="general" match="General|Library">General</alt>
+        Public License restrictions do apply in other respects; for
+        example, they cover modification of the file, and distribution
+        when not linked into
+        <alt name="anotherProgram" match="another program|a combined? executable">another program</alt>.)</p>
   </exception>
 </SPDXLicenseCollection>


### PR DESCRIPTION
This exception grew an upstream URL in 23b6d5a5 (#413), but we didn't compare the text carefully enough in that case.  This commit adds `<optional>` and `<alt>` blocks so we match both the upstream texts and the old SPDX text.  I've used the original upstream text for our new canonical version.  Checking the mailing lists, we have @jlovejoy reporting uncertainty about the source used for this exception [here][1] and [here][2].  But digging through GCC's version-control history turns up [this initial version][3] (which, with this commit, will become our canonical version).  The “combine executable” form seems to be from [here][4].  I've also allowed for “combined executable”, which first lands [here][5] in a commit that also lands the first instance of the “Library” wording (although I'm not clear on why you'd need this exception if you were already using an LGPL).

[1]: https://lists.spdx.org/pipermail/spdx/2010-November/000204.html
[2]: https://lists.spdx.org/pipermail/spdx-legal/2012-September/000692.html
[3]: https://gcc.gnu.org/git/?p=gcc.git;a=blob;f=gcc/libgcc1.c;h=762f5143fc6eed57b6797c82710f3538aa52b40b;hb=cb143a3ce4fb417c68f5fa2691a1b1b1053dfba9#l10
[4]: https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff;h=4c9b6e719ad35162a897aa09936acce597d0848d;hp=6e36176ee3f04651030cfc6669e99f5b19934573
[5]: https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff;h=ac5e00d3f37fa940ed51493fa157b016a97c35ae;hp=d1f15f1bce018b6f30830858bf2a5a2f205bd8a5