### PR TITLE
Adding BSD-1-Clause

### DIFF
--- a/src/BSD-1-Clause.xml
+++ b/src/BSD-1-Clause.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SPDXLicenseCollection xmlns="http://www.spdx.org/license">
+   <license licenseId="BSD-1-Clause"
+            name="BSD 1-clause License">
+      <crossRefs>
+	      <crossRef>
+		      https://svnweb.freebsd.org/base/head/include/ifaddrs.h?revision=326823
+	      </crossRef>
+      </crossRefs>
+      <copyrightText>
+         <p>Copyright (c) 
+        <alt match=".+" name="copyright"> &lt;year&gt; &lt;owner&gt;</alt> All rights reserved. 
+      </p>
+      </copyrightText>
+    
+      <p>
+ Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+      </p>
+      <list>
+        <item>
+            <bullet>1.</bullet>
+Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+        </item>
+      </list>
+
+      <p>
+      THIS SOFTWARE IS PROVIDED BY
+        <alt match=".+" name="copyrightHolderAsIs">Berkeley Software Design, Inc.</alt>
+      "AS IS" AND
+ANY
+        <alt match="EXPRESS|EXPRESSED" name="express">EXPRESS</alt>
+OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL
+<alt match=".+" name="copyrightHolderLiability">Berkeley Software Design, Inc.</alt>
+BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+      </p>
+
+  </license>
+</SPDXLicenseCollection>

--- a/src/BSD-1-Clause.xml
+++ b/src/BSD-1-Clause.xml
@@ -1,50 +1,42 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license licenseId="BSD-1-Clause"
-            name="BSD 1-clause License">
-      <crossRefs>
-	      <crossRef>
-		      https://svnweb.freebsd.org/base/head/include/ifaddrs.h?revision=326823
-	      </crossRef>
-      </crossRefs>
-      <copyrightText>
-         <p>Copyright (c) 
-        <alt match=".+" name="copyright"> &lt;year&gt; &lt;owner&gt;</alt> All rights reserved. 
-      </p>
-      </copyrightText>
-    
+  <license licenseId="BSD-1-Clause" name="BSD 1-clause License">
+    <crossRefs>
+      <crossRef>https://svnweb.freebsd.org/base/head/include/ifaddrs.h?revision=326823</crossRef>
+    </crossRefs>
+    <copyrightText>
       <p>
- Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
+        Copyright (c)<alt name="copyright" match=".+"><year> <owner></alt>
+        All rights reserved.
       </p>
-      <list>
-        <item>
-            <bullet>1.</bullet>
-Redistributions of source code must retain the above copyright
-   notice, this list of conditions and the following disclaimer.
-        </item>
-      </list>
-
-      <p>
-      THIS SOFTWARE IS PROVIDED BY
-        <alt match=".+" name="copyrightHolderAsIs">Berkeley Software Design, Inc.</alt>
-      "AS IS" AND
-ANY
-        <alt match="EXPRESS|EXPRESSED" name="express">EXPRESS</alt>
-OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-ARE DISCLAIMED.  IN NO EVENT SHALL
-<alt match=".+" name="copyrightHolderLiability">Berkeley Software Design, Inc.</alt>
-BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
-OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
-OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
-SUCH DAMAGE.
-      </p>
-
+    </copyrightText>
+    <p>
+      Redistribution and use in source and binary
+      forms, with or without modification, are permitted
+      provided that the following conditions are met:
+    </p>
+    <list>
+      <item>
+        <bullet>1.</bullet>
+        Redistributions of source code must retain the above copyright
+        notice, this list of conditions and the following disclaimer.
+      </item>
+    </list>
+    <p>
+      THIS SOFTWARE IS PROVIDED BY<alt name="copyrightHolderAsIs"
+      match=".+">Berkeley Software Design, Inc.</alt>
+      "AS IS" AND ANY<alt name="express" match="EXPRESS|EXPRESSED">EXPRESS</alt>
+      OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+      WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+      ARE DISCLAIMED. IN NO EVENT SHALL<alt name="copyrightHolderLiability"
+      match=".+">Berkeley Software Design, Inc.</alt>
+      BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+      OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+      OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+      OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+      LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+      NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+      THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+    </p>
   </license>
 </SPDXLicenseCollection>

--- a/src/BSD-1-Clause.xml
+++ b/src/BSD-1-Clause.xml
@@ -6,7 +6,7 @@
     </crossRefs>
     <copyrightText>
       <p>
-        Copyright (c)<alt name="copyright" match=".+"><year> <owner></alt>
+        Copyright (c)<alt name="copyright" match=".+">[year] [owner]</alt>
         All rights reserved.
       </p>
     </copyrightText>

--- a/src/BSD-1-Clause.xml
+++ b/src/BSD-1-Clause.xml
@@ -23,7 +23,7 @@
       </item>
     </list>
     <p>
-      THIS SOFTWARE IS PROVIDED BY<alt name="copyrightHolderAsIs"
+      THIS SOFTWARE IS PROVIDED BY <alt name="copyrightHolderAsIs"
       match=".+">Berkeley Software Design, Inc.</alt>
       "AS IS" AND ANY<alt name="express" match="EXPRESS|EXPRESSED">EXPRESS</alt>
       OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED

--- a/src/BSD-1-Clause.xml
+++ b/src/BSD-1-Clause.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-  <license licenseId="BSD-1-Clause" name="BSD 1-clause License">
+  <license licenseId="BSD-1-Clause" name="BSD 1-Clause License">
     <crossRefs>
       <crossRef>https://svnweb.freebsd.org/base/head/include/ifaddrs.h?revision=326823</crossRef>
     </crossRefs>


### PR DESCRIPTION
Taking care of #506 

I have used "BSD-1-Clause" for identifier and "BSD 1-clause License" for name.
We haven't always been consistent on capitalization of "clause" in names.

I have also templatized the license, matching the other BSD ones.