### PR TITLE
.travis.yml: Add gulp validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 .DS_Store
-# Ignore all hidden files/dirs except .gitignore
+# Ignore all hidden files/dirs except .gitignore and .travis.yml
 .*
 !/.gitignore
+!/.travis.yml
 
 # nodeJS
 node_modules/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - "node"
+before_script:
+  - npm run preinstall

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -37,7 +37,6 @@ function validate(file) {
 				} else {
 					errormsg = ' at line ' + error.line + ' ' + error.message;
 				}
-				console.log('Validation error(s) for file '+file+':'+error);
 			});
 			return new Error("File "+file+" "+errormsg);
 		} else {
@@ -75,11 +74,3 @@ gulp.task('validate', function(callback) {
 });
 
 gulp.task('default', ['validate']);
-
-// Comment the following out - just used for testing
-validateall(function(error) {
-	if (error) {
-		console.log(error.message);
-	}
-});
-console.log('done');

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -51,21 +51,26 @@ function validateall(callback) {
 			return;
 		}
 		var error = null;
+		var pass = 0, fail = 0;
 		files.forEach(function(file) {
 			var fileError = validate(file, fileError);
 			if (fileError) {
+				fail++;
 				if (!error) {
 					error = fileError;
 				} else {
 					// append the file in error
 					error = new Error(error.message+fileError.message);
 				}
+			} else {
+				pass++;
 			}
 		});
 		if (error) {
 			gutil.log(error.message);
 			callback(error);
 		}
+		gutil.log('validation complete ' + pass + ' passed, ' + fail + ' failed');
 	});
 }
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -74,6 +74,8 @@ gulp.task('validate', function(callback) {
 	validateall(callback);
 });
 
+gulp.task('default', ['validate']);
+
 // Comment the following out - just used for testing
 validateall(function(error) {
 	if (error) {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
         "software"
     ],
     "scripts": {
-        "preinstall": "(npm list gulp -g || npm install gulp -g)"
+        "preinstall": "(npm list gulp -g || npm install gulp -g)",
+        "test": "gulp"
     },
     "dependencies": {
         "libxml-xsd": "0.5.2",

--- a/schema/ListedLicense.xsd
+++ b/schema/ListedLicense.xsd
@@ -29,9 +29,9 @@
 			<element name="alt" type="tns:altType"/>
 			<element name="br" type="tns:emptyType"/>
 		</choice>
-		<attribute name="licenseId" type="string"/>
+		<attribute name="licenseId" type="string" use="required" />
 		<attribute name="isDeprecated" type="boolean"/>
-		<attribute name="name" type="string"/>
+		<attribute name="name" type="string" use="required" />
 		<attribute name="listVersionAdded" type="string"/>
 		<attribute name="deprecatedVersion" type="string"/>
 	</complexType>
@@ -49,11 +49,11 @@
 			<element name="alt" type="tns:altType"/>
 			<element name="br" type="tns:emptyType"/>
 		</choice>
-		<attribute name="licenseId" type="string"/>
+		<attribute name="licenseId" type="string" use="required" />
 		<attribute name="isOsiApproved" type="boolean"/>
 		<attribute name="isFsfLibre" type="boolean"/>
 		<attribute name="isDeprecated" type="boolean"/>
-		<attribute name="name" type="string"/>
+		<attribute name="name" type="string" use="required" />
 		<attribute name="listVersionAdded" type="string"/>
 		<attribute name="deprecatedVersion" type="string"/>
 	</complexType>
@@ -64,8 +64,8 @@
 	</complexType>
 	<complexType name="altType" mixed="true">
 		<group ref="tns:formattedFixedTextGroup" minOccurs="0" maxOccurs="unbounded"/>
-		<attribute name="name" type="string"/>
-		<attribute name="match" type="string"/>
+		<attribute name="name" type="string" use="required" />
+		<attribute name="match" type="string" use="required" />
 	</complexType>
 	<complexType name="optionalType" mixed="true">
 		<group ref="tns:formattedAltTextGroup" minOccurs="0" maxOccurs="unbounded"/>

--- a/src/ISC.xml
+++ b/src/ISC.xml
@@ -6,7 +6,7 @@
          <crossRef>http://www.opensource.org/licenses/ISC</crossRef>
       </crossRefs>
       <titleText>
-         <p><alt match="(The )?ISC License( \(ISC[L]?\))?:?">ISC License</alt></p>
+         <p><alt name="title" match="(The )?ISC License( \(ISC[L]?\))?:?">ISC License</alt></p>
       </titleText>
       <copyrightText>
          <p>Copyright (c) <alt match=".+" name="copyright">2004-2010 by Internet Systems Consortium, Inc. ("ISC")


### PR DESCRIPTION
Details on the individual pivots in the commit messages, but this pull requests gets automatic schema validation to avoid issues like #517 ~~(which it fixes)~~.

The tests aren't as extensive as those in #513.  I think we want that sort of XML-template vs. known good/bad sample testing soon, but filling in gulp-based tests seems like something we want as well, and it's easier to implement.

Fixes #518.