### PR TITLE
BSD-1-Clause: Add a space between “(c)” and “<year>”

### DIFF
--- a/src/BSD-1-Clause.xml
+++ b/src/BSD-1-Clause.xml
@@ -6,7 +6,7 @@
     </crossRefs>
     <copyrightText>
       <p>
-        Copyright (c)<alt name="copyright" match=".+">&lt;year&gt; &lt;owner&gt;</alt>
+        Copyright (c) <alt name="copyright" match=".+">&lt;year&gt; &lt;owner&gt;</alt>
         All rights reserved.
       </p>
     </copyrightText>

--- a/src/BSD-1-Clause.xml
+++ b/src/BSD-1-Clause.xml
@@ -6,7 +6,7 @@
     </crossRefs>
     <copyrightText>
       <p>
-        Copyright (c)<alt name="copyright" match=".+">[year] [owner]</alt>
+        Copyright (c)<alt name="copyright" match=".+">&lt;year&gt; &lt;owner&gt;</alt>
         All rights reserved.
       </p>
     </copyrightText>


### PR DESCRIPTION
Also use `<…>` instead of `[…]` for template placeholders to match our other `BSD-*-Clause` licenses.

Follow-ups to #522.