### PR TITLE
Add OpenJDK Assembly exception

### DIFF
--- a/src/exceptions/OpenJDK-Assembly-exception-2.0.xml
+++ b/src/exceptions/OpenJDK-Assembly-exception-2.0.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SPDXLicenseCollection xmlns="http://www.spdx.org/license">
+   <exception licenseId="OpenJDK-assembly-exception-2.0" name="Open JDK Assembly exception 2.0">
+      <crossRefs>
+         <crossRef>http://openjdk.java.net/legal/assembly-exception.html
+         </crossRef>
+      </crossRefs>
+      <titleText>OpenJDK Assembly Exception</titleText>
+      <p>
+         The OpenJDK source code made available by Oracle America, Inc.
+         (Oracle) at openjdk.java.net ("OpenJDK Code") is distributed
+         under the terms of the GNU General Public License
+         &lt;http://www.gnu.org/copyleft/gpl.html&gt; version 2 only
+         ("GPL2"), with the following clarification and special
+         exception.
+      </p>
+
+      <list>
+         <item>
+            <p>Linking this OpenJDK Code statically or dynamically with
+               other code is making a combined work based on this
+               library. Thus, the terms and conditions of GPL2 cover the
+               whole combination.
+            </p>
+
+            <p>As a special exception, Oracle gives you permission to
+               link this OpenJDK Code with certain code licensed by
+               Oracle as indicated at
+               http://openjdk.java.net/legal/exception-modules-2007-05-08.html
+               ("Designated Exception Modules") to produce an
+               executable, regardless of the license terms of the
+               Designated Exception Modules, and to copy and distribute
+               the resulting executable under GPL2, provided that the
+               Designated Exception Modules continue to be governed by
+               the licenses under which they were offered by Oracle.
+            </p>
+         </item>
+      </list>
+
+      <p>As such, it allows licensees and sublicensees of Oracle's GPL2
+         OpenJDK Code to build an executable that includes those
+         portions of necessary code that Oracle could not provide under
+         GPL2 (or that Oracle has provided under GPL2 with the Classpath
+         exception). If you modify or add to the OpenJDK code, that new
+         GPL2 code may still be combined with Designated Exception
+         Modules if the new code is made subject to this exception by
+         its copyright holder.
+      </p>
+   </exception>
+</SPDXLicenseCollection>


### PR DESCRIPTION
At least two Eclipse projects use the Open JDK Assembly exception. I'd like to add it to the exception list.

I've labelled it 2.0 because it is an exception specifically to the GPL-2.0. I am hopeful that this was the right thing to do.

I'll address this to the SPDX legal mailing list.