### PR TITLE
Wrap OFL-1.1 copyrightText in optional

### DIFF
--- a/src/OFL-1.1.xml
+++ b/src/OFL-1.1.xml
@@ -6,8 +6,8 @@
          <crossRef>http://www.opensource.org/licenses/OFL-1.1</crossRef>
       </crossRefs>
       <notes>This license was released: 26 February 2007.</notes>
-      <copyrightText><p>Copyright (c) &lt;dates&gt;, &lt;Copyright Holder&gt; (&lt;URL|email&gt;),
-            <br/>with Reserved Font Name &lt;Reserved Font Name&gt;.</p></copyrightText>
+      <copyrightText><optional><p>Copyright (c) &lt;dates&gt;, &lt;Copyright Holder&gt; (&lt;URL|email&gt;),
+         <br/>with Reserved Font Name &lt;Reserved Font Name&gt;.</p></optional></copyrightText>
       <optional>
          <p>This Font Software is licensed under the SIL Open Font License, Version 1.1.</p>
          <p>This license is copied below, and is also available with a FAQ at: http://scripts.sil.org/OFL</p>


### PR DESCRIPTION
Similar to #531 

I'm not sure this is all that is needed for #528 as #482 added some optional text between the copyrightText and titleText. If the tools can't deal with this, the additional text could be moved into copyrightText. I didn't add it there originally because it isn't exactly copyright text, but again it could fit there.