### PR TITLE
New GNU identifiers

### DIFF
--- a/src/AGPL-3.0-only.xml
+++ b/src/AGPL-3.0-only.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-  <license licenseId="AGPL-3.0" isOsiApproved="true"
-  name="GNU Affero General Public License v3.0">
+  <license licenseId="AGPL-3.0-only" isOsiApproved="true"
+  name="GNU Affero General Public License v3.0 only">
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/agpl.txt</crossRef>
       <crossRef>http://www.opensource.org/licenses/AGPL-3.0</crossRef>

--- a/src/AGPL-3.0-only.xml
+++ b/src/AGPL-3.0-only.xml
@@ -1,0 +1,848 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SPDXLicenseCollection xmlns="http://www.spdx.org/license">
+  <license licenseId="AGPL-3.0" isOsiApproved="true"
+  name="GNU Affero General Public License v3.0">
+    <crossRefs>
+      <crossRef>http://www.gnu.org/licenses/agpl.txt</crossRef>
+      <crossRef>http://www.opensource.org/licenses/AGPL-3.0</crossRef>
+    </crossRefs>
+    <standardLicenseHeader>
+      Copyright (C)<alt name="copyright" match=".+">[year] [name of author]</alt>
+      This program is free software: you can redistribute it and/or modify it
+      under the terms of the GNU Affero General Public License as published
+      by the Free Software Foundation, version 3. This program is distributed
+      in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+      even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+      PURPOSE. See the GNU Affero General Public License for more details.
+      You should have received a copy of the GNU Affero General Public License
+      along with this program. If not, see
+      &lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;
+    </standardLicenseHeader>
+    <notes>
+      This version was released: 19 November 2007
+    </notes>
+    <titleText>
+      <p>
+        GNU AFFERO GENERAL PUBLIC LICENSE<br></br>
+        Version 3, 19 November 2007
+      </p>
+    </titleText>
+    <p>
+      Copyright (C) 2007 Free Software Foundation, Inc.
+      &lt;http<optional>s</optional>://fsf.org/&gt;
+    </p>
+    <p>
+      Everyone is permitted to copy and distribute verbatim copies
+      of this license document, but changing it is not allowed.
+    </p>
+    <p>
+      Preamble
+    </p>
+    <p>
+      The GNU Affero General Public License is a free, copyleft license for
+      software and other kinds of works, specifically designed to ensure
+      cooperation with the community in the case of network server software.
+    </p>
+    <p>
+      The licenses for most software and other practical works are
+      designed to take away your freedom to share and change the
+      works. By contrast, our General Public Licenses are intended
+      to guarantee your freedom to share and change all versions of a
+      program--to make sure it remains free software for all its users.
+    </p>
+    <p>
+      When we speak of free software, we are referring to freedom, not
+      price. Our General Public Licenses are designed to make sure that you
+      have the freedom to distribute copies of free software (and charge
+      for them if you wish), that you receive source code or can get it
+      if you want it, that you can change the software or use pieces of
+      it in new free programs, and that you know you can do these things.
+    </p>
+    <p>
+      Developers that use our General Public Licenses protect
+      your rights with two steps: (1) assert copyright on the
+      software, and (2) offer you this License which gives you legal
+      permission to copy, distribute and/or modify the software.
+    </p>
+    <p>
+      A secondary benefit of defending all users' freedom is that improvements
+      made in alternate versions of the program, if they receive widespread
+      use, become available for other developers to incorporate. Many
+      developers of free software are heartened and encouraged by the
+      resulting cooperation. However, in the case of software used on network
+      servers, this result may fail to come about. The GNU General Public
+      License permits making a modified version and letting the public access
+      it on a server without ever releasing its source code to the public.
+    </p>
+    <p>
+      The GNU Affero General Public License is designed specifically
+      to ensure that, in such cases, the modified source code becomes
+      available to the community. It requires the operator of a
+      network server to provide the source code of the modified version
+      running there to the users of that server. Therefore, public use
+      of a modified version, on a publicly accessible server, gives
+      the public access to the source code of the modified version.
+    </p>
+    <p>
+      An older license, called the Affero General Public License and published
+      by Affero, was designed to accomplish similar goals. This is a different
+      license, not a version of the Affero GPL, but Affero has released a new
+      version of the Affero GPL which permits relicensing under this license.
+    </p>
+    <p>
+      The precise terms and conditions for copying,
+      distribution and modification follow.
+    </p>
+    <p>
+      TERMS AND CONDITIONS
+    </p>
+    <list>
+      <item>
+        <bullet>0.</bullet>
+        Definitions.
+        <p>
+          "This License" refers to version 3 of
+          the GNU Affero General Public License.
+        </p>
+        <p>
+          "Copyright" also means copyright-like laws that apply
+          to other kinds of works, such as semiconductor masks.
+        </p>
+        <p>
+          "The Program" refers to any copyrightable work licensed under
+          this License. Each licensee is addressed as "you". "Licensees"
+          and "recipients" may be individuals or organizations.
+        </p>
+        <p>
+          To "modify" a work means to copy from or adapt all or part of the
+          work in a fashion requiring copyright permission, other than the
+          making of an exact copy. The resulting work is called a "modified
+          version" of the earlier work or a work "based on" the earlier work.
+        </p>
+        <p>
+          A "covered work" means either the unmodified
+          Program or a work based on the Program.
+        </p>
+        <p>
+          To "propagate" a work means to do anything with it that, without
+          permission, would make you directly or secondarily liable for
+          infringement under applicable copyright law, except executing it
+          on a computer or modifying a private copy. Propagation includes
+          copying, distribution (with or without modification), making available
+          to the public, and in some countries other activities as well.
+        </p>
+        <p>
+          To "convey" a work means any kind of propagation
+          that enables other parties to make or receive copies.
+          Mere interaction with a user through a computer
+          network, with no transfer of a copy, is not conveying.
+        </p>
+        <p>
+          An interactive user interface displays "Appropriate Legal Notices"
+          to the extent that it includes a convenient and prominently visible
+          feature that (1) displays an appropriate copyright notice, and (2)
+          tells the user that there is no warranty for the work (except to
+          the extent that warranties are provided), that licensees may convey
+          the work under this License, and how to view a copy of this License.
+          If the interface presents a list of user commands or options,
+          such as a menu, a prominent item in the list meets this criterion.
+        </p>
+      </item>
+      <item>
+        <bullet>1.</bullet>
+        Source Code.<br></br>
+        The "source code" for a work means the preferred
+        form of the work for making modifications to it.
+        "Object code" means any non-source form of a work.
+        <p>
+          A "Standard Interface" means an interface that either is an official
+          standard defined by a recognized standards body, or, in the case
+          of interfaces specified for a particular programming language,
+          one that is widely used among developers working in that language.
+        </p>
+        <p>
+          The "System Libraries" of an executable work include anything, other
+          than the work as a whole, that (a) is included in the normal form
+          of packaging a Major Component, but which is not part of that Major
+          Component, and (b) serves only to enable use of the work with that
+          Major Component, or to implement a Standard Interface for which an
+          implementation is available to the public in source code form. A
+          "Major Component", in this context, means a major essential component
+          (kernel, window system, and so on) of the specific operating system
+          (if any) on which the executable work runs, or a compiler used to
+          produce the work, or an object code interpreter used to run it.
+        </p>
+        <p>
+          The "Corresponding Source" for a work in object code form means
+          all the source code needed to generate, install, and (for an
+          executable work) run the object code and to modify the work,
+          including scripts to control those activities. However, it does
+          not include the work's System Libraries, or general-purpose tools
+          or generally available free programs which are used unmodified in
+          performing those activities but which are not part of the work.
+          For example, Corresponding Source includes interface definition
+          files associated with source files for the work, and the source
+          code for shared libraries and dynamically linked subprograms
+          that the work is specifically designed to require, such as by
+          intimate data communication or control flow between those<br></br>
+          subprograms and other parts of the work.
+        </p>
+        <p>
+          The Corresponding Source need not include anything that users can
+          regenerate automatically from other parts of the Corresponding Source.
+        </p>
+        <p>
+          The Corresponding Source for a work
+          in source code form is that same work.
+        </p>
+      </item>
+      <item>
+        <bullet>2.</bullet>
+        Basic Permissions.<br></br>
+        All rights granted under this License are granted for the term of
+        copyright on the Program, and are irrevocable provided the stated
+        conditions are met. This License explicitly affirms your unlimited
+        permission to run the unmodified Program. The output from running a
+        covered work is covered by this License only if the output, given its
+        content, constitutes a covered work. This License acknowledges your
+        rights of fair use or other equivalent, as provided by copyright law.
+        <p>
+          You may make, run and propagate covered works that you do not convey,
+          without conditions so long as your license otherwise remains in force.
+          You may convey covered works to others for the sole purpose of having
+          them make modifications exclusively for you, or provide you with
+          facilities for running those works, provided that you comply with
+          the terms of this License in conveying all material for which you do
+          not control copyright. Those thus making or running the covered works
+          for you must do so exclusively on your behalf, under your direction
+          and control, on terms that prohibit them from making any copies
+          of your copyrighted material outside their relationship with you.
+        </p>
+        <p>
+          Conveying under any other circumstances is permitted
+          solely under the conditions stated below. Sublicensing
+          is not allowed; section 10 makes it unnecessary.
+        </p>
+      </item>
+      <item>
+        <bullet>3.</bullet>
+        Protecting Users' Legal Rights From Anti-Circumvention Law.<br></br>
+        No covered work shall be deemed part of an effective technological
+        measure under any applicable law fulfilling obligations under article
+        11 of the WIPO copyright treaty adopted on 20 December 1996, or
+        similar laws prohibiting or restricting circumvention of such measures.
+        <p>
+          When you convey a covered work, you waive any legal power to
+          forbid circumvention of technological measures to the extent
+          such circumvention is effected by exercising rights under this
+          License with respect to the covered work, and you disclaim any
+          intention to limit operation or modification of the work as a means
+          of enforcing, against the work's users, your or third parties'
+          legal rights to forbid circumvention of technological measures.
+        </p>
+      </item>
+      <item>
+        <bullet>4.</bullet>
+        Conveying Verbatim Copies.<br></br>
+        You may convey verbatim copies of the Program's source code as
+        you receive it, in any medium, provided that you conspicuously
+        and appropriately publish on each copy an appropriate copyright
+        notice; keep intact all notices stating that this License and any
+        non-permissive terms added in accord with section 7 apply to the
+        code; keep intact all notices of the absence of any warranty; and
+        give all recipients a copy of this License along with the Program.
+        <p>
+          You may charge any price or no price for each copy that you
+          convey, and you may offer support or warranty protection for a fee.
+        </p>
+      </item>
+      <item>
+        <bullet>5.</bullet>
+        Conveying Modified Source Versions.<br></br>
+        You may convey a work based on the Program, or the modifications to
+        produce it from the Program, in the form of source code under the terms
+        of section 4, provided that you also meet all of these conditions:
+        <list>
+          <item>
+            <bullet>a)</bullet>
+            The work must carry prominent notices stating
+            that you modified it, and giving a relevant date.
+          </item>
+          <item>
+            <bullet>b)</bullet>
+            The work must carry prominent notices stating that
+            it is released under this License and any conditions
+            added under section 7. This requirement modifies the
+            requirement in section 4 to "keep intact all notices".
+          </item>
+          <item>
+            <bullet>c)</bullet>
+            You must license the entire work, as a whole, under this License
+            to anyone who comes into possession of a copy. This License
+            will therefore apply, along with any applicable section 7
+            additional terms, to the whole of the work, and all its parts,
+            regardless of how they are packaged. This License gives no
+            permission to license the work in any other way, but it does not
+            invalidate such permission if you have separately received it.
+          </item>
+          <item>
+            <bullet>d)</bullet>
+            If the work has interactive user interfaces, each must
+            display Appropriate Legal Notices; however, if the Program
+            has interactive interfaces that do not display Appropriate
+            Legal Notices, your work need not make them do so.
+          </item>
+        </list>
+        <p>
+          A compilation of a covered work with other separate and independent
+          works, which are not by their nature extensions of the covered
+          work, and which are not combined with it such as to form a larger
+          program, in or on a volume of a storage or distribution medium,
+          is called an "aggregate" if the compilation and its resulting
+          copyright are not used to limit the access or legal rights
+          of the compilation's users beyond what the individual works
+          permit. Inclusion of a covered work in an aggregate does not
+          cause this License to apply to the other parts of the aggregate.
+        </p>
+      </item>
+      <item>
+        <bullet>6.</bullet>
+        Conveying Non-Source Forms.<br></br>
+        You may convey a covered work in object code form
+        under the terms of sections 4 and 5, provided that you
+        also convey the machine-readable Corresponding Source
+        under the terms of this License, in one of these ways:
+        <list>
+          <item>
+            <bullet>a)</bullet>
+            Convey the object code in, or embodied in, a physical
+            product (including a physical distribution medium),
+            accompanied by the Corresponding Source fixed on a durable
+            physical medium customarily used for software interchange.
+          </item>
+          <item>
+            <bullet>b)</bullet>
+            Convey the object code in, or embodied in, a physical product
+            (including a physical distribution medium), accompanied by a
+            written offer, valid for at least three years and valid for
+            as long as you offer spare parts or customer support for that
+            product model, to give anyone who possesses the object code
+            either (1) a copy of the Corresponding Source for all the software
+            in the product that is covered by this License, on a durable
+            physical medium customarily used for software interchange,
+            for a price no more than your reasonable cost of physically
+            performing this conveying of source, or (2) access to copy
+            the Corresponding Source from a network server at no charge.
+          </item>
+          <item>
+            <bullet>c)</bullet>
+            Convey individual copies of the object code with a
+            copy of the written offer to provide the Corresponding
+            Source. This alternative is allowed only occasionally
+            and noncommercially, and only if you received the object
+            code with such an offer, in accord with subsection 6b.
+          </item>
+          <item>
+            <bullet>d)</bullet>
+            Convey the object code by offering access from a designated place
+            (gratis or for a charge), and offer equivalent access to the
+            Corresponding Source in the same way through the same place at
+            no further charge. You need not require recipients to copy the
+            Corresponding Source along with the object code. If the place
+            to copy the object code is a network server, the Corresponding
+            Source may be on a different server (operated by you or a third
+            party) that supports equivalent copying facilities, provided you
+            maintain clear directions next to the object code saying where
+            to find the Corresponding Source. Regardless of what server hosts
+            the Corresponding Source, you remain obligated to ensure that it
+            is available for as long as needed to satisfy these requirements.
+          </item>
+          <item>
+            <bullet>e)</bullet>
+            Convey the object code using peer-to-peer transmission,
+            provided you inform other peers where the object code
+            and Corresponding Source of the work are being offered
+            to the general public at no charge under subsection 6d.
+          </item>
+        </list>
+        <p>
+          A separable portion of the object code, whose source code is
+          excluded from the Corresponding Source as a System Library,
+          need not be included in conveying the object code work.
+        </p>
+        <p>
+          A "User Product" is either (1) a "consumer product", which means
+          any tangible personal property which is normally used for personal,
+          family, or household purposes, or (2) anything designed or sold
+          for incorporation into a dwelling. In determining whether a product
+          is a consumer product, doubtful cases shall be resolved in favor
+          of coverage. For a particular product received by a particular
+          user, "normally used" refers to a typical or common use of that
+          class of product, regardless of the status of the particular
+          user or of the way in which the particular user actually uses,
+          or expects or is expected to use, the product. A product is a
+          consumer product regardless of whether the product has substantial
+          commercial, industrial or non-consumer uses, unless such uses
+          represent the only significant mode of use of the product.
+        </p>
+        <p>
+          "Installation Information" for a User Product means any methods,
+          procedures, authorization keys, or other information required
+          to install and execute modified versions of a covered work in
+          that User Product from a modified version of its Corresponding
+          Source. The information must suffice to ensure that the continued
+          functioning of the modified object code is in no case prevented
+          or interfered with solely because modification has been made.
+        </p>
+        <p>
+          If you convey an object code work under this section in, or with,
+          or specifically for use in, a User Product, and the conveying
+          occurs as part of a transaction in which the right of possession
+          and use of the User Product is transferred to the recipient in
+          perpetuity or for a fixed term (regardless of how the transaction
+          is characterized), the Corresponding Source conveyed under this
+          section must be accompanied by the Installation Information.
+          But this requirement does not apply if neither you nor any third
+          party retains the ability to install modified object code on the
+          User Product (for example, the work has been installed in ROM).
+        </p>
+        <p>
+          The requirement to provide Installation Information does not
+          include a requirement to continue to provide support service,
+          warranty, or updates for a work that has been modified
+          or installed by the recipient, or for the User Product in
+          which it has been modified or installed. Access to a network
+          may be denied when the modification itself materially and
+          adversely affects the operation of the network or violates
+          the rules and protocols for communication across the network.
+        </p>
+        <p>
+          Corresponding Source conveyed, and Installation Information
+          provided, in accord with this section must be in a format that
+          is publicly documented (and with an implementation available
+          to the public in source code form), and must require no
+          special password or key for unpacking, reading or copying.
+        </p>
+      </item>
+      <item>
+        <bullet>7.</bullet>
+        Additional Terms.<br></br>
+        "Additional permissions" are terms that supplement the terms of this
+        License by making exceptions from one or more of its conditions.
+        Additional permissions that are applicable to the entire Program
+        shall be treated as though they were included in this License, to
+        the extent that they are valid under applicable law. If additional
+        permissions apply only to part of the Program, that part may be used
+        separately under those permissions, but the entire Program remains
+        governed by this License without regard to the additional permissions.
+        <p>
+          When you convey a copy of a covered work, you may at your option
+          remove any additional permissions from that copy, or from any part
+          of it. (Additional permissions may be written to require their own
+          removal in certain cases when you modify the work.) You may place
+          additional permissions on material, added by you to a covered work,
+          for which you have or can give appropriate copyright permission.
+        </p>
+        <p>
+          Notwithstanding any other provision of this License, for material you
+          add to a covered work, you may (if authorized by the copyright holders
+          of that material) supplement the terms of this License with terms:
+        </p>
+        <list>
+          <item>
+            <bullet>a)</bullet>
+            Disclaiming warranty or limiting liability differently
+            from the terms of sections 15 and 16 of this License; or
+          </item>
+          <item>
+            <bullet>b)</bullet>
+            Requiring preservation of specified reasonable legal
+            notices or author attributions in that material or in the
+            Appropriate Legal Notices displayed by works containing it; or
+          </item>
+          <item>
+            <bullet>c)</bullet>
+            Prohibiting misrepresentation of the origin of that material,
+            or requiring that modified versions of such material be marked
+            in reasonable ways as different from the original version; or
+          </item>
+          <item>
+            <bullet>d)</bullet>
+            Limiting the use for publicity purposes of names
+            of licensors or authors of the material; or
+          </item>
+          <item>
+            <bullet>e)</bullet>
+            Declining to grant rights under trademark law for use
+            of some trade names, trademarks, or service marks; or
+          </item>
+          <item>
+            <bullet>f)</bullet>
+            Requiring indemnification of licensors and authors of that
+            material by anyone who conveys the material (or modified
+            versions of it) with contractual assumptions of liability
+            to the recipient, for any liability that these contractual
+            assumptions directly impose on those licensors and authors.
+          </item>
+        </list>
+        <p>
+          All other non-permissive additional terms are considered "further
+          restrictions" within the meaning of section 10. If the Program
+          as you received it, or any part of it, contains a notice stating
+          that it is governed by this License along with a term that is
+          a further restriction, you may remove that term. If a license
+          document contains a further restriction but permits relicensing or
+          conveying under this License, you may add to a covered work material
+          governed by the terms of that license document, provided that the
+          further restriction does not survive such relicensing or conveying.
+        </p>
+        <p>
+          If you add terms to a covered work in accord with this
+          section, you must place, in the relevant source files, a
+          statement of the additional terms that apply to those files,
+          or a notice indicating where to find the applicable terms.
+        </p>
+        <p>
+          Additional terms, permissive or non-permissive, may be
+          stated in the form of a separately written license, or stated
+          as exceptions; the above requirements apply either way.
+        </p>
+      </item>
+      <item>
+        <bullet>8.</bullet>
+        Termination.
+        <p>
+          You may not propagate or modify a covered work except as
+          expressly provided under this License. Any attempt otherwise
+          to propagate or modify it is void, and will automatically
+          terminate your rights under this License (including any patent
+          licenses granted under the third paragraph of section 11).
+        </p>
+        <p>
+          However, if you cease all violation of this License, then your
+          license from a particular copyright holder is reinstated (a)
+          provisionally, unless and until the copyright holder explicitly
+          and finally terminates your license, and (b) permanently, if
+          the copyright holder fails to notify you of the violation by
+          some reasonable means prior to 60 days after the cessation.
+        </p>
+        <p>
+          Moreover, your license from a particular copyright holder is
+          reinstated permanently if the copyright holder notifies you
+          of the violation by some reasonable means, this is the first
+          time you have received notice of violation of this License
+          (for any work) from that copyright holder, and you cure the
+          violation prior to 30 days after your receipt of the notice.
+        </p>
+        <p>
+          Termination of your rights under this section does not
+          terminate the licenses of parties who have received copies or
+          rights from you under this License. If your rights have been
+          terminated and not permanently reinstated, you do not qualify
+          to receive new licenses for the same material under section 10.
+        </p>
+      </item>
+      <item>
+        <bullet>9.</bullet>
+        Acceptance Not Required for Having Copies.
+        <p>
+          You are not required to accept this License in order to receive or
+          run a copy of the Program. Ancillary propagation of a covered work
+          occurring solely as a consequence of using peer-to-peer transmission
+          to receive a copy likewise does not require acceptance. However,
+          nothing other than this License grants you permission to propagate
+          or modify any covered work. These actions infringe copyright if you
+          do not accept this License. Therefore, by modifying or propagating a
+          covered work, you indicate your acceptance of this License to do so.
+        </p>
+      </item>
+      <item>
+        <bullet>10.</bullet>
+        Automatic Licensing of Downstream Recipients.
+        <p>
+          Each time you convey a covered work, the recipient automatically
+          receives a license from the original licensors, to run, modify and
+          propagate that work, subject to this License. You are not responsible
+          for enforcing compliance by third parties with this License.
+        </p>
+        <p>
+          An "entity transaction" is a transaction transferring control of
+          an organization, or substantially all assets of one, or subdividing
+          an organization, or merging organizations. If propagation of a
+          covered work results from an entity transaction, each party to that
+          transaction who receives a copy of the work also receives whatever
+          licenses to the work the party's predecessor in interest had or could
+          give under the previous paragraph, plus a right to possession of the
+          Corresponding Source of the work from the predecessor in interest,
+          if the predecessor has it or can get it with reasonable efforts.
+        </p>
+        <p>
+          You may not impose any further restrictions on the exercise of the
+          rights granted or affirmed under this License. For example, you
+          may not impose a license fee, royalty, or other charge for exercise
+          of rights granted under this License, and you may not initiate
+          litigation (including a cross-claim or counterclaim in a lawsuit)
+          alleging that any patent claim is infringed by making, using, selling,
+          offering for sale, or importing the Program or any portion of it.
+        </p>
+      </item>
+      <item>
+        <bullet>11.</bullet>
+        Patents.
+        <p>
+          A "contributor" is a copyright holder who authorizes use under this
+          License of the Program or a work on which the Program is based. The
+          work thus licensed is called the contributor's "contributor version".
+        </p>
+        <p>
+          A contributor's "essential patent claims" are all patent
+          claims owned or controlled by the contributor, whether already
+          acquired or hereafter acquired, that would be infringed by some
+          manner, permitted by this License, of making, using, or selling
+          its contributor version, but do not include claims that would
+          be infringed only as a consequence of further modification
+          of the contributor version. For purposes of this definition,
+          "control" includes the right to grant patent sublicenses in
+          a manner consistent with the requirements of this License.
+        </p>
+        <p>
+          Each contributor grants you a non-exclusive, worldwide, royalty-free
+          patent license under the contributor's essential patent claims,
+          to make, use, sell, offer for sale, import and otherwise run,
+          modify and propagate the contents of its contributor version.
+        </p>
+        <p>
+          In the following three paragraphs, a "patent license" is any
+          express agreement or commitment, however denominated, not to
+          enforce a patent (such as an express permission to practice
+          a patent or covenant not to s ue for patent infringement). To
+          "grant" such a patent license to a party means to make such an
+          agreement or commitment not to enforce a patent against the party.
+        </p>
+        <p>
+          If you convey a covered work, knowingly relying on a patent
+          license, and the Corresponding Source of the work is not available
+          for anyone to copy, free of charge and under the terms of this
+          License, through a publicly available network server or other
+          readily accessible means, then you must either (1) cause the
+          Corresponding Source to be so available, or (2) arrange to
+          deprive yourself of the benefit of the patent license for this
+          particular work, or (3) arrange, in a manner consistent with
+          the requirements of this License, to extend the patent<br></br>
+          license to downstream recipients. "Knowingly relying" means you have
+          actual knowledge that, but for the patent license, your conveying
+          the covered work in a country, or your recipient's use of the
+          covered work in a country, would infringe one or more identifiable
+          patents in that country that you have reason to believe are valid.
+        </p>
+        <p>
+          If, pursuant to or in connection with a single transaction or
+          arrangement, you convey, or propagate by procuring conveyance
+          of, a covered work, and grant a patent license to some of the
+          parties receiving the covered work authorizing them to use,
+          propagate, modify or convey a specific copy of the covered work,
+          then the patent license you grant is automatically extended
+          to all recipients of the covered work and works based on it.
+        </p>
+        <p>
+          A patent license is "discriminatory" if it does not include within the
+          scope of its coverage, prohibits the exercise of, or is conditioned
+          on the non-exercise of one or more of the rights that are specifically
+          granted under this License. You may not convey a covered work if
+          you are a party to an arrangement with a third party that is in the
+          business of distributing software, under which you make payment to
+          the third party based on the extent of your activity of conveying
+          the work, and under which the third party grants, to any of the
+          parties who would receive the covered work from you, a discriminatory
+          patent license (a) in connection with copies of the covered work
+          conveyed by you (or copies made from those copies), or (b) primarily
+          for and in connection with specific products or compilations that
+          contain the covered work, unless you entered into that arrangement,
+          or that patent license was granted, prior to 28 March 2007.
+        </p>
+        <p>
+          Nothing in this License shall be construed as excluding or
+          limiting any implied license or other defenses to infringement
+          that may otherwise be available to you under applicable patent law.
+        </p>
+      </item>
+      <item>
+        <bullet>12.</bullet>
+        No Surrender of Others' Freedom.
+        <p>
+          If conditions are imposed on you (whether by court order,
+          agreement or otherwise) that contradict the conditions of this
+          License, they do not excuse you from the conditions of this
+          License. If you cannot convey a covered work so as to satisfy
+          simultaneously your obligations under this License and any other
+          pertinent obligations, then as a consequence you may<br></br>
+          not convey it at all. For example, if you agree to terms
+          that obligate you to collect a royalty for further conveying
+          from those to whom you convey the Program, the only
+          way you could satisfy both those terms and this License
+          would be to refrain entirely from conveying the Program.
+        </p>
+      </item>
+      <item>
+        <bullet>13.</bullet>
+        Remote Network Interaction; Use with the GNU General Public License.
+        <p>
+          Notwithstanding any other provision of this License, if you modify
+          the Program, your modified version must prominently offer all users
+          interacting with it remotely through a computer network (if your
+          version supports such interaction) an opportunity to receive the
+          Corresponding Source of your version by providing access to the
+          Corresponding Source from a network server at no charge, through
+          some standard or customary means of facilitating copying of
+          software. This Corresponding Source shall include the Corresponding
+          Source for any work covered by version 3 of the GNU General Public
+          License that is incorporated pursuant to the following paragraph.
+        </p>
+        <p>
+          Notwithstanding any other provision of this License, you have
+          permission to link or combine any covered work with a work
+          licensed under version 3 of the GNU General Public License into
+          a single combined work, and to convey the resulting work. The
+          terms of this License will continue to apply to the part which
+          is the covered work, but the work with which it is combined will
+          remain governed by version 3 of the GNU General Public License.
+        </p>
+      </item>
+      <item>
+        <bullet>14.</bullet>
+        Revised Versions of this License.
+        <p>
+          The Free Software Foundation may publish revised and/or new versions
+          of the GNU Affero General Public License from time to time. Such
+          new versions will be similar in spirit to the present version,
+          but may differ in detail to address new problems or concerns.
+        </p>
+        <p>
+          Each version is given a distinguishing version number. If the
+          Program specifies that a certain numbered version of the GNU
+          Affero General Public License "or any later version" applies to
+          it, you have the option of following the terms and conditions
+          either of that numbered version or of any later version published
+          by the Free Software Foundation. If the Program does not specify
+          a version number of the GNU Affero General Public License, you may
+          choose any version ever published by the Free Software Foundation.
+        </p>
+        <p>
+          If the Program specifies that a proxy can decide which future
+          versions of the GNU Affero General Public License can be
+          used, that proxy's public statement of acceptance of a version
+          permanently authorizes you to choose that version for the Program.
+        </p>
+        <p>
+          Later license versions may give you additional or
+          different permissions. However, no additional obligations
+          are imposed on any author or copyright holder as a
+          result of your choosing to follow a later version.
+        </p>
+      </item>
+      <item>
+        <bullet>15.</bullet>
+        Disclaimer of Warranty.
+        <p>
+          THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED
+          BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING
+          THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM
+          "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR
+          IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+          OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+          ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+          IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME
+          THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+        </p>
+      </item>
+      <item>
+        <bullet>16.</bullet>
+        Limitation of Liability.
+        <p>
+          IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+          WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR
+          CONVEYS THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+          INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES
+          ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING
+          BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE
+          OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE
+          PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER
+          OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+        </p>
+      </item>
+      <item>
+        <bullet>17.</bullet>
+        Interpretation of Sections 15 and 16.
+      </item>
+    </list>
+    <p>
+      If the disclaimer of warranty and limitation of liability
+      provided above cannot be given local legal effect according to
+      their terms, reviewing courts shall apply local law that most
+      closely approximates an absolute waiver of all civil liability in
+      connection with the Program, unless a warranty or assumption of
+      liability accompanies a copy of the Program in return for a fee.
+    </p>
+    <optional>
+      <p>
+        END OF TERMS AND CONDITIONS
+      </p>
+      <p>
+        How to Apply These Terms to Your New Programs
+      </p>
+      <p>
+        If you develop a new program, and you want it to be
+        of the greatest possible use to the public, the best
+        way to achieve this is to make it free software which
+        everyone can redistribute and change under these terms.
+      </p>
+      <p>
+        To do so, attach the following notices to the program. It is safest
+        to attach them to the start of each source file to most effectively
+        state the exclusion of warranty; and each file should have at least
+        the "copyright" line and a pointer to where the full notice is found.
+      </p>
+      <p>
+        &lt;one line to give the program's name and
+        a brief idea of what it does.&gt;<br></br>
+        Copyright (C) &lt;year&gt; &lt;name of author&gt;
+      </p>
+      <p>
+        This program is free software: you can redistribute it and/or
+        modify it under the terms of the GNU Affero General Public
+        License as published by the Free Software Foundation, either
+        version 3 of the License, or (at your option) any later version.
+      </p>
+      <p>
+        This program is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty
+        of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+        See the GNU Affero General Public License for more details.
+      </p>
+      <p>
+        You should have received a copy of the GNU Affero General
+	Public License along with this program. If not, see
+	&lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.
+      </p>
+      <p>
+        Also add information on how to contact you by electronic and paper mail.
+      </p>
+      <p>
+        If your software can interact with users remotely through a
+        computer network, you should also make sure that it provides a
+        way for users to get its source. For example, if your program is
+        a web application, its interface could display a "Source" link
+        that leads users to an archive of the code. There are many ways
+        you could offer source, and different solutions will be better for
+        different programs; see section 13 for the specific requirements.
+      </p>
+      <p>
+        You should also get your employer (if you work as a programmer)
+        or school, if any, to sign a "copyright disclaimer" for
+        the program, if necessary. For more information on this,
+	and how to apply and follow the GNU AGPL, see
+	&lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.
+      </p>
+    </optional>
+  </license>
+</SPDXLicenseCollection>

--- a/src/AGPL-3.0-or-later.xml
+++ b/src/AGPL-3.0-or-later.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-  <license licenseId="AGPL-3.0" isOsiApproved="true"
-  name="GNU Affero General Public License v3.0">
+  <license licenseId="AGPL-3.0-or-later" isOsiApproved="true"
+  name="GNU Affero General Public License v3.0 or later">
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/agpl.txt</crossRef>
       <crossRef>http://www.opensource.org/licenses/AGPL-3.0</crossRef>

--- a/src/AGPL-3.0-or-later.xml
+++ b/src/AGPL-3.0-or-later.xml
@@ -1,0 +1,848 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SPDXLicenseCollection xmlns="http://www.spdx.org/license">
+  <license licenseId="AGPL-3.0" isOsiApproved="true"
+  name="GNU Affero General Public License v3.0">
+    <crossRefs>
+      <crossRef>http://www.gnu.org/licenses/agpl.txt</crossRef>
+      <crossRef>http://www.opensource.org/licenses/AGPL-3.0</crossRef>
+    </crossRefs>
+    <standardLicenseHeader>
+      Copyright (C)<alt name="copyright" match=".+">[year] [name of author]</alt>
+      This program is free software: you can redistribute it and/or modify it
+      under the terms of the GNU Affero General Public License as published
+      by the Free Software Foundation, version 3. This program is distributed
+      in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+      even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+      PURPOSE. See the GNU Affero General Public License for more details.
+      You should have received a copy of the GNU Affero General Public License
+      along with this program. If not, see
+      &lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;
+    </standardLicenseHeader>
+    <notes>
+      This version was released: 19 November 2007
+    </notes>
+    <titleText>
+      <p>
+        GNU AFFERO GENERAL PUBLIC LICENSE<br></br>
+        Version 3, 19 November 2007
+      </p>
+    </titleText>
+    <p>
+      Copyright (C) 2007 Free Software Foundation, Inc.
+      &lt;http<optional>s</optional>://fsf.org/&gt;
+    </p>
+    <p>
+      Everyone is permitted to copy and distribute verbatim copies
+      of this license document, but changing it is not allowed.
+    </p>
+    <p>
+      Preamble
+    </p>
+    <p>
+      The GNU Affero General Public License is a free, copyleft license for
+      software and other kinds of works, specifically designed to ensure
+      cooperation with the community in the case of network server software.
+    </p>
+    <p>
+      The licenses for most software and other practical works are
+      designed to take away your freedom to share and change the
+      works. By contrast, our General Public Licenses are intended
+      to guarantee your freedom to share and change all versions of a
+      program--to make sure it remains free software for all its users.
+    </p>
+    <p>
+      When we speak of free software, we are referring to freedom, not
+      price. Our General Public Licenses are designed to make sure that you
+      have the freedom to distribute copies of free software (and charge
+      for them if you wish), that you receive source code or can get it
+      if you want it, that you can change the software or use pieces of
+      it in new free programs, and that you know you can do these things.
+    </p>
+    <p>
+      Developers that use our General Public Licenses protect
+      your rights with two steps: (1) assert copyright on the
+      software, and (2) offer you this License which gives you legal
+      permission to copy, distribute and/or modify the software.
+    </p>
+    <p>
+      A secondary benefit of defending all users' freedom is that improvements
+      made in alternate versions of the program, if they receive widespread
+      use, become available for other developers to incorporate. Many
+      developers of free software are heartened and encouraged by the
+      resulting cooperation. However, in the case of software used on network
+      servers, this result may fail to come about. The GNU General Public
+      License permits making a modified version and letting the public access
+      it on a server without ever releasing its source code to the public.
+    </p>
+    <p>
+      The GNU Affero General Public License is designed specifically
+      to ensure that, in such cases, the modified source code becomes
+      available to the community. It requires the operator of a
+      network server to provide the source code of the modified version
+      running there to the users of that server. Therefore, public use
+      of a modified version, on a publicly accessible server, gives
+      the public access to the source code of the modified version.
+    </p>
+    <p>
+      An older license, called the Affero General Public License and published
+      by Affero, was designed to accomplish similar goals. This is a different
+      license, not a version of the Affero GPL, but Affero has released a new
+      version of the Affero GPL which permits relicensing under this license.
+    </p>
+    <p>
+      The precise terms and conditions for copying,
+      distribution and modification follow.
+    </p>
+    <p>
+      TERMS AND CONDITIONS
+    </p>
+    <list>
+      <item>
+        <bullet>0.</bullet>
+        Definitions.
+        <p>
+          "This License" refers to version 3 of
+          the GNU Affero General Public License.
+        </p>
+        <p>
+          "Copyright" also means copyright-like laws that apply
+          to other kinds of works, such as semiconductor masks.
+        </p>
+        <p>
+          "The Program" refers to any copyrightable work licensed under
+          this License. Each licensee is addressed as "you". "Licensees"
+          and "recipients" may be individuals or organizations.
+        </p>
+        <p>
+          To "modify" a work means to copy from or adapt all or part of the
+          work in a fashion requiring copyright permission, other than the
+          making of an exact copy. The resulting work is called a "modified
+          version" of the earlier work or a work "based on" the earlier work.
+        </p>
+        <p>
+          A "covered work" means either the unmodified
+          Program or a work based on the Program.
+        </p>
+        <p>
+          To "propagate" a work means to do anything with it that, without
+          permission, would make you directly or secondarily liable for
+          infringement under applicable copyright law, except executing it
+          on a computer or modifying a private copy. Propagation includes
+          copying, distribution (with or without modification), making available
+          to the public, and in some countries other activities as well.
+        </p>
+        <p>
+          To "convey" a work means any kind of propagation
+          that enables other parties to make or receive copies.
+          Mere interaction with a user through a computer
+          network, with no transfer of a copy, is not conveying.
+        </p>
+        <p>
+          An interactive user interface displays "Appropriate Legal Notices"
+          to the extent that it includes a convenient and prominently visible
+          feature that (1) displays an appropriate copyright notice, and (2)
+          tells the user that there is no warranty for the work (except to
+          the extent that warranties are provided), that licensees may convey
+          the work under this License, and how to view a copy of this License.
+          If the interface presents a list of user commands or options,
+          such as a menu, a prominent item in the list meets this criterion.
+        </p>
+      </item>
+      <item>
+        <bullet>1.</bullet>
+        Source Code.<br></br>
+        The "source code" for a work means the preferred
+        form of the work for making modifications to it.
+        "Object code" means any non-source form of a work.
+        <p>
+          A "Standard Interface" means an interface that either is an official
+          standard defined by a recognized standards body, or, in the case
+          of interfaces specified for a particular programming language,
+          one that is widely used among developers working in that language.
+        </p>
+        <p>
+          The "System Libraries" of an executable work include anything, other
+          than the work as a whole, that (a) is included in the normal form
+          of packaging a Major Component, but which is not part of that Major
+          Component, and (b) serves only to enable use of the work with that
+          Major Component, or to implement a Standard Interface for which an
+          implementation is available to the public in source code form. A
+          "Major Component", in this context, means a major essential component
+          (kernel, window system, and so on) of the specific operating system
+          (if any) on which the executable work runs, or a compiler used to
+          produce the work, or an object code interpreter used to run it.
+        </p>
+        <p>
+          The "Corresponding Source" for a work in object code form means
+          all the source code needed to generate, install, and (for an
+          executable work) run the object code and to modify the work,
+          including scripts to control those activities. However, it does
+          not include the work's System Libraries, or general-purpose tools
+          or generally available free programs which are used unmodified in
+          performing those activities but which are not part of the work.
+          For example, Corresponding Source includes interface definition
+          files associated with source files for the work, and the source
+          code for shared libraries and dynamically linked subprograms
+          that the work is specifically designed to require, such as by
+          intimate data communication or control flow between those<br></br>
+          subprograms and other parts of the work.
+        </p>
+        <p>
+          The Corresponding Source need not include anything that users can
+          regenerate automatically from other parts of the Corresponding Source.
+        </p>
+        <p>
+          The Corresponding Source for a work
+          in source code form is that same work.
+        </p>
+      </item>
+      <item>
+        <bullet>2.</bullet>
+        Basic Permissions.<br></br>
+        All rights granted under this License are granted for the term of
+        copyright on the Program, and are irrevocable provided the stated
+        conditions are met. This License explicitly affirms your unlimited
+        permission to run the unmodified Program. The output from running a
+        covered work is covered by this License only if the output, given its
+        content, constitutes a covered work. This License acknowledges your
+        rights of fair use or other equivalent, as provided by copyright law.
+        <p>
+          You may make, run and propagate covered works that you do not convey,
+          without conditions so long as your license otherwise remains in force.
+          You may convey covered works to others for the sole purpose of having
+          them make modifications exclusively for you, or provide you with
+          facilities for running those works, provided that you comply with
+          the terms of this License in conveying all material for which you do
+          not control copyright. Those thus making or running the covered works
+          for you must do so exclusively on your behalf, under your direction
+          and control, on terms that prohibit them from making any copies
+          of your copyrighted material outside their relationship with you.
+        </p>
+        <p>
+          Conveying under any other circumstances is permitted
+          solely under the conditions stated below. Sublicensing
+          is not allowed; section 10 makes it unnecessary.
+        </p>
+      </item>
+      <item>
+        <bullet>3.</bullet>
+        Protecting Users' Legal Rights From Anti-Circumvention Law.<br></br>
+        No covered work shall be deemed part of an effective technological
+        measure under any applicable law fulfilling obligations under article
+        11 of the WIPO copyright treaty adopted on 20 December 1996, or
+        similar laws prohibiting or restricting circumvention of such measures.
+        <p>
+          When you convey a covered work, you waive any legal power to
+          forbid circumvention of technological measures to the extent
+          such circumvention is effected by exercising rights under this
+          License with respect to the covered work, and you disclaim any
+          intention to limit operation or modification of the work as a means
+          of enforcing, against the work's users, your or third parties'
+          legal rights to forbid circumvention of technological measures.
+        </p>
+      </item>
+      <item>
+        <bullet>4.</bullet>
+        Conveying Verbatim Copies.<br></br>
+        You may convey verbatim copies of the Program's source code as
+        you receive it, in any medium, provided that you conspicuously
+        and appropriately publish on each copy an appropriate copyright
+        notice; keep intact all notices stating that this License and any
+        non-permissive terms added in accord with section 7 apply to the
+        code; keep intact all notices of the absence of any warranty; and
+        give all recipients a copy of this License along with the Program.
+        <p>
+          You may charge any price or no price for each copy that you
+          convey, and you may offer support or warranty protection for a fee.
+        </p>
+      </item>
+      <item>
+        <bullet>5.</bullet>
+        Conveying Modified Source Versions.<br></br>
+        You may convey a work based on the Program, or the modifications to
+        produce it from the Program, in the form of source code under the terms
+        of section 4, provided that you also meet all of these conditions:
+        <list>
+          <item>
+            <bullet>a)</bullet>
+            The work must carry prominent notices stating
+            that you modified it, and giving a relevant date.
+          </item>
+          <item>
+            <bullet>b)</bullet>
+            The work must carry prominent notices stating that
+            it is released under this License and any conditions
+            added under section 7. This requirement modifies the
+            requirement in section 4 to "keep intact all notices".
+          </item>
+          <item>
+            <bullet>c)</bullet>
+            You must license the entire work, as a whole, under this License
+            to anyone who comes into possession of a copy. This License
+            will therefore apply, along with any applicable section 7
+            additional terms, to the whole of the work, and all its parts,
+            regardless of how they are packaged. This License gives no
+            permission to license the work in any other way, but it does not
+            invalidate such permission if you have separately received it.
+          </item>
+          <item>
+            <bullet>d)</bullet>
+            If the work has interactive user interfaces, each must
+            display Appropriate Legal Notices; however, if the Program
+            has interactive interfaces that do not display Appropriate
+            Legal Notices, your work need not make them do so.
+          </item>
+        </list>
+        <p>
+          A compilation of a covered work with other separate and independent
+          works, which are not by their nature extensions of the covered
+          work, and which are not combined with it such as to form a larger
+          program, in or on a volume of a storage or distribution medium,
+          is called an "aggregate" if the compilation and its resulting
+          copyright are not used to limit the access or legal rights
+          of the compilation's users beyond what the individual works
+          permit. Inclusion of a covered work in an aggregate does not
+          cause this License to apply to the other parts of the aggregate.
+        </p>
+      </item>
+      <item>
+        <bullet>6.</bullet>
+        Conveying Non-Source Forms.<br></br>
+        You may convey a covered work in object code form
+        under the terms of sections 4 and 5, provided that you
+        also convey the machine-readable Corresponding Source
+        under the terms of this License, in one of these ways:
+        <list>
+          <item>
+            <bullet>a)</bullet>
+            Convey the object code in, or embodied in, a physical
+            product (including a physical distribution medium),
+            accompanied by the Corresponding Source fixed on a durable
+            physical medium customarily used for software interchange.
+          </item>
+          <item>
+            <bullet>b)</bullet>
+            Convey the object code in, or embodied in, a physical product
+            (including a physical distribution medium), accompanied by a
+            written offer, valid for at least three years and valid for
+            as long as you offer spare parts or customer support for that
+            product model, to give anyone who possesses the object code
+            either (1) a copy of the Corresponding Source for all the software
+            in the product that is covered by this License, on a durable
+            physical medium customarily used for software interchange,
+            for a price no more than your reasonable cost of physically
+            performing this conveying of source, or (2) access to copy
+            the Corresponding Source from a network server at no charge.
+          </item>
+          <item>
+            <bullet>c)</bullet>
+            Convey individual copies of the object code with a
+            copy of the written offer to provide the Corresponding
+            Source. This alternative is allowed only occasionally
+            and noncommercially, and only if you received the object
+            code with such an offer, in accord with subsection 6b.
+          </item>
+          <item>
+            <bullet>d)</bullet>
+            Convey the object code by offering access from a designated place
+            (gratis or for a charge), and offer equivalent access to the
+            Corresponding Source in the same way through the same place at
+            no further charge. You need not require recipients to copy the
+            Corresponding Source along with the object code. If the place
+            to copy the object code is a network server, the Corresponding
+            Source may be on a different server (operated by you or a third
+            party) that supports equivalent copying facilities, provided you
+            maintain clear directions next to the object code saying where
+            to find the Corresponding Source. Regardless of what server hosts
+            the Corresponding Source, you remain obligated to ensure that it
+            is available for as long as needed to satisfy these requirements.
+          </item>
+          <item>
+            <bullet>e)</bullet>
+            Convey the object code using peer-to-peer transmission,
+            provided you inform other peers where the object code
+            and Corresponding Source of the work are being offered
+            to the general public at no charge under subsection 6d.
+          </item>
+        </list>
+        <p>
+          A separable portion of the object code, whose source code is
+          excluded from the Corresponding Source as a System Library,
+          need not be included in conveying the object code work.
+        </p>
+        <p>
+          A "User Product" is either (1) a "consumer product", which means
+          any tangible personal property which is normally used for personal,
+          family, or household purposes, or (2) anything designed or sold
+          for incorporation into a dwelling. In determining whether a product
+          is a consumer product, doubtful cases shall be resolved in favor
+          of coverage. For a particular product received by a particular
+          user, "normally used" refers to a typical or common use of that
+          class of product, regardless of the status of the particular
+          user or of the way in which the particular user actually uses,
+          or expects or is expected to use, the product. A product is a
+          consumer product regardless of whether the product has substantial
+          commercial, industrial or non-consumer uses, unless such uses
+          represent the only significant mode of use of the product.
+        </p>
+        <p>
+          "Installation Information" for a User Product means any methods,
+          procedures, authorization keys, or other information required
+          to install and execute modified versions of a covered work in
+          that User Product from a modified version of its Corresponding
+          Source. The information must suffice to ensure that the continued
+          functioning of the modified object code is in no case prevented
+          or interfered with solely because modification has been made.
+        </p>
+        <p>
+          If you convey an object code work under this section in, or with,
+          or specifically for use in, a User Product, and the conveying
+          occurs as part of a transaction in which the right of possession
+          and use of the User Product is transferred to the recipient in
+          perpetuity or for a fixed term (regardless of how the transaction
+          is characterized), the Corresponding Source conveyed under this
+          section must be accompanied by the Installation Information.
+          But this requirement does not apply if neither you nor any third
+          party retains the ability to install modified object code on the
+          User Product (for example, the work has been installed in ROM).
+        </p>
+        <p>
+          The requirement to provide Installation Information does not
+          include a requirement to continue to provide support service,
+          warranty, or updates for a work that has been modified
+          or installed by the recipient, or for the User Product in
+          which it has been modified or installed. Access to a network
+          may be denied when the modification itself materially and
+          adversely affects the operation of the network or violates
+          the rules and protocols for communication across the network.
+        </p>
+        <p>
+          Corresponding Source conveyed, and Installation Information
+          provided, in accord with this section must be in a format that
+          is publicly documented (and with an implementation available
+          to the public in source code form), and must require no
+          special password or key for unpacking, reading or copying.
+        </p>
+      </item>
+      <item>
+        <bullet>7.</bullet>
+        Additional Terms.<br></br>
+        "Additional permissions" are terms that supplement the terms of this
+        License by making exceptions from one or more of its conditions.
+        Additional permissions that are applicable to the entire Program
+        shall be treated as though they were included in this License, to
+        the extent that they are valid under applicable law. If additional
+        permissions apply only to part of the Program, that part may be used
+        separately under those permissions, but the entire Program remains
+        governed by this License without regard to the additional permissions.
+        <p>
+          When you convey a copy of a covered work, you may at your option
+          remove any additional permissions from that copy, or from any part
+          of it. (Additional permissions may be written to require their own
+          removal in certain cases when you modify the work.) You may place
+          additional permissions on material, added by you to a covered work,
+          for which you have or can give appropriate copyright permission.
+        </p>
+        <p>
+          Notwithstanding any other provision of this License, for material you
+          add to a covered work, you may (if authorized by the copyright holders
+          of that material) supplement the terms of this License with terms:
+        </p>
+        <list>
+          <item>
+            <bullet>a)</bullet>
+            Disclaiming warranty or limiting liability differently
+            from the terms of sections 15 and 16 of this License; or
+          </item>
+          <item>
+            <bullet>b)</bullet>
+            Requiring preservation of specified reasonable legal
+            notices or author attributions in that material or in the
+            Appropriate Legal Notices displayed by works containing it; or
+          </item>
+          <item>
+            <bullet>c)</bullet>
+            Prohibiting misrepresentation of the origin of that material,
+            or requiring that modified versions of such material be marked
+            in reasonable ways as different from the original version; or
+          </item>
+          <item>
+            <bullet>d)</bullet>
+            Limiting the use for publicity purposes of names
+            of licensors or authors of the material; or
+          </item>
+          <item>
+            <bullet>e)</bullet>
+            Declining to grant rights under trademark law for use
+            of some trade names, trademarks, or service marks; or
+          </item>
+          <item>
+            <bullet>f)</bullet>
+            Requiring indemnification of licensors and authors of that
+            material by anyone who conveys the material (or modified
+            versions of it) with contractual assumptions of liability
+            to the recipient, for any liability that these contractual
+            assumptions directly impose on those licensors and authors.
+          </item>
+        </list>
+        <p>
+          All other non-permissive additional terms are considered "further
+          restrictions" within the meaning of section 10. If the Program
+          as you received it, or any part of it, contains a notice stating
+          that it is governed by this License along with a term that is
+          a further restriction, you may remove that term. If a license
+          document contains a further restriction but permits relicensing or
+          conveying under this License, you may add to a covered work material
+          governed by the terms of that license document, provided that the
+          further restriction does not survive such relicensing or conveying.
+        </p>
+        <p>
+          If you add terms to a covered work in accord with this
+          section, you must place, in the relevant source files, a
+          statement of the additional terms that apply to those files,
+          or a notice indicating where to find the applicable terms.
+        </p>
+        <p>
+          Additional terms, permissive or non-permissive, may be
+          stated in the form of a separately written license, or stated
+          as exceptions; the above requirements apply either way.
+        </p>
+      </item>
+      <item>
+        <bullet>8.</bullet>
+        Termination.
+        <p>
+          You may not propagate or modify a covered work except as
+          expressly provided under this License. Any attempt otherwise
+          to propagate or modify it is void, and will automatically
+          terminate your rights under this License (including any patent
+          licenses granted under the third paragraph of section 11).
+        </p>
+        <p>
+          However, if you cease all violation of this License, then your
+          license from a particular copyright holder is reinstated (a)
+          provisionally, unless and until the copyright holder explicitly
+          and finally terminates your license, and (b) permanently, if
+          the copyright holder fails to notify you of the violation by
+          some reasonable means prior to 60 days after the cessation.
+        </p>
+        <p>
+          Moreover, your license from a particular copyright holder is
+          reinstated permanently if the copyright holder notifies you
+          of the violation by some reasonable means, this is the first
+          time you have received notice of violation of this License
+          (for any work) from that copyright holder, and you cure the
+          violation prior to 30 days after your receipt of the notice.
+        </p>
+        <p>
+          Termination of your rights under this section does not
+          terminate the licenses of parties who have received copies or
+          rights from you under this License. If your rights have been
+          terminated and not permanently reinstated, you do not qualify
+          to receive new licenses for the same material under section 10.
+        </p>
+      </item>
+      <item>
+        <bullet>9.</bullet>
+        Acceptance Not Required for Having Copies.
+        <p>
+          You are not required to accept this License in order to receive or
+          run a copy of the Program. Ancillary propagation of a covered work
+          occurring solely as a consequence of using peer-to-peer transmission
+          to receive a copy likewise does not require acceptance. However,
+          nothing other than this License grants you permission to propagate
+          or modify any covered work. These actions infringe copyright if you
+          do not accept this License. Therefore, by modifying or propagating a
+          covered work, you indicate your acceptance of this License to do so.
+        </p>
+      </item>
+      <item>
+        <bullet>10.</bullet>
+        Automatic Licensing of Downstream Recipients.
+        <p>
+          Each time you convey a covered work, the recipient automatically
+          receives a license from the original licensors, to run, modify and
+          propagate that work, subject to this License. You are not responsible
+          for enforcing compliance by third parties with this License.
+        </p>
+        <p>
+          An "entity transaction" is a transaction transferring control of
+          an organization, or substantially all assets of one, or subdividing
+          an organization, or merging organizations. If propagation of a
+          covered work results from an entity transaction, each party to that
+          transaction who receives a copy of the work also receives whatever
+          licenses to the work the party's predecessor in interest had or could
+          give under the previous paragraph, plus a right to possession of the
+          Corresponding Source of the work from the predecessor in interest,
+          if the predecessor has it or can get it with reasonable efforts.
+        </p>
+        <p>
+          You may not impose any further restrictions on the exercise of the
+          rights granted or affirmed under this License. For example, you
+          may not impose a license fee, royalty, or other charge for exercise
+          of rights granted under this License, and you may not initiate
+          litigation (including a cross-claim or counterclaim in a lawsuit)
+          alleging that any patent claim is infringed by making, using, selling,
+          offering for sale, or importing the Program or any portion of it.
+        </p>
+      </item>
+      <item>
+        <bullet>11.</bullet>
+        Patents.
+        <p>
+          A "contributor" is a copyright holder who authorizes use under this
+          License of the Program or a work on which the Program is based. The
+          work thus licensed is called the contributor's "contributor version".
+        </p>
+        <p>
+          A contributor's "essential patent claims" are all patent
+          claims owned or controlled by the contributor, whether already
+          acquired or hereafter acquired, that would be infringed by some
+          manner, permitted by this License, of making, using, or selling
+          its contributor version, but do not include claims that would
+          be infringed only as a consequence of further modification
+          of the contributor version. For purposes of this definition,
+          "control" includes the right to grant patent sublicenses in
+          a manner consistent with the requirements of this License.
+        </p>
+        <p>
+          Each contributor grants you a non-exclusive, worldwide, royalty-free
+          patent license under the contributor's essential patent claims,
+          to make, use, sell, offer for sale, import and otherwise run,
+          modify and propagate the contents of its contributor version.
+        </p>
+        <p>
+          In the following three paragraphs, a "patent license" is any
+          express agreement or commitment, however denominated, not to
+          enforce a patent (such as an express permission to practice
+          a patent or covenant not to s ue for patent infringement). To
+          "grant" such a patent license to a party means to make such an
+          agreement or commitment not to enforce a patent against the party.
+        </p>
+        <p>
+          If you convey a covered work, knowingly relying on a patent
+          license, and the Corresponding Source of the work is not available
+          for anyone to copy, free of charge and under the terms of this
+          License, through a publicly available network server or other
+          readily accessible means, then you must either (1) cause the
+          Corresponding Source to be so available, or (2) arrange to
+          deprive yourself of the benefit of the patent license for this
+          particular work, or (3) arrange, in a manner consistent with
+          the requirements of this License, to extend the patent<br></br>
+          license to downstream recipients. "Knowingly relying" means you have
+          actual knowledge that, but for the patent license, your conveying
+          the covered work in a country, or your recipient's use of the
+          covered work in a country, would infringe one or more identifiable
+          patents in that country that you have reason to believe are valid.
+        </p>
+        <p>
+          If, pursuant to or in connection with a single transaction or
+          arrangement, you convey, or propagate by procuring conveyance
+          of, a covered work, and grant a patent license to some of the
+          parties receiving the covered work authorizing them to use,
+          propagate, modify or convey a specific copy of the covered work,
+          then the patent license you grant is automatically extended
+          to all recipients of the covered work and works based on it.
+        </p>
+        <p>
+          A patent license is "discriminatory" if it does not include within the
+          scope of its coverage, prohibits the exercise of, or is conditioned
+          on the non-exercise of one or more of the rights that are specifically
+          granted under this License. You may not convey a covered work if
+          you are a party to an arrangement with a third party that is in the
+          business of distributing software, under which you make payment to
+          the third party based on the extent of your activity of conveying
+          the work, and under which the third party grants, to any of the
+          parties who would receive the covered work from you, a discriminatory
+          patent license (a) in connection with copies of the covered work
+          conveyed by you (or copies made from those copies), or (b) primarily
+          for and in connection with specific products or compilations that
+          contain the covered work, unless you entered into that arrangement,
+          or that patent license was granted, prior to 28 March 2007.
+        </p>
+        <p>
+          Nothing in this License shall be construed as excluding or
+          limiting any implied license or other defenses to infringement
+          that may otherwise be available to you under applicable patent law.
+        </p>
+      </item>
+      <item>
+        <bullet>12.</bullet>
+        No Surrender of Others' Freedom.
+        <p>
+          If conditions are imposed on you (whether by court order,
+          agreement or otherwise) that contradict the conditions of this
+          License, they do not excuse you from the conditions of this
+          License. If you cannot convey a covered work so as to satisfy
+          simultaneously your obligations under this License and any other
+          pertinent obligations, then as a consequence you may<br></br>
+          not convey it at all. For example, if you agree to terms
+          that obligate you to collect a royalty for further conveying
+          from those to whom you convey the Program, the only
+          way you could satisfy both those terms and this License
+          would be to refrain entirely from conveying the Program.
+        </p>
+      </item>
+      <item>
+        <bullet>13.</bullet>
+        Remote Network Interaction; Use with the GNU General Public License.
+        <p>
+          Notwithstanding any other provision of this License, if you modify
+          the Program, your modified version must prominently offer all users
+          interacting with it remotely through a computer network (if your
+          version supports such interaction) an opportunity to receive the
+          Corresponding Source of your version by providing access to the
+          Corresponding Source from a network server at no charge, through
+          some standard or customary means of facilitating copying of
+          software. This Corresponding Source shall include the Corresponding
+          Source for any work covered by version 3 of the GNU General Public
+          License that is incorporated pursuant to the following paragraph.
+        </p>
+        <p>
+          Notwithstanding any other provision of this License, you have
+          permission to link or combine any covered work with a work
+          licensed under version 3 of the GNU General Public License into
+          a single combined work, and to convey the resulting work. The
+          terms of this License will continue to apply to the part which
+          is the covered work, but the work with which it is combined will
+          remain governed by version 3 of the GNU General Public License.
+        </p>
+      </item>
+      <item>
+        <bullet>14.</bullet>
+        Revised Versions of this License.
+        <p>
+          The Free Software Foundation may publish revised and/or new versions
+          of the GNU Affero General Public License from time to time. Such
+          new versions will be similar in spirit to the present version,
+          but may differ in detail to address new problems or concerns.
+        </p>
+        <p>
+          Each version is given a distinguishing version number. If the
+          Program specifies that a certain numbered version of the GNU
+          Affero General Public License "or any later version" applies to
+          it, you have the option of following the terms and conditions
+          either of that numbered version or of any later version published
+          by the Free Software Foundation. If the Program does not specify
+          a version number of the GNU Affero General Public License, you may
+          choose any version ever published by the Free Software Foundation.
+        </p>
+        <p>
+          If the Program specifies that a proxy can decide which future
+          versions of the GNU Affero General Public License can be
+          used, that proxy's public statement of acceptance of a version
+          permanently authorizes you to choose that version for the Program.
+        </p>
+        <p>
+          Later license versions may give you additional or
+          different permissions. However, no additional obligations
+          are imposed on any author or copyright holder as a
+          result of your choosing to follow a later version.
+        </p>
+      </item>
+      <item>
+        <bullet>15.</bullet>
+        Disclaimer of Warranty.
+        <p>
+          THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED
+          BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING
+          THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM
+          "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR
+          IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+          OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+          ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+          IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME
+          THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+        </p>
+      </item>
+      <item>
+        <bullet>16.</bullet>
+        Limitation of Liability.
+        <p>
+          IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+          WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR
+          CONVEYS THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+          INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES
+          ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING
+          BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE
+          OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE
+          PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER
+          OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+        </p>
+      </item>
+      <item>
+        <bullet>17.</bullet>
+        Interpretation of Sections 15 and 16.
+      </item>
+    </list>
+    <p>
+      If the disclaimer of warranty and limitation of liability
+      provided above cannot be given local legal effect according to
+      their terms, reviewing courts shall apply local law that most
+      closely approximates an absolute waiver of all civil liability in
+      connection with the Program, unless a warranty or assumption of
+      liability accompanies a copy of the Program in return for a fee.
+    </p>
+    <optional>
+      <p>
+        END OF TERMS AND CONDITIONS
+      </p>
+      <p>
+        How to Apply These Terms to Your New Programs
+      </p>
+      <p>
+        If you develop a new program, and you want it to be
+        of the greatest possible use to the public, the best
+        way to achieve this is to make it free software which
+        everyone can redistribute and change under these terms.
+      </p>
+      <p>
+        To do so, attach the following notices to the program. It is safest
+        to attach them to the start of each source file to most effectively
+        state the exclusion of warranty; and each file should have at least
+        the "copyright" line and a pointer to where the full notice is found.
+      </p>
+      <p>
+        &lt;one line to give the program's name and
+        a brief idea of what it does.&gt;<br></br>
+        Copyright (C) &lt;year&gt; &lt;name of author&gt;
+      </p>
+      <p>
+        This program is free software: you can redistribute it and/or
+        modify it under the terms of the GNU Affero General Public
+        License as published by the Free Software Foundation, either
+        version 3 of the License, or (at your option) any later version.
+      </p>
+      <p>
+        This program is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty
+        of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+        See the GNU Affero General Public License for more details.
+      </p>
+      <p>
+        You should have received a copy of the GNU Affero General
+	Public License along with this program. If not, see
+	&lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.
+      </p>
+      <p>
+        Also add information on how to contact you by electronic and paper mail.
+      </p>
+      <p>
+        If your software can interact with users remotely through a
+        computer network, you should also make sure that it provides a
+        way for users to get its source. For example, if your program is
+        a web application, its interface could display a "Source" link
+        that leads users to an archive of the code. There are many ways
+        you could offer source, and different solutions will be better for
+        different programs; see section 13 for the specific requirements.
+      </p>
+      <p>
+        You should also get your employer (if you work as a programmer)
+        or school, if any, to sign a "copyright disclaimer" for
+        the program, if necessary. For more information on this,
+	and how to apply and follow the GNU AGPL, see
+	&lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.
+      </p>
+    </optional>
+  </license>
+</SPDXLicenseCollection>

--- a/src/AGPL-3.0.xml
+++ b/src/AGPL-3.0.xml
@@ -1,11 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
   <license licenseId="AGPL-3.0" isOsiApproved="true"
-  name="GNU Affero General Public License v3.0">
+  name="GNU Affero General Public License v3.0"
+  isDeprecated="true" deprecatedVersion="3.0">
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/agpl.txt</crossRef>
       <crossRef>http://www.opensource.org/licenses/AGPL-3.0</crossRef>
     </crossRefs>
+    <notes>
+      DEPRECATED: Deprecated in lieu of more
+      explicit license identifier of AGPL-3.0-only
+    </notes>
     <standardLicenseHeader>
       Copyright (C)<alt name="copyright" match=".+">[year] [name of author]</alt>
       This program is free software: you can redistribute it and/or modify it

--- a/src/AGPL-3.0.xml
+++ b/src/AGPL-3.0.xml
@@ -1,580 +1,848 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isOsiApproved="true" licenseId="AGPL-3.0"
-            name="GNU Affero General Public License v3.0">
-      <crossRefs>
-         <crossRef>http://www.gnu.org/licenses/agpl.txt</crossRef>
-         <crossRef>http://www.opensource.org/licenses/AGPL-3.0</crossRef>
-      </crossRefs>
-      <standardLicenseHeader> Copyright (C) 
-    <alt match=".+" name="copyright">[year] [name of author]</alt> This program is free software: you can
-    redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the
-    Free Software Foundation, version 3. This program is distributed in the hope that it will be useful, but WITHOUT
-    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-    GNU Affero General Public License for more details. You should have received a copy of the GNU Affero General
-    Public License along with this program. If not, see &lt;http://www.gnu.org/licenses/&gt;
-  </standardLicenseHeader>
-      <notes>This version was released: 19 November 2007</notes>
-      <titleText>
-         <p>GNU AFFERO GENERAL PUBLIC LICENSE 
-        <br/>Version 3, 19 November 2007 
+  <license licenseId="AGPL-3.0" isOsiApproved="true"
+  name="GNU Affero General Public License v3.0">
+    <crossRefs>
+      <crossRef>http://www.gnu.org/licenses/agpl.txt</crossRef>
+      <crossRef>http://www.opensource.org/licenses/AGPL-3.0</crossRef>
+    </crossRefs>
+    <standardLicenseHeader>
+      Copyright (C)<alt name="copyright" match=".+">[year] [name of author]</alt>
+      This program is free software: you can redistribute it and/or modify it
+      under the terms of the GNU Affero General Public License as published
+      by the Free Software Foundation, version 3. This program is distributed
+      in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+      even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+      PURPOSE. See the GNU Affero General Public License for more details.
+      You should have received a copy of the GNU Affero General Public License
+      along with this program. If not, see
+      &lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;
+    </standardLicenseHeader>
+    <notes>
+      This version was released: 19 November 2007
+    </notes>
+    <titleText>
+      <p>
+        GNU AFFERO GENERAL PUBLIC LICENSE<br></br>
+        Version 3, 19 November 2007
       </p>
-      </titleText>
-      <p>Copyright (C) 2007 Free Software Foundation, Inc. &lt;http<optional>s</optional>://fsf.org/&gt;</p>
-      <p>Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is
-         not allowed.</p>
-      <p>Preamble</p>
-      <p>The GNU Affero General Public License is a free, copyleft license for software and other kinds of works,
-         specifically designed to ensure cooperation with the community in the case of network server
-         software.</p>
-      <p>The licenses for most software and other practical works are designed to take away your freedom to share
-         and change the works. By contrast, our General Public Licenses are intended to guarantee your freedom
-         to share and change all versions of a program--to make sure it remains free software for all its
-         users.</p>
-      <p>When we speak of free software, we are referring to freedom, not price. Our General Public Licenses are
-         designed to make sure that you have the freedom to distribute copies of free software (and charge for
-         them if you wish), that you receive source code or can get it if you want it, that you can change the
-         software or use pieces of it in new free programs, and that you know you can do these things.</p>
-      <p>Developers that use our General Public Licenses protect your rights with two steps: (1) assert copyright
-         on the software, and (2) offer you this License which gives you legal permission to copy, distribute
-         and/or modify the software.</p>
-      <p>A secondary benefit of defending all users' freedom is that improvements made in alternate versions
-         of the program, if they receive widespread use, become available for other developers to incorporate.
-         Many developers of free software are heartened and encouraged by the resulting cooperation. However,
-         in the case of software used on network servers, this result may fail to come about. The GNU General
-         Public License permits making a modified version and letting the public access it on a server without
-         ever releasing its source code to the public.</p>
-      <p>The GNU Affero General Public License is designed specifically to ensure that, in such cases, the
-         modified source code becomes available to the community. It requires the operator of a network server
-         to provide the source code of the modified version running there to the users of that server.
-         Therefore, public use of a modified version, on a publicly accessible server, gives the public access
-         to the source code of the modified version.</p>
-      <p>An older license, called the Affero General Public License and published by Affero, was designed to
-         accomplish similar goals. This is a different license, not a version of the Affero GPL, but Affero has
-         released a new version of the Affero GPL which permits relicensing under this license.</p>
-      <p>The precise terms and conditions for copying, distribution and modification follow.</p>
-
-      <p>TERMS AND CONDITIONS</p>
-      <list>
-        <item>
-            <bullet>0.</bullet>
-          Definitions.
-          <p>"This License" refers to version 3 of the GNU Affero General Public License.</p>
-            <p>"Copyright" also means copyright-like laws that apply to other kinds of works, such as
-             semiconductor masks.</p>
-            <p>"The Program" refers to any copyrightable work licensed under this License. Each
-             licensee is addressed as "you". "Licensees" and "recipients" may
-             be individuals or organizations.</p>
-            <p>To "modify" a work means to copy from or adapt all or part of the work in a fashion
-             requiring copyright permission, other than the making of an exact copy. The resulting work is
-             called a "modified version" of the earlier work or a work "based on" the
-             earlier work.</p>
-            <p>A "covered work" means either the unmodified Program or a work based on the Program.</p>
-            <p>To "propagate" a work means to do anything with it that, without permission, would make
-             you directly or secondarily liable for infringement under applicable copyright law, except
-             executing it on a computer or modifying a private copy. Propagation includes copying,
-             distribution (with or without modification), making available to the public, and in some
-             countries other activities as well.</p>
-            <p>To "convey" a work means any kind of propagation that enables other parties to make or
-             receive copies. Mere interaction with a user through a computer network, with no transfer of a
-             copy, is not conveying.</p>
-            <p>An interactive user interface displays "Appropriate Legal Notices" to the extent that
-             it includes a convenient and prominently visible feature that (1) displays an appropriate
-             copyright notice, and (2) tells the user that there is no warranty for the work (except to the
-             extent that warranties are provided), that licensees may convey the work under this License,
-             and how to view a copy of this License. If the interface presents a list of user commands or
-             options, such as a menu, a prominent item in the list meets this criterion.</p>
-        </item>
-        <item>
-            <bullet>1.</bullet>
-          Source Code. 
-            <br/>The "source code" for a work means the preferred form of the work for making
-                 modifications to it. "Object code" means any non-source form of a work. 
-          
-          <p>A "Standard Interface" means an interface that either is an official standard defined
-             by a recognized standards body, or, in the case of interfaces specified for a particular
-             programming language, one that is widely used among developers working in that language.</p>
-            <p>The "System Libraries" of an executable work include anything, other than the work as a
-             whole, that (a) is included in the normal form of packaging a Major Component, but which is
-             not part of that Major Component, and (b) serves only to enable use of the work with that
-             Major Component, or to implement a Standard Interface for which an implementation is available
-             to the public in source code form. A "Major Component", in this context, means a
-             major essential component (kernel, window system, and so on) of the specific operating system
-             (if any) on which the executable work runs, or a compiler used to produce the work, or an
-             object code interpreter used to run it.</p>
-            <p>The "Corresponding Source" for a work in object code form means all the source code
-             needed to generate, install, and (for an executable work) run the object code and to modify
-             the work, including scripts to control those activities. However, it does not include the
-             work's System Libraries, or general-purpose tools or generally available free programs
-             which are used unmodified in performing those activities but which are not part of the work.
-             For example, Corresponding Source includes interface definition files associated with source
-             files for the work, and the source code for shared libraries and dynamically linked
-             subprograms that the work is specifically designed to require, such as by intimate data
-             communication or control flow between those 
-            <br/>subprograms and other parts of the work. 
-          </p>
-            <p>The Corresponding Source need not include anything that users can regenerate automatically from
-             other parts of the Corresponding Source.</p>
-            <p>The Corresponding Source for a work in source code form is that same work.</p>
-        </item>
-        <item>
-            <bullet>2.</bullet>
-          Basic Permissions. 
-            <br/>All rights granted under this License are granted for the term of copyright on the Program,
-                 and are irrevocable provided the stated conditions are met. This License explicitly
-                 affirms your unlimited permission to run the unmodified Program. The output from
-                 running a covered work is covered by this License only if the output, given its
-                 content, constitutes a covered work. This License acknowledges your rights of fair use
-                 or other equivalent, as provided by copyright law. 
-          
-          <p>You may make, run and propagate covered works that you do not convey, without conditions so long
-             as your license otherwise remains in force. You may convey covered works to others for the
-             sole purpose of having them make modifications exclusively for you, or provide you with
-             facilities for running those works, provided that you comply with the terms of this License in
-             conveying all material for which you do not control copyright. Those thus making or running
-             the covered works for you must do so exclusively on your behalf, under your direction and
-             control, on terms that prohibit them from making any copies of your copyrighted material
-             outside their relationship with you.</p>
-            <p>Conveying under any other circumstances is permitted solely under the conditions stated below.
-             Sublicensing is not allowed; section 10 makes it unnecessary.</p>
-        </item>
-        <item>
-            <bullet>3.</bullet>
-          Protecting Users' Legal Rights From Anti-Circumvention Law. 
-            <br/>No covered work shall be deemed part of an effective technological measure under any
-                 applicable law fulfilling obligations under article 11 of the WIPO copyright treaty
-                 adopted on 20 December 1996, or similar laws prohibiting or restricting circumvention
-                 of such measures. 
-          
-          <p>When you convey a covered work, you waive any legal power to forbid circumvention of
-             technological measures to the extent such circumvention is effected by exercising rights under
-             this License with respect to the covered work, and you disclaim any intention to limit
-             operation or modification of the work as a means of enforcing, against the work's users,
-             your or third parties' legal rights to forbid circumvention of technological
-             measures.</p>
-        </item>
-        <item>
-            <bullet>4.</bullet>
-          Conveying Verbatim Copies. 
-            <br/>You may convey verbatim copies of the Program's source code as you receive it, in any
-                 medium, provided that you conspicuously and appropriately publish on each copy an
-                 appropriate copyright notice; keep intact all notices stating that this License and
-                 any non-permissive terms added in accord with section 7 apply to the code; keep intact
-                 all notices of the absence of any warranty; and give all recipients a copy of this
-                 License along with the Program. 
-          
-          <p>You may charge any price or no price for each copy that you convey, and you may offer support or
-             warranty protection for a fee.</p>
-        </item>
-        <item>
-            <bullet>5.</bullet>
-          Conveying Modified Source Versions. 
-            <br/>You may convey a work based on the Program, or the modifications to produce it from the
-                 Program, in the form of source code under the terms of section 4, provided that you
-                 also meet all of these conditions: 
-          
+    </titleText>
+    <p>
+      Copyright (C) 2007 Free Software Foundation, Inc.
+      &lt;http<optional>s</optional>://fsf.org/&gt;
+    </p>
+    <p>
+      Everyone is permitted to copy and distribute verbatim copies
+      of this license document, but changing it is not allowed.
+    </p>
+    <p>
+      Preamble
+    </p>
+    <p>
+      The GNU Affero General Public License is a free, copyleft license for
+      software and other kinds of works, specifically designed to ensure
+      cooperation with the community in the case of network server software.
+    </p>
+    <p>
+      The licenses for most software and other practical works are
+      designed to take away your freedom to share and change the
+      works. By contrast, our General Public Licenses are intended
+      to guarantee your freedom to share and change all versions of a
+      program--to make sure it remains free software for all its users.
+    </p>
+    <p>
+      When we speak of free software, we are referring to freedom, not
+      price. Our General Public Licenses are designed to make sure that you
+      have the freedom to distribute copies of free software (and charge
+      for them if you wish), that you receive source code or can get it
+      if you want it, that you can change the software or use pieces of
+      it in new free programs, and that you know you can do these things.
+    </p>
+    <p>
+      Developers that use our General Public Licenses protect
+      your rights with two steps: (1) assert copyright on the
+      software, and (2) offer you this License which gives you legal
+      permission to copy, distribute and/or modify the software.
+    </p>
+    <p>
+      A secondary benefit of defending all users' freedom is that improvements
+      made in alternate versions of the program, if they receive widespread
+      use, become available for other developers to incorporate. Many
+      developers of free software are heartened and encouraged by the
+      resulting cooperation. However, in the case of software used on network
+      servers, this result may fail to come about. The GNU General Public
+      License permits making a modified version and letting the public access
+      it on a server without ever releasing its source code to the public.
+    </p>
+    <p>
+      The GNU Affero General Public License is designed specifically
+      to ensure that, in such cases, the modified source code becomes
+      available to the community. It requires the operator of a
+      network server to provide the source code of the modified version
+      running there to the users of that server. Therefore, public use
+      of a modified version, on a publicly accessible server, gives
+      the public access to the source code of the modified version.
+    </p>
+    <p>
+      An older license, called the Affero General Public License and published
+      by Affero, was designed to accomplish similar goals. This is a different
+      license, not a version of the Affero GPL, but Affero has released a new
+      version of the Affero GPL which permits relicensing under this license.
+    </p>
+    <p>
+      The precise terms and conditions for copying,
+      distribution and modification follow.
+    </p>
+    <p>
+      TERMS AND CONDITIONS
+    </p>
+    <list>
+      <item>
+        <bullet>0.</bullet>
+        Definitions.
+        <p>
+          "This License" refers to version 3 of
+          the GNU Affero General Public License.
+        </p>
+        <p>
+          "Copyright" also means copyright-like laws that apply
+          to other kinds of works, such as semiconductor masks.
+        </p>
+        <p>
+          "The Program" refers to any copyrightable work licensed under
+          this License. Each licensee is addressed as "you". "Licensees"
+          and "recipients" may be individuals or organizations.
+        </p>
+        <p>
+          To "modify" a work means to copy from or adapt all or part of the
+          work in a fashion requiring copyright permission, other than the
+          making of an exact copy. The resulting work is called a "modified
+          version" of the earlier work or a work "based on" the earlier work.
+        </p>
+        <p>
+          A "covered work" means either the unmodified
+          Program or a work based on the Program.
+        </p>
+        <p>
+          To "propagate" a work means to do anything with it that, without
+          permission, would make you directly or secondarily liable for
+          infringement under applicable copyright law, except executing it
+          on a computer or modifying a private copy. Propagation includes
+          copying, distribution (with or without modification), making available
+          to the public, and in some countries other activities as well.
+        </p>
+        <p>
+          To "convey" a work means any kind of propagation
+          that enables other parties to make or receive copies.
+          Mere interaction with a user through a computer
+          network, with no transfer of a copy, is not conveying.
+        </p>
+        <p>
+          An interactive user interface displays "Appropriate Legal Notices"
+          to the extent that it includes a convenient and prominently visible
+          feature that (1) displays an appropriate copyright notice, and (2)
+          tells the user that there is no warranty for the work (except to
+          the extent that warranties are provided), that licensees may convey
+          the work under this License, and how to view a copy of this License.
+          If the interface presents a list of user commands or options,
+          such as a menu, a prominent item in the list meets this criterion.
+        </p>
+      </item>
+      <item>
+        <bullet>1.</bullet>
+        Source Code.<br></br>
+        The "source code" for a work means the preferred
+        form of the work for making modifications to it.
+        "Object code" means any non-source form of a work.
+        <p>
+          A "Standard Interface" means an interface that either is an official
+          standard defined by a recognized standards body, or, in the case
+          of interfaces specified for a particular programming language,
+          one that is widely used among developers working in that language.
+        </p>
+        <p>
+          The "System Libraries" of an executable work include anything, other
+          than the work as a whole, that (a) is included in the normal form
+          of packaging a Major Component, but which is not part of that Major
+          Component, and (b) serves only to enable use of the work with that
+          Major Component, or to implement a Standard Interface for which an
+          implementation is available to the public in source code form. A
+          "Major Component", in this context, means a major essential component
+          (kernel, window system, and so on) of the specific operating system
+          (if any) on which the executable work runs, or a compiler used to
+          produce the work, or an object code interpreter used to run it.
+        </p>
+        <p>
+          The "Corresponding Source" for a work in object code form means
+          all the source code needed to generate, install, and (for an
+          executable work) run the object code and to modify the work,
+          including scripts to control those activities. However, it does
+          not include the work's System Libraries, or general-purpose tools
+          or generally available free programs which are used unmodified in
+          performing those activities but which are not part of the work.
+          For example, Corresponding Source includes interface definition
+          files associated with source files for the work, and the source
+          code for shared libraries and dynamically linked subprograms
+          that the work is specifically designed to require, such as by
+          intimate data communication or control flow between those<br></br>
+          subprograms and other parts of the work.
+        </p>
+        <p>
+          The Corresponding Source need not include anything that users can
+          regenerate automatically from other parts of the Corresponding Source.
+        </p>
+        <p>
+          The Corresponding Source for a work
+          in source code form is that same work.
+        </p>
+      </item>
+      <item>
+        <bullet>2.</bullet>
+        Basic Permissions.<br></br>
+        All rights granted under this License are granted for the term of
+        copyright on the Program, and are irrevocable provided the stated
+        conditions are met. This License explicitly affirms your unlimited
+        permission to run the unmodified Program. The output from running a
+        covered work is covered by this License only if the output, given its
+        content, constitutes a covered work. This License acknowledges your
+        rights of fair use or other equivalent, as provided by copyright law.
+        <p>
+          You may make, run and propagate covered works that you do not convey,
+          without conditions so long as your license otherwise remains in force.
+          You may convey covered works to others for the sole purpose of having
+          them make modifications exclusively for you, or provide you with
+          facilities for running those works, provided that you comply with
+          the terms of this License in conveying all material for which you do
+          not control copyright. Those thus making or running the covered works
+          for you must do so exclusively on your behalf, under your direction
+          and control, on terms that prohibit them from making any copies
+          of your copyrighted material outside their relationship with you.
+        </p>
+        <p>
+          Conveying under any other circumstances is permitted
+          solely under the conditions stated below. Sublicensing
+          is not allowed; section 10 makes it unnecessary.
+        </p>
+      </item>
+      <item>
+        <bullet>3.</bullet>
+        Protecting Users' Legal Rights From Anti-Circumvention Law.<br></br>
+        No covered work shall be deemed part of an effective technological
+        measure under any applicable law fulfilling obligations under article
+        11 of the WIPO copyright treaty adopted on 20 December 1996, or
+        similar laws prohibiting or restricting circumvention of such measures.
+        <p>
+          When you convey a covered work, you waive any legal power to
+          forbid circumvention of technological measures to the extent
+          such circumvention is effected by exercising rights under this
+          License with respect to the covered work, and you disclaim any
+          intention to limit operation or modification of the work as a means
+          of enforcing, against the work's users, your or third parties'
+          legal rights to forbid circumvention of technological measures.
+        </p>
+      </item>
+      <item>
+        <bullet>4.</bullet>
+        Conveying Verbatim Copies.<br></br>
+        You may convey verbatim copies of the Program's source code as
+        you receive it, in any medium, provided that you conspicuously
+        and appropriately publish on each copy an appropriate copyright
+        notice; keep intact all notices stating that this License and any
+        non-permissive terms added in accord with section 7 apply to the
+        code; keep intact all notices of the absence of any warranty; and
+        give all recipients a copy of this License along with the Program.
+        <p>
+          You may charge any price or no price for each copy that you
+          convey, and you may offer support or warranty protection for a fee.
+        </p>
+      </item>
+      <item>
+        <bullet>5.</bullet>
+        Conveying Modified Source Versions.<br></br>
+        You may convey a work based on the Program, or the modifications to
+        produce it from the Program, in the form of source code under the terms
+        of section 4, provided that you also meet all of these conditions:
         <list>
-               <item>
-                  <bullet>a)</bullet>
-            The work must carry prominent notices stating that you modified it, and giving a relevant date.
+          <item>
+            <bullet>a)</bullet>
+            The work must carry prominent notices stating
+            that you modified it, and giving a relevant date.
           </item>
-               <item>
-                  <bullet>b)</bullet>
-            The work must carry prominent notices stating that it is released under this License and any
-               conditions added under section 7. This requirement modifies the requirement in section 4
-               to "keep intact all notices".
+          <item>
+            <bullet>b)</bullet>
+            The work must carry prominent notices stating that
+            it is released under this License and any conditions
+            added under section 7. This requirement modifies the
+            requirement in section 4 to "keep intact all notices".
           </item>
-               <item>
-                  <bullet>c)</bullet>
-            You must license the entire work, as a whole, under this License to anyone who comes into
-               possession of a copy. This License will therefore apply, along with any applicable section
-               7 additional terms, to the whole of the work, and all its parts, regardless of how they
-               are packaged. This License gives no permission to license the work in any other way, but
-               it does not invalidate such permission if you have separately received it.
+          <item>
+            <bullet>c)</bullet>
+            You must license the entire work, as a whole, under this License
+            to anyone who comes into possession of a copy. This License
+            will therefore apply, along with any applicable section 7
+            additional terms, to the whole of the work, and all its parts,
+            regardless of how they are packaged. This License gives no
+            permission to license the work in any other way, but it does not
+            invalidate such permission if you have separately received it.
           </item>
-               <item>
-                  <bullet>d)</bullet>
-            If the work has interactive user interfaces, each must display Appropriate Legal Notices;
-               however, if the Program has interactive interfaces that do not display Appropriate Legal
-               Notices, your work need not make them do so.
+          <item>
+            <bullet>d)</bullet>
+            If the work has interactive user interfaces, each must
+            display Appropriate Legal Notices; however, if the Program
+            has interactive interfaces that do not display Appropriate
+            Legal Notices, your work need not make them do so.
           </item>
-            </list>
-            <p>A compilation of a covered work with other separate and independent works, which are not by
-               their nature extensions of the covered work, and which are not combined with it such as to
-               form a larger program, in or on a volume of a storage or distribution medium, is called an
-               "aggregate" if the compilation and its resulting copyright are not used to limit
-               the access or legal rights of the compilation's users beyond what the individual
-               works permit. Inclusion of a covered work in an aggregate does not cause this License to
-               apply to the other parts of the aggregate.</p>
-        </item>
-        <item>
-            <bullet>6.</bullet>
-          Conveying Non-Source Forms. 
-            <br/>You may convey a covered work in object code form under the terms of sections 4 and 5,
-                 provided that you also convey the machine-readable Corresponding Source under the
-                 terms of this License, in one of these ways: 
-          
+        </list>
+        <p>
+          A compilation of a covered work with other separate and independent
+          works, which are not by their nature extensions of the covered
+          work, and which are not combined with it such as to form a larger
+          program, in or on a volume of a storage or distribution medium,
+          is called an "aggregate" if the compilation and its resulting
+          copyright are not used to limit the access or legal rights
+          of the compilation's users beyond what the individual works
+          permit. Inclusion of a covered work in an aggregate does not
+          cause this License to apply to the other parts of the aggregate.
+        </p>
+      </item>
+      <item>
+        <bullet>6.</bullet>
+        Conveying Non-Source Forms.<br></br>
+        You may convey a covered work in object code form
+        under the terms of sections 4 and 5, provided that you
+        also convey the machine-readable Corresponding Source
+        under the terms of this License, in one of these ways:
         <list>
-               <item>
-                  <bullet>a)</bullet>
-            Convey the object code in, or embodied in, a physical product (including a physical
-               distribution medium), accompanied by the Corresponding Source fixed on a durable physical
-               medium customarily used for software interchange.
+          <item>
+            <bullet>a)</bullet>
+            Convey the object code in, or embodied in, a physical
+            product (including a physical distribution medium),
+            accompanied by the Corresponding Source fixed on a durable
+            physical medium customarily used for software interchange.
           </item>
-               <item>
-                  <bullet>b)</bullet>
-            Convey the object code in, or embodied in, a physical product (including a physical
-               distribution medium), accompanied by a written offer, valid for at least three years and
-               valid for as long as you offer spare parts or customer support for that product model, to
-               give anyone who possesses the object code either (1) a copy of the Corresponding Source
-               for all the software in the product that is covered by this License, on a durable physical
-               medium customarily used for software interchange, for a price no more than your reasonable
-               cost of physically performing this conveying of source, or (2) access to copy the
-               Corresponding Source from a network server at no charge.
+          <item>
+            <bullet>b)</bullet>
+            Convey the object code in, or embodied in, a physical product
+            (including a physical distribution medium), accompanied by a
+            written offer, valid for at least three years and valid for
+            as long as you offer spare parts or customer support for that
+            product model, to give anyone who possesses the object code
+            either (1) a copy of the Corresponding Source for all the software
+            in the product that is covered by this License, on a durable
+            physical medium customarily used for software interchange,
+            for a price no more than your reasonable cost of physically
+            performing this conveying of source, or (2) access to copy
+            the Corresponding Source from a network server at no charge.
           </item>
-               <item>
-                  <bullet>c)</bullet>
-            Convey individual copies of the object code with a copy of the written offer to provide the
-               Corresponding Source. This alternative is allowed only occasionally and noncommercially,
-               and only if you received the object code with such an offer, in accord with subsection
-               6b.
+          <item>
+            <bullet>c)</bullet>
+            Convey individual copies of the object code with a
+            copy of the written offer to provide the Corresponding
+            Source. This alternative is allowed only occasionally
+            and noncommercially, and only if you received the object
+            code with such an offer, in accord with subsection 6b.
           </item>
-               <item>
-                  <bullet>d)</bullet>
-            Convey the object code by offering access from a designated place (gratis or for a charge),
-               and offer equivalent access to the Corresponding Source in the same way through the same
-               place at no further charge. You need not require recipients to copy the Corresponding
-               Source along with the object code. If the place to copy the object code is a network
-               server, the Corresponding Source may be on a different server (operated by you or a third
-               party) that supports equivalent copying facilities, provided you maintain clear directions
-               next to the object code saying where to find the Corresponding Source. Regardless of what
-               server hosts the Corresponding Source, you remain obligated to ensure that it is available
-               for as long as needed to satisfy these requirements.
+          <item>
+            <bullet>d)</bullet>
+            Convey the object code by offering access from a designated place
+            (gratis or for a charge), and offer equivalent access to the
+            Corresponding Source in the same way through the same place at
+            no further charge. You need not require recipients to copy the
+            Corresponding Source along with the object code. If the place
+            to copy the object code is a network server, the Corresponding
+            Source may be on a different server (operated by you or a third
+            party) that supports equivalent copying facilities, provided you
+            maintain clear directions next to the object code saying where
+            to find the Corresponding Source. Regardless of what server hosts
+            the Corresponding Source, you remain obligated to ensure that it
+            is available for as long as needed to satisfy these requirements.
           </item>
-               <item>
-                  <bullet>e)</bullet>
-            Convey the object code using peer-to-peer transmission, provided you inform other peers where
-               the object code and Corresponding Source of the work are being offered to the general
-               public at no charge under subsection 6d.
+          <item>
+            <bullet>e)</bullet>
+            Convey the object code using peer-to-peer transmission,
+            provided you inform other peers where the object code
+            and Corresponding Source of the work are being offered
+            to the general public at no charge under subsection 6d.
           </item>
-            </list>
-            <p>A separable portion of the object code, whose source code is excluded from the Corresponding
-               Source as a System Library, need not be included in conveying the object code work.</p>
-            <p>A "User Product" is either (1) a "consumer product", which means any
-               tangible personal property which is normally used for personal, family, or household
-               purposes, or (2) anything designed or sold for incorporation into a dwelling. In
-               determining whether a product is a consumer product, doubtful cases shall be resolved in
-               favor of coverage. For a particular product received by a particular user, "normally
-               used" refers to a typical or common use of that class of product, regardless of the
-               status of the particular user or of the way in which the particular user actually uses, or
-               expects or is expected to use, the product. A product is a consumer product regardless of
-               whether the product has substantial commercial, industrial or non-consumer uses, unless
-               such uses represent the only significant mode of use of the product.</p>
-            <p>"Installation Information" for a User Product means any methods, procedures,
-               authorization keys, or other information required to install and execute modified versions
-               of a covered work in that User Product from a modified version of its Corresponding
-               Source. The information must suffice to ensure that the continued functioning of the
-               modified object code is in no case prevented or interfered with solely because
-               modification has been made.</p>
-            <p>If you convey an object code work under this section in, or with, or specifically for use in,
-               a User Product, and the conveying occurs as part of a transaction in which the right of
-               possession and use of the User Product is transferred to the recipient in perpetuity or
-               for a fixed term (regardless of how the transaction is characterized), the Corresponding
-               Source conveyed under this section must be accompanied by the Installation Information.
-               But this requirement does not apply if neither you nor any third party retains the ability
-               to install modified object code on the User Product (for example, the work has been
-               installed in ROM).</p>
-            <p>The requirement to provide Installation Information does not include a requirement to
-               continue to provide support service, warranty, or updates for a work that has been
-               modified or installed by the recipient, or for the User Product in which it has been
-               modified or installed. Access to a network may be denied when the modification itself
-               materially and adversely affects the operation of the network or violates the rules and
-               protocols for communication across the network.</p>
-            <p>Corresponding Source conveyed, and Installation Information provided, in accord with this
-               section must be in a format that is publicly documented (and with an implementation
-               available to the public in source code form), and must require no special password or key
-               for unpacking, reading or copying.</p>
-        </item>
-        <item>
-            <bullet>7.</bullet>
-          Additional Terms. 
-            <br/>"Additional permissions" are terms that supplement the terms of this License by
-                 making exceptions from one or more of its conditions. Additional permissions that are
-                 applicable to the entire Program shall be treated as though they were included in this
-                 License, to the extent that they are valid under applicable law. If additional
-                 permissions apply only to part of the Program, that part may be used separately under
-                 those permissions, but the entire Program remains governed by this License without
-                 regard to the additional permissions. 
-          
-          <p>When you convey a copy of a covered work, you may at your option remove any additional
-             permissions from that copy, or from any part of it. (Additional permissions may be written to
-             require their own removal in certain cases when you modify the work.) You may place additional
-             permissions on material, added by you to a covered work, for which you have or can give
-             appropriate copyright permission.</p>
-            <p>Notwithstanding any other provision of this License, for material you add to a covered work, you
-             may (if authorized by the copyright holders of that material) supplement the terms of this
-             License with terms:</p>
-            <list>
-               <item>
-                  <bullet>a)</bullet>
-            Disclaiming warranty or limiting liability differently from the terms of sections 15 and 16
-               of this License; or
+        </list>
+        <p>
+          A separable portion of the object code, whose source code is
+          excluded from the Corresponding Source as a System Library,
+          need not be included in conveying the object code work.
+        </p>
+        <p>
+          A "User Product" is either (1) a "consumer product", which means
+          any tangible personal property which is normally used for personal,
+          family, or household purposes, or (2) anything designed or sold
+          for incorporation into a dwelling. In determining whether a product
+          is a consumer product, doubtful cases shall be resolved in favor
+          of coverage. For a particular product received by a particular
+          user, "normally used" refers to a typical or common use of that
+          class of product, regardless of the status of the particular
+          user or of the way in which the particular user actually uses,
+          or expects or is expected to use, the product. A product is a
+          consumer product regardless of whether the product has substantial
+          commercial, industrial or non-consumer uses, unless such uses
+          represent the only significant mode of use of the product.
+        </p>
+        <p>
+          "Installation Information" for a User Product means any methods,
+          procedures, authorization keys, or other information required
+          to install and execute modified versions of a covered work in
+          that User Product from a modified version of its Corresponding
+          Source. The information must suffice to ensure that the continued
+          functioning of the modified object code is in no case prevented
+          or interfered with solely because modification has been made.
+        </p>
+        <p>
+          If you convey an object code work under this section in, or with,
+          or specifically for use in, a User Product, and the conveying
+          occurs as part of a transaction in which the right of possession
+          and use of the User Product is transferred to the recipient in
+          perpetuity or for a fixed term (regardless of how the transaction
+          is characterized), the Corresponding Source conveyed under this
+          section must be accompanied by the Installation Information.
+          But this requirement does not apply if neither you nor any third
+          party retains the ability to install modified object code on the
+          User Product (for example, the work has been installed in ROM).
+        </p>
+        <p>
+          The requirement to provide Installation Information does not
+          include a requirement to continue to provide support service,
+          warranty, or updates for a work that has been modified
+          or installed by the recipient, or for the User Product in
+          which it has been modified or installed. Access to a network
+          may be denied when the modification itself materially and
+          adversely affects the operation of the network or violates
+          the rules and protocols for communication across the network.
+        </p>
+        <p>
+          Corresponding Source conveyed, and Installation Information
+          provided, in accord with this section must be in a format that
+          is publicly documented (and with an implementation available
+          to the public in source code form), and must require no
+          special password or key for unpacking, reading or copying.
+        </p>
+      </item>
+      <item>
+        <bullet>7.</bullet>
+        Additional Terms.<br></br>
+        "Additional permissions" are terms that supplement the terms of this
+        License by making exceptions from one or more of its conditions.
+        Additional permissions that are applicable to the entire Program
+        shall be treated as though they were included in this License, to
+        the extent that they are valid under applicable law. If additional
+        permissions apply only to part of the Program, that part may be used
+        separately under those permissions, but the entire Program remains
+        governed by this License without regard to the additional permissions.
+        <p>
+          When you convey a copy of a covered work, you may at your option
+          remove any additional permissions from that copy, or from any part
+          of it. (Additional permissions may be written to require their own
+          removal in certain cases when you modify the work.) You may place
+          additional permissions on material, added by you to a covered work,
+          for which you have or can give appropriate copyright permission.
+        </p>
+        <p>
+          Notwithstanding any other provision of this License, for material you
+          add to a covered work, you may (if authorized by the copyright holders
+          of that material) supplement the terms of this License with terms:
+        </p>
+        <list>
+          <item>
+            <bullet>a)</bullet>
+            Disclaiming warranty or limiting liability differently
+            from the terms of sections 15 and 16 of this License; or
           </item>
-               <item>
-                  <bullet>b)</bullet>
-            Requiring preservation of specified reasonable legal notices or author attributions in that
-               material or in the Appropriate Legal Notices displayed by works containing it; or
+          <item>
+            <bullet>b)</bullet>
+            Requiring preservation of specified reasonable legal
+            notices or author attributions in that material or in the
+            Appropriate Legal Notices displayed by works containing it; or
           </item>
-               <item>
-                  <bullet>c)</bullet>
-            Prohibiting misrepresentation of the origin of that material, or requiring that modified
-               versions of such material be marked in reasonable ways as different from the original
-               version; or
+          <item>
+            <bullet>c)</bullet>
+            Prohibiting misrepresentation of the origin of that material,
+            or requiring that modified versions of such material be marked
+            in reasonable ways as different from the original version; or
           </item>
-               <item>
-                  <bullet>d)</bullet>
-            Limiting the use for publicity purposes of names of licensors or authors of the material; or
+          <item>
+            <bullet>d)</bullet>
+            Limiting the use for publicity purposes of names
+            of licensors or authors of the material; or
           </item>
-               <item>
-                  <bullet>e)</bullet>
-            Declining to grant rights under trademark law for use of some trade names, trademarks, or
-               service marks; or
+          <item>
+            <bullet>e)</bullet>
+            Declining to grant rights under trademark law for use
+            of some trade names, trademarks, or service marks; or
           </item>
-               <item>
-                  <bullet>f)</bullet>
-            Requiring indemnification of licensors and authors of that material by anyone who conveys the
-               material (or modified versions of it) with contractual assumptions of liability to the
-               recipient, for any liability that these contractual assumptions directly impose on those
-               licensors and authors.
+          <item>
+            <bullet>f)</bullet>
+            Requiring indemnification of licensors and authors of that
+            material by anyone who conveys the material (or modified
+            versions of it) with contractual assumptions of liability
+            to the recipient, for any liability that these contractual
+            assumptions directly impose on those licensors and authors.
           </item>
-            </list>               
-            <p>All other non-permissive additional terms are considered "further restrictions"
-               within the meaning of section 10. If the Program as you received it, or any part of it,
-               contains a notice stating that it is governed by this License along with a term that is a
-               further restriction, you may remove that term. If a license document contains a further
-               restriction but permits relicensing or conveying under this License, you may add to a
-               covered work material governed by the terms of that license document, provided that the
-               further restriction does not survive such relicensing or conveying.</p>
-            <p>If you add terms to a covered work in accord with this section, you must place, in the
-               relevant source files, a statement of the additional terms that apply to those files, or a
-               notice indicating where to find the applicable terms.</p>
-            <p>Additional terms, permissive or non-permissive, may be stated in the form of a separately
-               written license, or stated as exceptions; the above requirements apply either way.</p>
-        </item>
-        <item>
-            <bullet>8.</bullet>
-          Termination.
-          <p>You may not propagate or modify a covered work except as expressly provided under this License.
-             Any attempt otherwise to propagate or modify it is void, and will automatically terminate your
-             rights under this License (including any patent licenses granted under the third paragraph of
-             section 11).</p>
-            <p>However, if you cease all violation of this License, then your license from a particular
-             copyright holder is reinstated (a) provisionally, unless and until the copyright holder
-             explicitly and finally terminates your license, and (b) permanently, if the copyright holder
-             fails to notify you of the violation by some reasonable means prior to 60 days after the
-             cessation.</p>
-            <p>Moreover, your license from a particular copyright holder is reinstated permanently if the
-             copyright holder notifies you of the violation by some reasonable means, this is the first
-             time you have received notice of violation of this License (for any work) from that copyright
-             holder, and you cure the violation prior to 30 days after your receipt of the notice.</p>
-            <p>Termination of your rights under this section does not terminate the licenses of parties who have
-             received copies or rights from you under this License. If your rights have been terminated and
-             not permanently reinstated, you do not qualify to receive new licenses for the same material
-             under section 10.</p>
-        </item>
-        <item>
-            <bullet>9.</bullet>
-          Acceptance Not Required for Having Copies.
-          <p>You are not required to accept this License in order to receive or run a copy of the Program.
-             Ancillary propagation of a covered work occurring solely as a consequence of using
-             peer-to-peer transmission to receive a copy likewise does not require acceptance. However,
-             nothing other than this License grants you permission to propagate or modify any covered work.
-             These actions infringe copyright if you do not accept this License. Therefore, by modifying or
-             propagating a covered work, you indicate your acceptance of this License to do so.</p>
-        </item>
-        <item>
-            <bullet>10.</bullet>
-          Automatic Licensing of Downstream Recipients.
-          <p>Each time you convey a covered work, the recipient automatically receives a license from the
-             original licensors, to run, modify and propagate that work, subject to this License. You are
-             not responsible for enforcing compliance by third parties with this License.</p>
-            <p>An "entity transaction" is a transaction transferring control of an organization, or
-             substantially all assets of one, or subdividing an organization, or merging organizations. If
-             propagation of a covered work results from an entity transaction, each party to that
-             transaction who receives a copy of the work also receives whatever licenses to the work the
-             party's predecessor in interest had or could give under the previous paragraph, plus a
-             right to possession of the Corresponding Source of the work from the predecessor in interest,
-             if the predecessor has it or can get it with reasonable efforts.</p>
-            <p>You may not impose any further restrictions on the exercise of the rights granted or affirmed
-             under this License. For example, you may not impose a license fee, royalty, or other charge
-             for exercise of rights granted under this License, and you may not initiate litigation
-             (including a cross-claim or counterclaim in a lawsuit) alleging that any patent claim is
-             infringed by making, using, selling, offering for sale, or importing the Program or any
-             portion of it.</p>
-        </item>
-        <item>
-            <bullet>11.</bullet>
-          Patents.
-          <p>A "contributor" is a copyright holder who authorizes use under this License of the
-             Program or a work on which the Program is based. The work thus licensed is called the
-             contributor's "contributor version".</p>
-            <p>A contributor's "essential patent claims" are all patent claims owned or
-             controlled by the contributor, whether already acquired or hereafter acquired, that would be
-             infringed by some manner, permitted by this License, of making, using, or selling its
-             contributor version, but do not include claims that would be infringed only as a consequence
-             of further modification of the contributor version. For purposes of this definition,
-             "control" includes the right to grant patent sublicenses in a manner consistent with
-             the requirements of this License.</p>
-            <p>Each contributor grants you a non-exclusive, worldwide, royalty-free patent license under the
-             contributor's essential patent claims, to make, use, sell, offer for sale, import and
-             otherwise run, modify and propagate the contents of its contributor version.</p>
-            <p>In the following three paragraphs, a "patent license" is any express agreement or
-             commitment, however denominated, not to enforce a patent (such as an express permission to
-             practice a patent or covenant not to s ue for patent infringement). To "grant" such
-             a patent license to a party means to make such an agreement or commitment not to enforce a
-             patent against the party.</p>
-            <p>If you convey a covered work, knowingly relying on a patent license, and the Corresponding Source
-             of the work is not available for anyone to copy, free of charge and under the terms of this
-             License, through a publicly available network server or other readily accessible means, then
-             you must either (1) cause the Corresponding Source to be so available, or (2) arrange to
-             deprive yourself of the benefit of the patent license for this particular work, or (3)
-             arrange, in a manner consistent with the requirements of this License, to extend the patent 
-            <br/>license to downstream recipients. "Knowingly relying" means you have actual
-                 knowledge that, but for the patent license, your conveying the covered work in a
-                 country, or your recipient's use of the covered work in a country, would infringe
-                 one or more identifiable patents in that country that you have reason to believe are
-                 valid. 
-          </p>
-            <p>If, pursuant to or in connection with a single transaction or arrangement, you convey, or
-             propagate by procuring conveyance of, a covered work, and grant a patent license to some of
-             the parties receiving the covered work authorizing them to use, propagate, modify or convey a
-             specific copy of the covered work, then the patent license you grant is automatically extended
-             to all recipients of the covered work and works based on it.</p>
-            <p>A patent license is "discriminatory" if it does not include within the scope of its
-             coverage, prohibits the exercise of, or is conditioned on the non-exercise of one or more of
-             the rights that are specifically granted under this License. You may not convey a covered work
-             if you are a party to an arrangement with a third party that is in the business of
-             distributing software, under which you make payment to the third party based on the extent of
-             your activity of conveying the work, and under which the third party grants, to any of the
-             parties who would receive the covered work from you, a discriminatory patent license (a) in
-             connection with copies of the covered work conveyed by you (or copies made from those copies),
-             or (b) primarily for and in connection with specific products or compilations that contain the
-             covered work, unless you entered into that arrangement, or that patent license was granted,
-             prior to 28 March 2007.</p>
-            <p>Nothing in this License shall be construed as excluding or limiting any implied license or other
-             defenses to infringement that may otherwise be available to you under applicable patent
-             law.</p>
-        </item>
-        <item>
-            <bullet>12.</bullet>
-          No Surrender of Others' Freedom.
-          <p>If conditions are imposed on you (whether by court order, agreement or otherwise) that contradict
-             the conditions of this License, they do not excuse you from the conditions of this License. If
-             you cannot convey a covered work so as to satisfy simultaneously your obligations under this
-             License and any other pertinent obligations, then as a consequence you may 
-            <br/>not convey it at all. For example, if you agree to terms that obligate you to collect a
-                 royalty for further conveying from those to whom you convey the Program, the only way
-                 you could satisfy both those terms and this License would be to refrain entirely from
-                 conveying the Program. 
-          </p>
-        </item>
-        <item>
-            <bullet>13.</bullet>
-          Remote Network Interaction; Use with the GNU General Public License.
-          <p>Notwithstanding any other provision of this License, if you modify the Program, your modified
-             version must prominently offer all users interacting with it remotely through a computer
-             network (if your version supports such interaction) an opportunity to receive the
-             Corresponding Source of your version by providing access to the Corresponding Source from a
-             network server at no charge, through some standard or customary means of facilitating copying
-             of software. This Corresponding Source shall include the Corresponding Source for any work
-             covered by version 3 of the GNU General Public License that is incorporated pursuant to the
-             following paragraph.</p>
-            <p>Notwithstanding any other provision of this License, you have permission to link or combine any
-             covered work with a work licensed under version 3 of the GNU General Public License into a
-             single combined work, and to convey the resulting work. The terms of this License will
-             continue to apply to the part which is the covered work, but the work with which it is
-             combined will remain governed by version 3 of the GNU General Public License.</p>
-        </item>
-        <item>
-            <bullet>14.</bullet>
-          Revised Versions of this License.
-          <p>The Free Software Foundation may publish revised and/or new versions of the GNU Affero General
-             Public License from time to time. Such new versions will be similar in spirit to the present
-             version, but may differ in detail to address new problems or concerns.</p>
-            <p>Each version is given a distinguishing version number. If the Program specifies that a certain
-             numbered version of the GNU Affero General Public License "or any later version"
-             applies to it, you have the option of following the terms and conditions either of that
-             numbered version or of any later version published by the Free Software Foundation. If the
-             Program does not specify a version number of the GNU Affero General Public License, you may
-             choose any version ever published by the Free Software Foundation.</p>
-            <p>If the Program specifies that a proxy can decide which future versions of the GNU Affero General
-             Public License can be used, that proxy's public statement of acceptance of a version
-             permanently authorizes you to choose that version for the Program.</p>
-            <p>Later license versions may give you additional or different permissions. However, no additional
-             obligations are imposed on any author or copyright holder as a result of your choosing to
-             follow a later version.</p>
-        </item>
-        <item>
-            <bullet>15.</bullet>
-          Disclaimer of Warranty.
-          <p>THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN
-             OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM
-             "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT
-             NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-             PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU. SHOULD
-             THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR
-             CORRECTION.</p>
-        </item>
-        <item>
-            <bullet>16.</bullet>
-          Limitation of Liability.
-          <p>IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY COPYRIGHT HOLDER,
-             OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO
-             YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
-             OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR
-             DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE
-             PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN
-             ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.</p>
-        </item>
-        <item>
-            <bullet>17.</bullet>
-          Interpretation of Sections 15 and 16.
-        </item>
-      </list>
-      <p>If the disclaimer of warranty and limitation of liability provided above cannot be given local legal
-         effect according to their terms, reviewing courts shall apply local law that most closely approximates
-         an absolute waiver of all civil liability in connection with the Program, unless a warranty or
-         assumption of liability accompanies a copy of the Program in return for a fee.</p>
-
-      <optional>
-         <p>END OF TERMS AND CONDITIONS</p>
-         <p>How to Apply These Terms to Your New Programs</p>
-         <p>If you develop a new program, and you want it to be of the greatest possible use to the public, the best
-         way to achieve this is to make it free software which everyone can redistribute and change under these
-         terms.</p>
-         <p>To do so, attach the following notices to the program. It is safest to attach them to the start of each
-         source file to most effectively state the exclusion of warranty; and each file should have at least
-         the "copyright" line and a pointer to where the full notice is found.</p>
-         <p>&lt;one line to give the program's name and a brief idea of what it does.&gt; 
-        <br/>Copyright (C) &lt;year&gt; &lt;name of author&gt; 
+        </list>
+        <p>
+          All other non-permissive additional terms are considered "further
+          restrictions" within the meaning of section 10. If the Program
+          as you received it, or any part of it, contains a notice stating
+          that it is governed by this License along with a term that is
+          a further restriction, you may remove that term. If a license
+          document contains a further restriction but permits relicensing or
+          conveying under this License, you may add to a covered work material
+          governed by the terms of that license document, provided that the
+          further restriction does not survive such relicensing or conveying.
+        </p>
+        <p>
+          If you add terms to a covered work in accord with this
+          section, you must place, in the relevant source files, a
+          statement of the additional terms that apply to those files,
+          or a notice indicating where to find the applicable terms.
+        </p>
+        <p>
+          Additional terms, permissive or non-permissive, may be
+          stated in the form of a separately written license, or stated
+          as exceptions; the above requirements apply either way.
+        </p>
+      </item>
+      <item>
+        <bullet>8.</bullet>
+        Termination.
+        <p>
+          You may not propagate or modify a covered work except as
+          expressly provided under this License. Any attempt otherwise
+          to propagate or modify it is void, and will automatically
+          terminate your rights under this License (including any patent
+          licenses granted under the third paragraph of section 11).
+        </p>
+        <p>
+          However, if you cease all violation of this License, then your
+          license from a particular copyright holder is reinstated (a)
+          provisionally, unless and until the copyright holder explicitly
+          and finally terminates your license, and (b) permanently, if
+          the copyright holder fails to notify you of the violation by
+          some reasonable means prior to 60 days after the cessation.
+        </p>
+        <p>
+          Moreover, your license from a particular copyright holder is
+          reinstated permanently if the copyright holder notifies you
+          of the violation by some reasonable means, this is the first
+          time you have received notice of violation of this License
+          (for any work) from that copyright holder, and you cure the
+          violation prior to 30 days after your receipt of the notice.
+        </p>
+        <p>
+          Termination of your rights under this section does not
+          terminate the licenses of parties who have received copies or
+          rights from you under this License. If your rights have been
+          terminated and not permanently reinstated, you do not qualify
+          to receive new licenses for the same material under section 10.
+        </p>
+      </item>
+      <item>
+        <bullet>9.</bullet>
+        Acceptance Not Required for Having Copies.
+        <p>
+          You are not required to accept this License in order to receive or
+          run a copy of the Program. Ancillary propagation of a covered work
+          occurring solely as a consequence of using peer-to-peer transmission
+          to receive a copy likewise does not require acceptance. However,
+          nothing other than this License grants you permission to propagate
+          or modify any covered work. These actions infringe copyright if you
+          do not accept this License. Therefore, by modifying or propagating a
+          covered work, you indicate your acceptance of this License to do so.
+        </p>
+      </item>
+      <item>
+        <bullet>10.</bullet>
+        Automatic Licensing of Downstream Recipients.
+        <p>
+          Each time you convey a covered work, the recipient automatically
+          receives a license from the original licensors, to run, modify and
+          propagate that work, subject to this License. You are not responsible
+          for enforcing compliance by third parties with this License.
+        </p>
+        <p>
+          An "entity transaction" is a transaction transferring control of
+          an organization, or substantially all assets of one, or subdividing
+          an organization, or merging organizations. If propagation of a
+          covered work results from an entity transaction, each party to that
+          transaction who receives a copy of the work also receives whatever
+          licenses to the work the party's predecessor in interest had or could
+          give under the previous paragraph, plus a right to possession of the
+          Corresponding Source of the work from the predecessor in interest,
+          if the predecessor has it or can get it with reasonable efforts.
+        </p>
+        <p>
+          You may not impose any further restrictions on the exercise of the
+          rights granted or affirmed under this License. For example, you
+          may not impose a license fee, royalty, or other charge for exercise
+          of rights granted under this License, and you may not initiate
+          litigation (including a cross-claim or counterclaim in a lawsuit)
+          alleging that any patent claim is infringed by making, using, selling,
+          offering for sale, or importing the Program or any portion of it.
+        </p>
+      </item>
+      <item>
+        <bullet>11.</bullet>
+        Patents.
+        <p>
+          A "contributor" is a copyright holder who authorizes use under this
+          License of the Program or a work on which the Program is based. The
+          work thus licensed is called the contributor's "contributor version".
+        </p>
+        <p>
+          A contributor's "essential patent claims" are all patent
+          claims owned or controlled by the contributor, whether already
+          acquired or hereafter acquired, that would be infringed by some
+          manner, permitted by this License, of making, using, or selling
+          its contributor version, but do not include claims that would
+          be infringed only as a consequence of further modification
+          of the contributor version. For purposes of this definition,
+          "control" includes the right to grant patent sublicenses in
+          a manner consistent with the requirements of this License.
+        </p>
+        <p>
+          Each contributor grants you a non-exclusive, worldwide, royalty-free
+          patent license under the contributor's essential patent claims,
+          to make, use, sell, offer for sale, import and otherwise run,
+          modify and propagate the contents of its contributor version.
+        </p>
+        <p>
+          In the following three paragraphs, a "patent license" is any
+          express agreement or commitment, however denominated, not to
+          enforce a patent (such as an express permission to practice
+          a patent or covenant not to s ue for patent infringement). To
+          "grant" such a patent license to a party means to make such an
+          agreement or commitment not to enforce a patent against the party.
+        </p>
+        <p>
+          If you convey a covered work, knowingly relying on a patent
+          license, and the Corresponding Source of the work is not available
+          for anyone to copy, free of charge and under the terms of this
+          License, through a publicly available network server or other
+          readily accessible means, then you must either (1) cause the
+          Corresponding Source to be so available, or (2) arrange to
+          deprive yourself of the benefit of the patent license for this
+          particular work, or (3) arrange, in a manner consistent with
+          the requirements of this License, to extend the patent<br></br>
+          license to downstream recipients. "Knowingly relying" means you have
+          actual knowledge that, but for the patent license, your conveying
+          the covered work in a country, or your recipient's use of the
+          covered work in a country, would infringe one or more identifiable
+          patents in that country that you have reason to believe are valid.
+        </p>
+        <p>
+          If, pursuant to or in connection with a single transaction or
+          arrangement, you convey, or propagate by procuring conveyance
+          of, a covered work, and grant a patent license to some of the
+          parties receiving the covered work authorizing them to use,
+          propagate, modify or convey a specific copy of the covered work,
+          then the patent license you grant is automatically extended
+          to all recipients of the covered work and works based on it.
+        </p>
+        <p>
+          A patent license is "discriminatory" if it does not include within the
+          scope of its coverage, prohibits the exercise of, or is conditioned
+          on the non-exercise of one or more of the rights that are specifically
+          granted under this License. You may not convey a covered work if
+          you are a party to an arrangement with a third party that is in the
+          business of distributing software, under which you make payment to
+          the third party based on the extent of your activity of conveying
+          the work, and under which the third party grants, to any of the
+          parties who would receive the covered work from you, a discriminatory
+          patent license (a) in connection with copies of the covered work
+          conveyed by you (or copies made from those copies), or (b) primarily
+          for and in connection with specific products or compilations that
+          contain the covered work, unless you entered into that arrangement,
+          or that patent license was granted, prior to 28 March 2007.
+        </p>
+        <p>
+          Nothing in this License shall be construed as excluding or
+          limiting any implied license or other defenses to infringement
+          that may otherwise be available to you under applicable patent law.
+        </p>
+      </item>
+      <item>
+        <bullet>12.</bullet>
+        No Surrender of Others' Freedom.
+        <p>
+          If conditions are imposed on you (whether by court order,
+          agreement or otherwise) that contradict the conditions of this
+          License, they do not excuse you from the conditions of this
+          License. If you cannot convey a covered work so as to satisfy
+          simultaneously your obligations under this License and any other
+          pertinent obligations, then as a consequence you may<br></br>
+          not convey it at all. For example, if you agree to terms
+          that obligate you to collect a royalty for further conveying
+          from those to whom you convey the Program, the only
+          way you could satisfy both those terms and this License
+          would be to refrain entirely from conveying the Program.
+        </p>
+      </item>
+      <item>
+        <bullet>13.</bullet>
+        Remote Network Interaction; Use with the GNU General Public License.
+        <p>
+          Notwithstanding any other provision of this License, if you modify
+          the Program, your modified version must prominently offer all users
+          interacting with it remotely through a computer network (if your
+          version supports such interaction) an opportunity to receive the
+          Corresponding Source of your version by providing access to the
+          Corresponding Source from a network server at no charge, through
+          some standard or customary means of facilitating copying of
+          software. This Corresponding Source shall include the Corresponding
+          Source for any work covered by version 3 of the GNU General Public
+          License that is incorporated pursuant to the following paragraph.
+        </p>
+        <p>
+          Notwithstanding any other provision of this License, you have
+          permission to link or combine any covered work with a work
+          licensed under version 3 of the GNU General Public License into
+          a single combined work, and to convey the resulting work. The
+          terms of this License will continue to apply to the part which
+          is the covered work, but the work with which it is combined will
+          remain governed by version 3 of the GNU General Public License.
+        </p>
+      </item>
+      <item>
+        <bullet>14.</bullet>
+        Revised Versions of this License.
+        <p>
+          The Free Software Foundation may publish revised and/or new versions
+          of the GNU Affero General Public License from time to time. Such
+          new versions will be similar in spirit to the present version,
+          but may differ in detail to address new problems or concerns.
+        </p>
+        <p>
+          Each version is given a distinguishing version number. If the
+          Program specifies that a certain numbered version of the GNU
+          Affero General Public License "or any later version" applies to
+          it, you have the option of following the terms and conditions
+          either of that numbered version or of any later version published
+          by the Free Software Foundation. If the Program does not specify
+          a version number of the GNU Affero General Public License, you may
+          choose any version ever published by the Free Software Foundation.
+        </p>
+        <p>
+          If the Program specifies that a proxy can decide which future
+          versions of the GNU Affero General Public License can be
+          used, that proxy's public statement of acceptance of a version
+          permanently authorizes you to choose that version for the Program.
+        </p>
+        <p>
+          Later license versions may give you additional or
+          different permissions. However, no additional obligations
+          are imposed on any author or copyright holder as a
+          result of your choosing to follow a later version.
+        </p>
+      </item>
+      <item>
+        <bullet>15.</bullet>
+        Disclaimer of Warranty.
+        <p>
+          THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED
+          BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING
+          THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM
+          "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR
+          IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+          OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+          ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+          IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME
+          THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+        </p>
+      </item>
+      <item>
+        <bullet>16.</bullet>
+        Limitation of Liability.
+        <p>
+          IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+          WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR
+          CONVEYS THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+          INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES
+          ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING
+          BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE
+          OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE
+          PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER
+          OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+        </p>
+      </item>
+      <item>
+        <bullet>17.</bullet>
+        Interpretation of Sections 15 and 16.
+      </item>
+    </list>
+    <p>
+      If the disclaimer of warranty and limitation of liability
+      provided above cannot be given local legal effect according to
+      their terms, reviewing courts shall apply local law that most
+      closely approximates an absolute waiver of all civil liability in
+      connection with the Program, unless a warranty or assumption of
+      liability accompanies a copy of the Program in return for a fee.
+    </p>
+    <optional>
+      <p>
+        END OF TERMS AND CONDITIONS
       </p>
-         <p>This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero
-         General Public License as published by the Free Software Foundation, either version 3 of the License,
-         or (at your option) any later version.</p>
-         <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
-         the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
-         General Public License for more details.</p>
-         <p>You should have received a copy of the GNU Affero General Public License along with this program. If not,
-         see &lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.</p>
-         <p>Also add information on how to contact you by electronic and paper mail.</p>
-         <p>If your software can interact with users remotely through a computer network, you should also make sure
-         that it provides a way for users to get its source. For example, if your program is a web application,
-         its interface could display a "Source" link that leads users to an archive of the code.
-         There are many ways you could offer source, and different solutions will be better for different
-         programs; see section 13 for the specific requirements.</p>
-         <p>You should also get your employer (if you work as a programmer) or school, if any, to sign a
-         "copyright disclaimer" for the program, if necessary. For more information on this, and how
-         to apply and follow the GNU AGPL, see &lt;http<optional>s</optional>https://www.gnu.org/licenses/&gt;.</p>
-      </optional>
+      <p>
+        How to Apply These Terms to Your New Programs
+      </p>
+      <p>
+        If you develop a new program, and you want it to be
+        of the greatest possible use to the public, the best
+        way to achieve this is to make it free software which
+        everyone can redistribute and change under these terms.
+      </p>
+      <p>
+        To do so, attach the following notices to the program. It is safest
+        to attach them to the start of each source file to most effectively
+        state the exclusion of warranty; and each file should have at least
+        the "copyright" line and a pointer to where the full notice is found.
+      </p>
+      <p>
+        &lt;one line to give the program's name and
+        a brief idea of what it does.&gt;<br></br>
+        Copyright (C) &lt;year&gt; &lt;name of author&gt;
+      </p>
+      <p>
+        This program is free software: you can redistribute it and/or
+        modify it under the terms of the GNU Affero General Public
+        License as published by the Free Software Foundation, either
+        version 3 of the License, or (at your option) any later version.
+      </p>
+      <p>
+        This program is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty
+        of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+        See the GNU Affero General Public License for more details.
+      </p>
+      <p>
+        You should have received a copy of the GNU Affero General
+	Public License along with this program. If not, see
+	&lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.
+      </p>
+      <p>
+        Also add information on how to contact you by electronic and paper mail.
+      </p>
+      <p>
+        If your software can interact with users remotely through a
+        computer network, you should also make sure that it provides a
+        way for users to get its source. For example, if your program is
+        a web application, its interface could display a "Source" link
+        that leads users to an archive of the code. There are many ways
+        you could offer source, and different solutions will be better for
+        different programs; see section 13 for the specific requirements.
+      </p>
+      <p>
+        You should also get your employer (if you work as a programmer)
+        or school, if any, to sign a "copyright disclaimer" for
+        the program, if necessary. For more information on this,
+	and how to apply and follow the GNU AGPL, see
+	&lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.
+      </p>
+    </optional>
   </license>
 </SPDXLicenseCollection>

--- a/src/GFDL-1.1-only.xml
+++ b/src/GFDL-1.1-only.xml
@@ -7,10 +7,9 @@
     </crossRefs>
     <standardLicenseHeader>
       Copyright (c) <alt name="copyright" match=".+">YEAR YOUR NAME</alt>
-      . Permission is granted to copy, distribute and/or modify this
+      Permission is granted to copy, distribute and/or modify this
       document under the terms of the GNU Free Documentation License,
-      Version 1.1 or any later version published by the Free Software
-      Foundation; with the Invariant Sections being LIST THEIR
+      Version 1.1; with the Invariant Sections being LIST THEIR
       TITLES, with the Front-Cover Texts being LIST, and with the
       Back-Cover Texts being LIST. A copy of the license is included
       in the section entitled "GNU Free Documentation License".

--- a/src/GFDL-1.1-only.xml
+++ b/src/GFDL-1.1-only.xml
@@ -1,0 +1,481 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SPDXLicenseCollection xmlns="http://www.spdx.org/license">
+  <license licenseId="GFDL-1.1" isOsiApproved="false"
+  name="GNU Free Documentation License v1.1">
+    <crossRefs>
+      <crossRef>http://www.gnu.org/licenses/old-licenses/fdl-1.1.txt</crossRef>
+    </crossRefs>
+    <standardLicenseHeader>
+      Copyright (c) <alt name="copyright" match=".+">YEAR YOUR NAME</alt>
+      . Permission is granted to copy, distribute and/or modify this
+      document under the terms of the GNU Free Documentation License,
+      Version 1.1 or any later version published by the Free Software
+      Foundation; with the Invariant Sections being LIST THEIR
+      TITLES, with the Front-Cover Texts being LIST, and with the
+      Back-Cover Texts being LIST. A copy of the license is included
+      in the section entitled "GNU Free Documentation License".
+    </standardLicenseHeader>
+    <notes>
+      This license was released March 2000
+    </notes>
+    <titleText>
+      <p>
+        GNU Free Documentation License<br></br>
+        Version 1.1, March 2000
+      </p>
+    </titleText>
+    <p>
+      Copyright (C) 2000 Free Software Foundation, Inc. 51
+      Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+    </p>
+    <p>
+      Everyone is permitted to copy and distribute verbatim copies
+      of this license document, but changing it is not allowed.
+    </p>
+    <list>
+      <item>
+        <bullet>0.</bullet>
+        PREAMBLE
+        <p>
+          The purpose of this License is to make a manual, textbook,
+          or other written document "free" in the sense of freedom: to
+          assure everyone the effective freedom to copy and redistribute
+          it, with or without modifying it, either commercially or
+          noncommercially. Secondarily, this License preserves for the
+          author and publisher a way to get credit for their work, while
+          not being considered responsible for modifications made by others.
+        </p>
+        <p>
+          This License is a kind of "copyleft", which means that
+          derivative works of the document must themselves be free in
+          the same sense. It complements the GNU General Public License,
+          which is a copyleft license designed for free software.
+        </p>
+        <p>
+          We have designed this License in order to use it for manuals for
+          free software, because free software needs free documentation: a free
+          program should come with manuals providing the same freedoms that the
+          software does. But this License is not limited to software manuals;
+          it can be used for any textual work, regardless of subject matter or
+          whether it is published as a printed book. We recommend this License
+          principally for works whose purpose is instruction or reference.
+        </p>
+      </item>
+      <item>
+        <bullet>1.</bullet>
+        APPLICABILITY AND DEFINITIONS
+        <p>
+          This License applies to any manual or other work that
+          contains a notice placed by the copyright holder saying
+          it can be distributed under the terms of this License. The
+          "Document", below, refers to any such manual or work. Any
+          member of the public is a licensee, and is addressed as "you".
+        </p>
+        <p>
+          A "Modified Version" of the Document means any work containing
+          the Document or a portion of it, either copied verbatim, or
+          with modifications and/or translated into another language.
+        </p>
+        <p>
+          A "Secondary Section" is a named appendix or a front-matter section
+          of the Document that deals exclusively with the relationship
+          of the publishers or authors of the Document to the Document's
+          overall subject (or to related matters) and contains nothing
+          that could fall directly within that overall subject. (For
+          example, if the Document is in part a textbook of mathematics,
+          a Secondary Section may not explain any mathematics.) The
+          relationship could be a matter of historical connection with
+          the subject or with related matters, or of legal, commercial,
+          philosophical, ethical or political position regarding them.
+        </p>
+        <p>
+          The "Invariant Sections" are certain Secondary Sections whose
+          titles are designated, as being those of Invariant Sections, in the
+          notice that says that the Document is released under this License.
+        </p>
+        <p>
+          The "Cover Texts" are certain short passages of text that are
+          listed, as Front-Cover Texts or Back-Cover Texts, in the notice
+          that says that the Document is released under this License.
+        </p>
+        <p>
+          A "Transparent" copy of the Document means a machine-readable copy,
+          represented in a format whose specification is available to the
+          general public, whose contents can be viewed and edited directly
+          and straightforwardly with generic text editors or (for images
+          composed of pixels) generic paint programs or (for drawings) some
+          widely available drawing editor, and that is suitable for input
+          to text formatters or for automatic translation to a variety of
+          formats suitable for input to text formatters. A copy made in an
+          otherwise Transparent file format whose markup has been designed
+          to thwart or discourage subsequent modification by readers is not
+          Transparent. A copy that is not "Transparent" is called "Opaque".
+        </p>
+        <p>
+          Examples of suitable formats for Transparent copies include
+          plain ASCII without markup, Texinfo input format, LaTeX
+          input format, SGML or XML using a publicly available DTD, and
+          standard-conforming simple HTML designed for human modification.
+          Opaque formats include PostScript, PDF, proprietary formats
+          that can be read and edited only by proprietary word processors,
+          SGML or XML for which the DTD and/or processing tools are
+          not generally available, and the machine-generated HTML
+          produced by some word processors for output purposes only.
+        </p>
+        <p>
+          The "Title Page" means, for a printed book, the title page itself,
+          plus such following pages as are needed to hold, legibly, the
+          material this License requires to appear in the title page. For
+          works in formats which do not have any title page as such, "Title
+          Page" means the text near the most prominent appearance of the
+          work's title, preceding the beginning of the body of the text.
+        </p>
+      </item>
+      <item>
+        <bullet>2.</bullet>
+        VERBATIM COPYING
+        <p>
+          You may copy and distribute the Document in any medium, either
+          commercially or noncommercially, provided that this License, the
+          copyright notices, and the license notice saying this License applies
+          to the Document are reproduced in all copies, and that you add no
+          other conditions whatsoever to those of this License. You may not
+          use technical measures to obstruct or control the reading or further
+          copying of the copies you make or distribute. However, you may accept
+          compensation in exchange for copies. If you distribute a large enough
+          number of copies you must also follow the conditions in section 3.
+        </p>
+        <p>
+          You may also lend copies, under the same conditions
+          stated above, and you may publicly display copies.
+        </p>
+      </item>
+      <item>
+        <bullet>3.</bullet>
+        COPYING IN QUANTITY
+        <p>
+          If you publish printed copies of the Document numbering more than
+          100, and the Document's license notice requires Cover Texts, you
+          must enclose the copies in covers that carry, clearly and legibly,
+          all these Cover Texts: Front-Cover Texts on the front cover, and
+          Back-Cover Texts on the back cover. Both covers must also clearly
+          and legibly identify you as the publisher of these copies. The
+          front cover must present the full title with all words of the title
+          equally prominent and visible. You may add other material on the
+          covers in addition. Copying with changes limited to the covers, as
+          long as they preserve the title of the Document and satisfy these
+          conditions, can be treated as verbatim copying in other respects.
+        </p>
+        <p>
+          If the required texts for either cover are too
+          voluminous to fit legibly, you should put the first
+          ones listed (as many as fit reasonably) on the actual
+          cover, and continue the rest onto adjacent pages.
+        </p>
+        <p>
+          If you publish or distribute Opaque copies of the Document
+          numbering more than 100, you must either include a machine-readable
+          Transparent copy along with each Opaque copy, or state in or with
+          each Opaque copy a publicly-accessible computer-network location
+          containing a complete Transparent copy of the Document, free
+          of added material, which the general network-using public has
+          access to download anonymously at no charge using public-standard
+          network protocols. If you use the latter option, you must take
+          reasonably prudent steps, when you begin distribution of Opaque
+          copies in quantity, to ensure that this Transparent copy will
+          remain thus accessible at the stated location until at least one
+          year after the last time you distribute an Opaque copy (directly
+          or through your agents or retailers) of that edition to the public.
+        </p>
+        <p>
+          It is requested, but not required, that you contact
+          the authors of the Document well before redistributing
+          any large number of copies, to give them a chance to
+          provide you with an updated version of the Document.
+        </p>
+      </item>
+      <item>
+        <bullet>4.</bullet>
+        MODIFICATIONS
+        <p>
+          You may copy and distribute a Modified Version of the Document under
+          the conditions of sections 2 and 3 above, provided that you release
+          the Modified Version under precisely this License, with the Modified
+          Version filling the role of the Document, thus licensing distribution
+          and modification of the Modified Version to whoever possesses a copy
+          of it. In addition, you must do these things in the Modified Version:
+        </p>
+        <list>
+          <item>
+            <bullet>A.</bullet>
+            Use in the Title Page (and on the covers, if any) a title distinct
+            from that of the Document, and from those of previous versions
+            (which should, if there were any, be listed in the History section
+            of the Document). You may use the same title as a previous version
+            if the original publisher of that version gives permission.
+          </item>
+          <item>
+            <bullet>B.</bullet>
+            List on the Title Page, as authors, one or more persons or entities
+            responsible for authorship of the modifications in the Modified
+            Version, together with at least five of the principal authors of the
+            Document (all of its principal authors, if it has less than five).
+          </item>
+          <item>
+            <bullet>C.</bullet>
+            State on the Title page the name of the publisher
+            of the Modified Version, as the publisher.
+          </item>
+          <item>
+            <bullet>D.</bullet>
+            Preserve all the copyright notices of the Document.
+          </item>
+          <item>
+            <bullet>E.</bullet>
+            Add an appropriate copyright notice for your
+            modifications adjacent to the other copyright notices.
+          </item>
+          <item>
+            <bullet>F.</bullet>
+            Include, immediately after the copyright notices, a license notice
+            giving the public permission to use the Modified Version under the
+            terms of this License, in the form shown in the Addendum below.
+          </item>
+          <item>
+            <bullet>G.</bullet>
+            Preserve in that license notice the full lists of Invariant Sections
+            and required Cover Texts given in the Document's license notice.
+          </item>
+          <item>
+            <bullet>H.</bullet>
+            Include an unaltered copy of this License.
+          </item>
+          <item>
+            <bullet>I.</bullet>
+            Preserve the section entitled "History", and its title, and add
+            to it an item stating at least the title, year, new authors,
+            and publisher of the Modified Version as given on the Title
+            Page. If there is no section entitled "History" in the Document,
+            create one stating the title, year, authors, and publisher
+            of the Document as given on its Title Page, then add an item
+            describing the Modified Version as stated in the previous sentence.
+          </item>
+          <item>
+            <bullet>J.</bullet>
+            Preserve the network location, if any, given in the Document
+            for public access to a Transparent copy of the Document, and
+            likewise the network locations given in the Document for previous
+            versions it was based on. These may be placed in the "History"
+            section. You may omit a network location for a work that was
+            published at least four years before the Document itself, or if the
+            original publisher of the version it refers to gives permission.
+          </item>
+          <item>
+            <bullet>K.</bullet>
+            In any section entitled "Acknowledgements" or "Dedications",
+            preserve the section's title, and preserve in the section
+            all the substance and tone of each of the contributor
+            acknowledgements and/or dedications given therein.
+          </item>
+          <item>
+            <bullet>L.</bullet>
+            Preserve all the Invariant Sections of the Document, unaltered
+            in their text and in their titles. Section numbers or the
+            equivalent are not considered part of the section titles.
+          </item>
+          <item>
+            <bullet>M.</bullet>
+            Delete any section entitled "Endorsements". Such a
+            section may not be included in the Modified Version.
+          </item>
+          <item>
+            <bullet>N.</bullet>
+            Do not retitle any existing section as "Endorsements"
+            or to conflict in title with any Invariant Section.
+          </item>
+        </list>
+        <p>
+          If the Modified Version includes new front-matter sections or
+          appendices that qualify as Secondary Sections and contain no material
+          copied from the Document, you may at your option designate some or
+          all of these sections as invariant. To do this, add their titles
+          to the list of Invariant Sections in the Modified Version's license
+          notice. These titles must be distinct from any other section titles.
+        </p>
+        <p>
+          You may add a section entitled "Endorsements", provided
+          it contains nothing but endorsements of your Modified
+          Version by various parties--for example, statements of
+          peer review or that the text has been approved by an
+          organization as the authoritative definition of a standard.
+        </p>
+        <p>
+          You may add a passage of up to five words as a Front-Cover Text,
+          and a passage of up to 25 words as a Back-Cover Text, to the end of
+          the list of Cover Texts in the Modified Version. Only one passage
+          of Front-Cover Text and one of Back-Cover Text may be added by (or
+          through arrangements made by) any one entity. If the Document already
+          includes a cover text for the same cover, previously added by you or
+          by arrangement made by the same entity you are acting on behalf of,
+          you may not add another; but you may replace the old one, on explicit
+          permission from the previous publisher that added the old one.
+        </p>
+        <p>
+          The author(s) and publisher(s) of the Document do not by this
+          License give permission to use their names for publicity for
+          or to assert or imply endorsement of any Modified Version.
+        </p>
+      </item>
+      <item>
+        <bullet>5.</bullet>
+        COMBINING DOCUMENTS
+        <p>
+          You may combine the Document with other documents released
+          under this License, under the terms defined in section 4
+          above for modified versions, provided that you include in
+          the combination all of the Invariant Sections of all of
+          the original documents, unmodified, and list them all as
+          Invariant Sections of your combined work in its license notice.
+        </p>
+        <p>
+          The combined work need only contain one copy of this License, and
+          multiple identical Invariant Sections may be replaced with a single
+          copy. If there are multiple Invariant Sections with the same name
+          but different contents, make the title of each such section unique
+          by adding at the end of it, in parentheses, the name of the original
+          author or publisher of that section if known, or else a unique
+          number. Make the same adjustment to the section titles in the list
+          of Invariant Sections in the license notice of the combined work.
+        </p>
+        <p>
+          In the combination, you must combine any sections entitled
+          "History" in the various original documents, forming one section
+          entitled "History"; likewise combine any sections entitled
+          "Acknowledgements", and any sections entitled "Dedications".
+          You must delete all sections entitled "Endorsements."
+        </p>
+      </item>
+      <item>
+        <bullet>6.</bullet>
+        COLLECTIONS OF DOCUMENTS
+        <p>
+          You may make a collection consisting of the Document and
+          other documents released under this License, and replace the
+          individual copies of this License in the various documents
+          with a single copy that is included in the collection,
+          provided that you follow the rules of this License for verbatim
+          copying of each of the documents in all other respects.
+        </p>
+        <p>
+          You may extract a single document from such a collection,
+          and distribute it individually under this License,
+          provided you insert a copy of this License into the
+          extracted document, and follow this License in all other
+          respects regarding verbatim copying of that document.
+        </p>
+      </item>
+      <item>
+        <bullet>7.</bullet>
+        AGGREGATION WITH INDEPENDENT WORKS
+        <p>
+          A compilation of the Document or its derivatives with other separate
+          and independent documents or works, in or on a volume of a storage
+          or distribution medium, does not as a whole count as a Modified
+          Version of the Document, provided no compilation copyright is claimed
+          for the compilation. Such a compilation is called an "aggregate",
+          and this License does not apply to the other self-contained works
+          thus compiled with the Document, on account of their being thus
+          compiled, if they are not themselves derivative works of the Document.
+        </p>
+        <p>
+          If the Cover Text requirement of section 3 is applicable to these
+          copies of the Document, then if the Document is less than one quarter
+          of the entire aggregate, the Document's Cover Texts may be placed
+          on covers that surround only the Document within the aggregate.
+          Otherwise they must appear on covers around the whole aggregate.
+        </p>
+      </item>
+      <item>
+        <bullet>8.</bullet>
+        TRANSLATION
+        <p>
+          Translation is considered a kind of modification, so you may
+          distribute translations of the Document under the terms of
+          section 4. Replacing Invariant Sections with translations requires
+          special permission from their copyright holders, but you may
+          include translations of some or all Invariant Sections in addition
+          to the original versions of these Invariant Sections. You may
+          include a translation of this License provided that you also
+          include the original English version of this License. In case of
+          a disagreement between the translation and the original English
+          version of this License, the original English version will prevail.
+        </p>
+      </item>
+      <item>
+        <bullet>9.</bullet>
+        TERMINATION
+        <p>
+          You may not copy, modify, sublicense, or distribute the Document
+          except as expressly provided for under this License. Any other
+          attempt to copy, modify, sublicense or distribute the Document
+          is void, and will automatically terminate your rights under
+          this License. However, parties who have received copies, or
+          rights, from you under this License will not have their licenses
+          terminated so long as such parties remain in full compliance.
+        </p>
+      </item>
+      <item>
+        <bullet>10.</bullet>
+        FUTURE REVISIONS OF THIS LICENSE
+        <p>
+          The Free Software Foundation may publish new, revised
+          versions of the GNU Free Documentation License from time
+          to time. Such new versions will be similar in spirit to
+          the present version, but may differ in detail to address
+          new problems or concerns. See http://www.gnu.org/copyleft/.
+        </p>
+        <p>
+          Each version of the License is given a distinguishing version number.
+          If the Document specifies that a particular numbered version of this
+          License "or any later version" applies to it, you have the option
+          of following the terms and conditions either of that specified
+          version or of any later version that has been published (not as a
+          draft) by the Free Software Foundation. If the Document does not
+          specify a version number of this License, you may choose any version
+          ever published (not as a draft) by the Free Software Foundation.
+        </p>
+      </item>
+    </list>
+    <optional>
+      <p>
+        ADDENDUM: How to use this License for your documents
+      </p>
+      <p>
+        To use this License in a document you have written, include
+        a copy of the License in the document and put the following
+        copyright and license notices just after the title page:
+      </p>
+      <p>
+        Copyright (c) YEAR YOUR NAME. Permission is granted to copy,
+        distribute and/or modify this document under the terms of the
+        GNU Free Documentation License, Version 1.1 or any later version
+        published by the Free Software Foundation; with the Invariant Sections
+        being LIST THEIR TITLES, with the Front-Cover Texts being LIST,
+        and with the Back-Cover Texts being LIST. A copy of the license is
+        included in the section entitled "GNU Free Documentation License".
+      </p>
+      <p>
+        If you have no Invariant Sections, write "with no Invariant
+        Sections" instead of saying which ones are invariant. If you have
+        no Front-Cover Texts, write "no Front-Cover Texts" instead of
+        "Front-Cover Texts being LIST"; likewise for Back-Cover Texts.
+      </p>
+      <p>
+        If your document contains nontrivial examples of program
+        code, we recommend releasing these examples in parallel
+        under your choice of free software license, such as the GNU
+        General Public License, to permit their use in free software.
+      </p>
+    </optional>
+  </license>
+</SPDXLicenseCollection>

--- a/src/GFDL-1.1-only.xml
+++ b/src/GFDL-1.1-only.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-  <license licenseId="GFDL-1.1" isOsiApproved="false"
-  name="GNU Free Documentation License v1.1">
+  <license licenseId="GFDL-1.1-only" isOsiApproved="false"
+  name="GNU Free Documentation License v1.1 only">
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/old-licenses/fdl-1.1.txt</crossRef>
     </crossRefs>

--- a/src/GFDL-1.1-or-later.xml
+++ b/src/GFDL-1.1-or-later.xml
@@ -7,7 +7,7 @@
     </crossRefs>
     <standardLicenseHeader>
       Copyright (c) <alt name="copyright" match=".+">YEAR YOUR NAME</alt>
-      . Permission is granted to copy, distribute and/or modify this
+      Permission is granted to copy, distribute and/or modify this
       document under the terms of the GNU Free Documentation License,
       Version 1.1 or any later version published by the Free Software
       Foundation; with the Invariant Sections being LIST THEIR

--- a/src/GFDL-1.1-or-later.xml
+++ b/src/GFDL-1.1-or-later.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-  <license licenseId="GFDL-1.1" isOsiApproved="false"
-  name="GNU Free Documentation License v1.1">
+  <license licenseId="GFDL-1.1-or-later" isOsiApproved="false"
+  name="GNU Free Documentation License v1.1 or later">
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/old-licenses/fdl-1.1.txt</crossRef>
     </crossRefs>

--- a/src/GFDL-1.1-or-later.xml
+++ b/src/GFDL-1.1-or-later.xml
@@ -1,0 +1,481 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SPDXLicenseCollection xmlns="http://www.spdx.org/license">
+  <license licenseId="GFDL-1.1" isOsiApproved="false"
+  name="GNU Free Documentation License v1.1">
+    <crossRefs>
+      <crossRef>http://www.gnu.org/licenses/old-licenses/fdl-1.1.txt</crossRef>
+    </crossRefs>
+    <standardLicenseHeader>
+      Copyright (c) <alt name="copyright" match=".+">YEAR YOUR NAME</alt>
+      . Permission is granted to copy, distribute and/or modify this
+      document under the terms of the GNU Free Documentation License,
+      Version 1.1 or any later version published by the Free Software
+      Foundation; with the Invariant Sections being LIST THEIR
+      TITLES, with the Front-Cover Texts being LIST, and with the
+      Back-Cover Texts being LIST. A copy of the license is included
+      in the section entitled "GNU Free Documentation License".
+    </standardLicenseHeader>
+    <notes>
+      This license was released March 2000
+    </notes>
+    <titleText>
+      <p>
+        GNU Free Documentation License<br></br>
+        Version 1.1, March 2000
+      </p>
+    </titleText>
+    <p>
+      Copyright (C) 2000 Free Software Foundation, Inc. 51
+      Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+    </p>
+    <p>
+      Everyone is permitted to copy and distribute verbatim copies
+      of this license document, but changing it is not allowed.
+    </p>
+    <list>
+      <item>
+        <bullet>0.</bullet>
+        PREAMBLE
+        <p>
+          The purpose of this License is to make a manual, textbook,
+          or other written document "free" in the sense of freedom: to
+          assure everyone the effective freedom to copy and redistribute
+          it, with or without modifying it, either commercially or
+          noncommercially. Secondarily, this License preserves for the
+          author and publisher a way to get credit for their work, while
+          not being considered responsible for modifications made by others.
+        </p>
+        <p>
+          This License is a kind of "copyleft", which means that
+          derivative works of the document must themselves be free in
+          the same sense. It complements the GNU General Public License,
+          which is a copyleft license designed for free software.
+        </p>
+        <p>
+          We have designed this License in order to use it for manuals for
+          free software, because free software needs free documentation: a free
+          program should come with manuals providing the same freedoms that the
+          software does. But this License is not limited to software manuals;
+          it can be used for any textual work, regardless of subject matter or
+          whether it is published as a printed book. We recommend this License
+          principally for works whose purpose is instruction or reference.
+        </p>
+      </item>
+      <item>
+        <bullet>1.</bullet>
+        APPLICABILITY AND DEFINITIONS
+        <p>
+          This License applies to any manual or other work that
+          contains a notice placed by the copyright holder saying
+          it can be distributed under the terms of this License. The
+          "Document", below, refers to any such manual or work. Any
+          member of the public is a licensee, and is addressed as "you".
+        </p>
+        <p>
+          A "Modified Version" of the Document means any work containing
+          the Document or a portion of it, either copied verbatim, or
+          with modifications and/or translated into another language.
+        </p>
+        <p>
+          A "Secondary Section" is a named appendix or a front-matter section
+          of the Document that deals exclusively with the relationship
+          of the publishers or authors of the Document to the Document's
+          overall subject (or to related matters) and contains nothing
+          that could fall directly within that overall subject. (For
+          example, if the Document is in part a textbook of mathematics,
+          a Secondary Section may not explain any mathematics.) The
+          relationship could be a matter of historical connection with
+          the subject or with related matters, or of legal, commercial,
+          philosophical, ethical or political position regarding them.
+        </p>
+        <p>
+          The "Invariant Sections" are certain Secondary Sections whose
+          titles are designated, as being those of Invariant Sections, in the
+          notice that says that the Document is released under this License.
+        </p>
+        <p>
+          The "Cover Texts" are certain short passages of text that are
+          listed, as Front-Cover Texts or Back-Cover Texts, in the notice
+          that says that the Document is released under this License.
+        </p>
+        <p>
+          A "Transparent" copy of the Document means a machine-readable copy,
+          represented in a format whose specification is available to the
+          general public, whose contents can be viewed and edited directly
+          and straightforwardly with generic text editors or (for images
+          composed of pixels) generic paint programs or (for drawings) some
+          widely available drawing editor, and that is suitable for input
+          to text formatters or for automatic translation to a variety of
+          formats suitable for input to text formatters. A copy made in an
+          otherwise Transparent file format whose markup has been designed
+          to thwart or discourage subsequent modification by readers is not
+          Transparent. A copy that is not "Transparent" is called "Opaque".
+        </p>
+        <p>
+          Examples of suitable formats for Transparent copies include
+          plain ASCII without markup, Texinfo input format, LaTeX
+          input format, SGML or XML using a publicly available DTD, and
+          standard-conforming simple HTML designed for human modification.
+          Opaque formats include PostScript, PDF, proprietary formats
+          that can be read and edited only by proprietary word processors,
+          SGML or XML for which the DTD and/or processing tools are
+          not generally available, and the machine-generated HTML
+          produced by some word processors for output purposes only.
+        </p>
+        <p>
+          The "Title Page" means, for a printed book, the title page itself,
+          plus such following pages as are needed to hold, legibly, the
+          material this License requires to appear in the title page. For
+          works in formats which do not have any title page as such, "Title
+          Page" means the text near the most prominent appearance of the
+          work's title, preceding the beginning of the body of the text.
+        </p>
+      </item>
+      <item>
+        <bullet>2.</bullet>
+        VERBATIM COPYING
+        <p>
+          You may copy and distribute the Document in any medium, either
+          commercially or noncommercially, provided that this License, the
+          copyright notices, and the license notice saying this License applies
+          to the Document are reproduced in all copies, and that you add no
+          other conditions whatsoever to those of this License. You may not
+          use technical measures to obstruct or control the reading or further
+          copying of the copies you make or distribute. However, you may accept
+          compensation in exchange for copies. If you distribute a large enough
+          number of copies you must also follow the conditions in section 3.
+        </p>
+        <p>
+          You may also lend copies, under the same conditions
+          stated above, and you may publicly display copies.
+        </p>
+      </item>
+      <item>
+        <bullet>3.</bullet>
+        COPYING IN QUANTITY
+        <p>
+          If you publish printed copies of the Document numbering more than
+          100, and the Document's license notice requires Cover Texts, you
+          must enclose the copies in covers that carry, clearly and legibly,
+          all these Cover Texts: Front-Cover Texts on the front cover, and
+          Back-Cover Texts on the back cover. Both covers must also clearly
+          and legibly identify you as the publisher of these copies. The
+          front cover must present the full title with all words of the title
+          equally prominent and visible. You may add other material on the
+          covers in addition. Copying with changes limited to the covers, as
+          long as they preserve the title of the Document and satisfy these
+          conditions, can be treated as verbatim copying in other respects.
+        </p>
+        <p>
+          If the required texts for either cover are too
+          voluminous to fit legibly, you should put the first
+          ones listed (as many as fit reasonably) on the actual
+          cover, and continue the rest onto adjacent pages.
+        </p>
+        <p>
+          If you publish or distribute Opaque copies of the Document
+          numbering more than 100, you must either include a machine-readable
+          Transparent copy along with each Opaque copy, or state in or with
+          each Opaque copy a publicly-accessible computer-network location
+          containing a complete Transparent copy of the Document, free
+          of added material, which the general network-using public has
+          access to download anonymously at no charge using public-standard
+          network protocols. If you use the latter option, you must take
+          reasonably prudent steps, when you begin distribution of Opaque
+          copies in quantity, to ensure that this Transparent copy will
+          remain thus accessible at the stated location until at least one
+          year after the last time you distribute an Opaque copy (directly
+          or through your agents or retailers) of that edition to the public.
+        </p>
+        <p>
+          It is requested, but not required, that you contact
+          the authors of the Document well before redistributing
+          any large number of copies, to give them a chance to
+          provide you with an updated version of the Document.
+        </p>
+      </item>
+      <item>
+        <bullet>4.</bullet>
+        MODIFICATIONS
+        <p>
+          You may copy and distribute a Modified Version of the Document under
+          the conditions of sections 2 and 3 above, provided that you release
+          the Modified Version under precisely this License, with the Modified
+          Version filling the role of the Document, thus licensing distribution
+          and modification of the Modified Version to whoever possesses a copy
+          of it. In addition, you must do these things in the Modified Version:
+        </p>
+        <list>
+          <item>
+            <bullet>A.</bullet>
+            Use in the Title Page (and on the covers, if any) a title distinct
+            from that of the Document, and from those of previous versions
+            (which should, if there were any, be listed in the History section
+            of the Document). You may use the same title as a previous version
+            if the original publisher of that version gives permission.
+          </item>
+          <item>
+            <bullet>B.</bullet>
+            List on the Title Page, as authors, one or more persons or entities
+            responsible for authorship of the modifications in the Modified
+            Version, together with at least five of the principal authors of the
+            Document (all of its principal authors, if it has less than five).
+          </item>
+          <item>
+            <bullet>C.</bullet>
+            State on the Title page the name of the publisher
+            of the Modified Version, as the publisher.
+          </item>
+          <item>
+            <bullet>D.</bullet>
+            Preserve all the copyright notices of the Document.
+          </item>
+          <item>
+            <bullet>E.</bullet>
+            Add an appropriate copyright notice for your
+            modifications adjacent to the other copyright notices.
+          </item>
+          <item>
+            <bullet>F.</bullet>
+            Include, immediately after the copyright notices, a license notice
+            giving the public permission to use the Modified Version under the
+            terms of this License, in the form shown in the Addendum below.
+          </item>
+          <item>
+            <bullet>G.</bullet>
+            Preserve in that license notice the full lists of Invariant Sections
+            and required Cover Texts given in the Document's license notice.
+          </item>
+          <item>
+            <bullet>H.</bullet>
+            Include an unaltered copy of this License.
+          </item>
+          <item>
+            <bullet>I.</bullet>
+            Preserve the section entitled "History", and its title, and add
+            to it an item stating at least the title, year, new authors,
+            and publisher of the Modified Version as given on the Title
+            Page. If there is no section entitled "History" in the Document,
+            create one stating the title, year, authors, and publisher
+            of the Document as given on its Title Page, then add an item
+            describing the Modified Version as stated in the previous sentence.
+          </item>
+          <item>
+            <bullet>J.</bullet>
+            Preserve the network location, if any, given in the Document
+            for public access to a Transparent copy of the Document, and
+            likewise the network locations given in the Document for previous
+            versions it was based on. These may be placed in the "History"
+            section. You may omit a network location for a work that was
+            published at least four years before the Document itself, or if the
+            original publisher of the version it refers to gives permission.
+          </item>
+          <item>
+            <bullet>K.</bullet>
+            In any section entitled "Acknowledgements" or "Dedications",
+            preserve the section's title, and preserve in the section
+            all the substance and tone of each of the contributor
+            acknowledgements and/or dedications given therein.
+          </item>
+          <item>
+            <bullet>L.</bullet>
+            Preserve all the Invariant Sections of the Document, unaltered
+            in their text and in their titles. Section numbers or the
+            equivalent are not considered part of the section titles.
+          </item>
+          <item>
+            <bullet>M.</bullet>
+            Delete any section entitled "Endorsements". Such a
+            section may not be included in the Modified Version.
+          </item>
+          <item>
+            <bullet>N.</bullet>
+            Do not retitle any existing section as "Endorsements"
+            or to conflict in title with any Invariant Section.
+          </item>
+        </list>
+        <p>
+          If the Modified Version includes new front-matter sections or
+          appendices that qualify as Secondary Sections and contain no material
+          copied from the Document, you may at your option designate some or
+          all of these sections as invariant. To do this, add their titles
+          to the list of Invariant Sections in the Modified Version's license
+          notice. These titles must be distinct from any other section titles.
+        </p>
+        <p>
+          You may add a section entitled "Endorsements", provided
+          it contains nothing but endorsements of your Modified
+          Version by various parties--for example, statements of
+          peer review or that the text has been approved by an
+          organization as the authoritative definition of a standard.
+        </p>
+        <p>
+          You may add a passage of up to five words as a Front-Cover Text,
+          and a passage of up to 25 words as a Back-Cover Text, to the end of
+          the list of Cover Texts in the Modified Version. Only one passage
+          of Front-Cover Text and one of Back-Cover Text may be added by (or
+          through arrangements made by) any one entity. If the Document already
+          includes a cover text for the same cover, previously added by you or
+          by arrangement made by the same entity you are acting on behalf of,
+          you may not add another; but you may replace the old one, on explicit
+          permission from the previous publisher that added the old one.
+        </p>
+        <p>
+          The author(s) and publisher(s) of the Document do not by this
+          License give permission to use their names for publicity for
+          or to assert or imply endorsement of any Modified Version.
+        </p>
+      </item>
+      <item>
+        <bullet>5.</bullet>
+        COMBINING DOCUMENTS
+        <p>
+          You may combine the Document with other documents released
+          under this License, under the terms defined in section 4
+          above for modified versions, provided that you include in
+          the combination all of the Invariant Sections of all of
+          the original documents, unmodified, and list them all as
+          Invariant Sections of your combined work in its license notice.
+        </p>
+        <p>
+          The combined work need only contain one copy of this License, and
+          multiple identical Invariant Sections may be replaced with a single
+          copy. If there are multiple Invariant Sections with the same name
+          but different contents, make the title of each such section unique
+          by adding at the end of it, in parentheses, the name of the original
+          author or publisher of that section if known, or else a unique
+          number. Make the same adjustment to the section titles in the list
+          of Invariant Sections in the license notice of the combined work.
+        </p>
+        <p>
+          In the combination, you must combine any sections entitled
+          "History" in the various original documents, forming one section
+          entitled "History"; likewise combine any sections entitled
+          "Acknowledgements", and any sections entitled "Dedications".
+          You must delete all sections entitled "Endorsements."
+        </p>
+      </item>
+      <item>
+        <bullet>6.</bullet>
+        COLLECTIONS OF DOCUMENTS
+        <p>
+          You may make a collection consisting of the Document and
+          other documents released under this License, and replace the
+          individual copies of this License in the various documents
+          with a single copy that is included in the collection,
+          provided that you follow the rules of this License for verbatim
+          copying of each of the documents in all other respects.
+        </p>
+        <p>
+          You may extract a single document from such a collection,
+          and distribute it individually under this License,
+          provided you insert a copy of this License into the
+          extracted document, and follow this License in all other
+          respects regarding verbatim copying of that document.
+        </p>
+      </item>
+      <item>
+        <bullet>7.</bullet>
+        AGGREGATION WITH INDEPENDENT WORKS
+        <p>
+          A compilation of the Document or its derivatives with other separate
+          and independent documents or works, in or on a volume of a storage
+          or distribution medium, does not as a whole count as a Modified
+          Version of the Document, provided no compilation copyright is claimed
+          for the compilation. Such a compilation is called an "aggregate",
+          and this License does not apply to the other self-contained works
+          thus compiled with the Document, on account of their being thus
+          compiled, if they are not themselves derivative works of the Document.
+        </p>
+        <p>
+          If the Cover Text requirement of section 3 is applicable to these
+          copies of the Document, then if the Document is less than one quarter
+          of the entire aggregate, the Document's Cover Texts may be placed
+          on covers that surround only the Document within the aggregate.
+          Otherwise they must appear on covers around the whole aggregate.
+        </p>
+      </item>
+      <item>
+        <bullet>8.</bullet>
+        TRANSLATION
+        <p>
+          Translation is considered a kind of modification, so you may
+          distribute translations of the Document under the terms of
+          section 4. Replacing Invariant Sections with translations requires
+          special permission from their copyright holders, but you may
+          include translations of some or all Invariant Sections in addition
+          to the original versions of these Invariant Sections. You may
+          include a translation of this License provided that you also
+          include the original English version of this License. In case of
+          a disagreement between the translation and the original English
+          version of this License, the original English version will prevail.
+        </p>
+      </item>
+      <item>
+        <bullet>9.</bullet>
+        TERMINATION
+        <p>
+          You may not copy, modify, sublicense, or distribute the Document
+          except as expressly provided for under this License. Any other
+          attempt to copy, modify, sublicense or distribute the Document
+          is void, and will automatically terminate your rights under
+          this License. However, parties who have received copies, or
+          rights, from you under this License will not have their licenses
+          terminated so long as such parties remain in full compliance.
+        </p>
+      </item>
+      <item>
+        <bullet>10.</bullet>
+        FUTURE REVISIONS OF THIS LICENSE
+        <p>
+          The Free Software Foundation may publish new, revised
+          versions of the GNU Free Documentation License from time
+          to time. Such new versions will be similar in spirit to
+          the present version, but may differ in detail to address
+          new problems or concerns. See http://www.gnu.org/copyleft/.
+        </p>
+        <p>
+          Each version of the License is given a distinguishing version number.
+          If the Document specifies that a particular numbered version of this
+          License "or any later version" applies to it, you have the option
+          of following the terms and conditions either of that specified
+          version or of any later version that has been published (not as a
+          draft) by the Free Software Foundation. If the Document does not
+          specify a version number of this License, you may choose any version
+          ever published (not as a draft) by the Free Software Foundation.
+        </p>
+      </item>
+    </list>
+    <optional>
+      <p>
+        ADDENDUM: How to use this License for your documents
+      </p>
+      <p>
+        To use this License in a document you have written, include
+        a copy of the License in the document and put the following
+        copyright and license notices just after the title page:
+      </p>
+      <p>
+        Copyright (c) YEAR YOUR NAME. Permission is granted to copy,
+        distribute and/or modify this document under the terms of the
+        GNU Free Documentation License, Version 1.1 or any later version
+        published by the Free Software Foundation; with the Invariant Sections
+        being LIST THEIR TITLES, with the Front-Cover Texts being LIST,
+        and with the Back-Cover Texts being LIST. A copy of the license is
+        included in the section entitled "GNU Free Documentation License".
+      </p>
+      <p>
+        If you have no Invariant Sections, write "with no Invariant
+        Sections" instead of saying which ones are invariant. If you have
+        no Front-Cover Texts, write "no Front-Cover Texts" instead of
+        "Front-Cover Texts being LIST"; likewise for Back-Cover Texts.
+      </p>
+      <p>
+        If your document contains nontrivial examples of program
+        code, we recommend releasing these examples in parallel
+        under your choice of free software license, such as the GNU
+        General Public License, to permit their use in free software.
+      </p>
+    </optional>
+  </license>
+</SPDXLicenseCollection>

--- a/src/GFDL-1.1.xml
+++ b/src/GFDL-1.1.xml
@@ -1,10 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
   <license licenseId="GFDL-1.1" isOsiApproved="false"
-  name="GNU Free Documentation License v1.1">
+  name="GNU Free Documentation License v1.1"
+  isDeprecated="true" deprecatedVersion="3.0">
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/old-licenses/fdl-1.1.txt</crossRef>
     </crossRefs>
+    <notes>
+      DEPRECATED: Deprecated in lieu of more
+      explicit license identifier of GFDL-1.1-only
+    </notes>
     <standardLicenseHeader>
       Copyright (c) <alt name="copyright" match=".+">YEAR YOUR NAME</alt>
       . Permission is granted to copy, distribute and/or modify this

--- a/src/GFDL-1.1.xml
+++ b/src/GFDL-1.1.xml
@@ -1,332 +1,481 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isOsiApproved="false" licenseId="GFDL-1.1"
-            name="GNU Free Documentation License v1.1">
-      <crossRefs>
-         <crossRef>http://www.gnu.org/licenses/old-licenses/fdl-1.1.txt</crossRef>
-      </crossRefs>
-      <standardLicenseHeader> Copyright (c) 
-    <alt match=".+" name="copyright">YEAR YOUR NAME</alt>. Permission is granted to copy, distribute and/or modify
-    this document under the terms of the GNU Free Documentation License, Version 1.1 or any later version published
-    by the Free Software Foundation; with the Invariant Sections being LIST THEIR TITLES, with the Front-Cover Texts
-    being LIST, and with the Back-Cover Texts being LIST. A copy of the license is included in the section entitled
-    "GNU Free Documentation License". 
-  </standardLicenseHeader>
-      <notes>This license was released March 2000</notes>
-      <titleText>
-         <p>GNU Free Documentation License 
-        <br/>Version 1.1, March 2000 
+  <license licenseId="GFDL-1.1" isOsiApproved="false"
+  name="GNU Free Documentation License v1.1">
+    <crossRefs>
+      <crossRef>http://www.gnu.org/licenses/old-licenses/fdl-1.1.txt</crossRef>
+    </crossRefs>
+    <standardLicenseHeader>
+      Copyright (c) <alt name="copyright" match=".+">YEAR YOUR NAME</alt>
+      . Permission is granted to copy, distribute and/or modify this
+      document under the terms of the GNU Free Documentation License,
+      Version 1.1 or any later version published by the Free Software
+      Foundation; with the Invariant Sections being LIST THEIR
+      TITLES, with the Front-Cover Texts being LIST, and with the
+      Back-Cover Texts being LIST. A copy of the license is included
+      in the section entitled "GNU Free Documentation License".
+    </standardLicenseHeader>
+    <notes>
+      This license was released March 2000
+    </notes>
+    <titleText>
+      <p>
+        GNU Free Documentation License<br></br>
+        Version 1.1, March 2000
       </p>
-      </titleText>
-      <p>Copyright (C) 2000 Free Software Foundation, Inc. 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA</p>
-      <p>Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is
-         not allowed.</p>
-      <list>
-        <item>
-            <bullet>0.</bullet>
-          PREAMBLE
-          <p>The purpose of this License is to make a manual, textbook, or other written document "free" in
-             the sense of freedom: to assure everyone the effective freedom to copy and redistribute it, with or
-             without modifying it, either commercially or noncommercially. Secondarily, this License preserves for
-             the author and publisher a way to get credit for their work, while not being considered responsible
-             for modifications made by others.</p>
-            <p>This License is a kind of "copyleft", which means that derivative works of the document must
-             themselves be free in the same sense. It complements the GNU General Public License, which is a
-             copyleft license designed for free software.</p>
-            <p>We have designed this License in order to use it for manuals for free software, because free software
-             needs free documentation: a free program should come with manuals providing the same freedoms that the
-             software does. But this License is not limited to software manuals; it can be used for any textual
-             work, regardless of subject matter or whether it is published as a printed book. We recommend this
-             License principally for works whose purpose is instruction or reference.</p>
-        </item>
-        <item>
-            <bullet>1.</bullet>
-          APPLICABILITY AND DEFINITIONS
-          <p>This License applies to any manual or other work that contains a notice placed by the copyright
-             holder saying it can be distributed under the terms of this License. The "Document",
-             below, refers to any such manual or work. Any member of the public is a licensee, and is
-             addressed as "you".</p>
-            <p>A "Modified Version" of the Document means any work containing the Document or a
-             portion of it, either copied verbatim, or with modifications and/or translated into another
-             language.</p>
-            <p>A "Secondary Section" is a named appendix or a front-matter section of the Document
-             that deals exclusively with the relationship of the publishers or authors of the Document to
-             the Document's overall subject (or to related matters) and contains nothing that could
-             fall directly within that overall subject. (For example, if the Document is in part a textbook
-             of mathematics, a Secondary Section may not explain any mathematics.) The relationship could
-             be a matter of historical connection with the subject or with related matters, or of legal,
-             commercial, philosophical, ethical or political position regarding them.</p>
-            <p>The "Invariant Sections" are certain Secondary Sections whose titles are designated, as
-             being those of Invariant Sections, in the notice that says that the Document is released under
-             this License.</p>
-            <p>The "Cover Texts" are certain short passages of text that are listed, as Front-Cover
-             Texts or Back-Cover Texts, in the notice that says that the Document is released under this
-             License.</p>
-            <p>A "Transparent" copy of the Document means a machine-readable copy, represented in a
-             format whose specification is available to the general public, whose contents can be viewed
-             and edited directly and straightforwardly with generic text editors or (for images composed of
-             pixels) generic paint programs or (for drawings) some widely available drawing editor, and
-             that is suitable for input to text formatters or for automatic translation to a variety of
-             formats suitable for input to text formatters. A copy made in an otherwise Transparent file
-             format whose markup has been designed to thwart or discourage subsequent modification by
-             readers is not Transparent. A copy that is not "Transparent" is called
-             "Opaque".</p>
-            <p>Examples of suitable formats for Transparent copies include plain ASCII without markup, Texinfo
-             input format, LaTeX input format, SGML or XML using a publicly available DTD, and
-             standard-conforming simple HTML designed for human modification. Opaque formats include
-             PostScript, PDF, proprietary formats that can be read and edited only by proprietary word
-             processors, SGML or XML for which the DTD and/or processing tools are not generally available,
-             and the machine-generated HTML produced by some word processors for output purposes only.</p>
-            <p>The "Title Page" means, for a printed book, the title page itself, plus such following
-             pages as are needed to hold, legibly, the material this License requires to appear in the
-             title page. For works in formats which do not have any title page as such, "Title
-             Page" means the text near the most prominent appearance of the work's title,
-             preceding the beginning of the body of the text.</p>
-        </item>
-        <item>
-            <bullet>2.</bullet>
-          VERBATIM COPYING
-          <p>You may copy and distribute the Document in any medium, either commercially or noncommercially,
-             provided that this License, the copyright notices, and the license notice saying this License
-             applies to the Document are reproduced in all copies, and that you add no other conditions
-             whatsoever to those of this License. You may not use technical measures to obstruct or control
-             the reading or further copying of the copies you make or distribute. However, you may accept
-             compensation in exchange for copies. If you distribute a large enough number of copies you
-             must also follow the conditions in section 3.</p>
-            <p>You may also lend copies, under the same conditions stated above, and you may publicly display copies.</p>
-        </item>
-        <item>
-            <bullet>3.</bullet>
-          COPYING IN QUANTITY
-          <p>If you publish printed copies of the Document numbering more than 100, and the Document's
-             license notice requires Cover Texts, you must enclose the copies in covers that carry, clearly
-             and legibly, all these Cover Texts: Front-Cover Texts on the front cover, and Back-Cover Texts
-             on the back cover. Both covers must also clearly and legibly identify you as the publisher of
-             these copies. The front cover must present the full title with all words of the title equally
-             prominent and visible. You may add other material on the covers in addition. Copying with
-             changes limited to the covers, as long as they preserve the title of the Document and satisfy
-             these conditions, can be treated as verbatim copying in other respects.</p>
-            <p>If the required texts for either cover are too voluminous to fit legibly, you should put the
-             first ones listed (as many as fit reasonably) on the actual cover, and continue the rest onto
-             adjacent pages.</p>
-            <p>If you publish or distribute Opaque copies of the Document numbering more than 100, you must
-             either include a machine-readable Transparent copy along with each Opaque copy, or state in or
-             with each Opaque copy a publicly-accessible computer-network location containing a complete
-             Transparent copy of the Document, free of added material, which the general network-using
-             public has access to download anonymously at no charge using public-standard network
-             protocols. If you use the latter option, you must take reasonably prudent steps, when you
-             begin distribution of Opaque copies in quantity, to ensure that this Transparent copy will
-             remain thus accessible at the stated location until at least one year after the last time you
-             distribute an Opaque copy (directly or through your agents or retailers) of that edition to
-             the public.</p>
-            <p>It is requested, but not required, that you contact the authors of the Document well before
-             redistributing any large number of copies, to give them a chance to provide you with an
-             updated version of the Document.</p>
-        </item>
-        <item>
-            <bullet>4.</bullet>
-          MODIFICATIONS
-          <p>You may copy and distribute a Modified Version of the Document under the conditions of sections 2
-             and 3 above, provided that you release the Modified Version under precisely this License, with
-             the Modified Version filling the role of the Document, thus licensing distribution and
-             modification of the Modified Version to whoever possesses a copy of it. In addition, you must
-             do these things in the Modified Version:</p>
-            <list>
-               <item>
-                  <bullet>A.</bullet>
-            Use in the Title Page (and on the covers, if any) a title distinct from that of the Document,
-               and from those of previous versions (which should, if there were any, be listed in the
-               History section of the Document). You may use the same title as a previous version if the
-               original publisher of that version gives permission.
+    </titleText>
+    <p>
+      Copyright (C) 2000 Free Software Foundation, Inc. 51
+      Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+    </p>
+    <p>
+      Everyone is permitted to copy and distribute verbatim copies
+      of this license document, but changing it is not allowed.
+    </p>
+    <list>
+      <item>
+        <bullet>0.</bullet>
+        PREAMBLE
+        <p>
+          The purpose of this License is to make a manual, textbook,
+          or other written document "free" in the sense of freedom: to
+          assure everyone the effective freedom to copy and redistribute
+          it, with or without modifying it, either commercially or
+          noncommercially. Secondarily, this License preserves for the
+          author and publisher a way to get credit for their work, while
+          not being considered responsible for modifications made by others.
+        </p>
+        <p>
+          This License is a kind of "copyleft", which means that
+          derivative works of the document must themselves be free in
+          the same sense. It complements the GNU General Public License,
+          which is a copyleft license designed for free software.
+        </p>
+        <p>
+          We have designed this License in order to use it for manuals for
+          free software, because free software needs free documentation: a free
+          program should come with manuals providing the same freedoms that the
+          software does. But this License is not limited to software manuals;
+          it can be used for any textual work, regardless of subject matter or
+          whether it is published as a printed book. We recommend this License
+          principally for works whose purpose is instruction or reference.
+        </p>
+      </item>
+      <item>
+        <bullet>1.</bullet>
+        APPLICABILITY AND DEFINITIONS
+        <p>
+          This License applies to any manual or other work that
+          contains a notice placed by the copyright holder saying
+          it can be distributed under the terms of this License. The
+          "Document", below, refers to any such manual or work. Any
+          member of the public is a licensee, and is addressed as "you".
+        </p>
+        <p>
+          A "Modified Version" of the Document means any work containing
+          the Document or a portion of it, either copied verbatim, or
+          with modifications and/or translated into another language.
+        </p>
+        <p>
+          A "Secondary Section" is a named appendix or a front-matter section
+          of the Document that deals exclusively with the relationship
+          of the publishers or authors of the Document to the Document's
+          overall subject (or to related matters) and contains nothing
+          that could fall directly within that overall subject. (For
+          example, if the Document is in part a textbook of mathematics,
+          a Secondary Section may not explain any mathematics.) The
+          relationship could be a matter of historical connection with
+          the subject or with related matters, or of legal, commercial,
+          philosophical, ethical or political position regarding them.
+        </p>
+        <p>
+          The "Invariant Sections" are certain Secondary Sections whose
+          titles are designated, as being those of Invariant Sections, in the
+          notice that says that the Document is released under this License.
+        </p>
+        <p>
+          The "Cover Texts" are certain short passages of text that are
+          listed, as Front-Cover Texts or Back-Cover Texts, in the notice
+          that says that the Document is released under this License.
+        </p>
+        <p>
+          A "Transparent" copy of the Document means a machine-readable copy,
+          represented in a format whose specification is available to the
+          general public, whose contents can be viewed and edited directly
+          and straightforwardly with generic text editors or (for images
+          composed of pixels) generic paint programs or (for drawings) some
+          widely available drawing editor, and that is suitable for input
+          to text formatters or for automatic translation to a variety of
+          formats suitable for input to text formatters. A copy made in an
+          otherwise Transparent file format whose markup has been designed
+          to thwart or discourage subsequent modification by readers is not
+          Transparent. A copy that is not "Transparent" is called "Opaque".
+        </p>
+        <p>
+          Examples of suitable formats for Transparent copies include
+          plain ASCII without markup, Texinfo input format, LaTeX
+          input format, SGML or XML using a publicly available DTD, and
+          standard-conforming simple HTML designed for human modification.
+          Opaque formats include PostScript, PDF, proprietary formats
+          that can be read and edited only by proprietary word processors,
+          SGML or XML for which the DTD and/or processing tools are
+          not generally available, and the machine-generated HTML
+          produced by some word processors for output purposes only.
+        </p>
+        <p>
+          The "Title Page" means, for a printed book, the title page itself,
+          plus such following pages as are needed to hold, legibly, the
+          material this License requires to appear in the title page. For
+          works in formats which do not have any title page as such, "Title
+          Page" means the text near the most prominent appearance of the
+          work's title, preceding the beginning of the body of the text.
+        </p>
+      </item>
+      <item>
+        <bullet>2.</bullet>
+        VERBATIM COPYING
+        <p>
+          You may copy and distribute the Document in any medium, either
+          commercially or noncommercially, provided that this License, the
+          copyright notices, and the license notice saying this License applies
+          to the Document are reproduced in all copies, and that you add no
+          other conditions whatsoever to those of this License. You may not
+          use technical measures to obstruct or control the reading or further
+          copying of the copies you make or distribute. However, you may accept
+          compensation in exchange for copies. If you distribute a large enough
+          number of copies you must also follow the conditions in section 3.
+        </p>
+        <p>
+          You may also lend copies, under the same conditions
+          stated above, and you may publicly display copies.
+        </p>
+      </item>
+      <item>
+        <bullet>3.</bullet>
+        COPYING IN QUANTITY
+        <p>
+          If you publish printed copies of the Document numbering more than
+          100, and the Document's license notice requires Cover Texts, you
+          must enclose the copies in covers that carry, clearly and legibly,
+          all these Cover Texts: Front-Cover Texts on the front cover, and
+          Back-Cover Texts on the back cover. Both covers must also clearly
+          and legibly identify you as the publisher of these copies. The
+          front cover must present the full title with all words of the title
+          equally prominent and visible. You may add other material on the
+          covers in addition. Copying with changes limited to the covers, as
+          long as they preserve the title of the Document and satisfy these
+          conditions, can be treated as verbatim copying in other respects.
+        </p>
+        <p>
+          If the required texts for either cover are too
+          voluminous to fit legibly, you should put the first
+          ones listed (as many as fit reasonably) on the actual
+          cover, and continue the rest onto adjacent pages.
+        </p>
+        <p>
+          If you publish or distribute Opaque copies of the Document
+          numbering more than 100, you must either include a machine-readable
+          Transparent copy along with each Opaque copy, or state in or with
+          each Opaque copy a publicly-accessible computer-network location
+          containing a complete Transparent copy of the Document, free
+          of added material, which the general network-using public has
+          access to download anonymously at no charge using public-standard
+          network protocols. If you use the latter option, you must take
+          reasonably prudent steps, when you begin distribution of Opaque
+          copies in quantity, to ensure that this Transparent copy will
+          remain thus accessible at the stated location until at least one
+          year after the last time you distribute an Opaque copy (directly
+          or through your agents or retailers) of that edition to the public.
+        </p>
+        <p>
+          It is requested, but not required, that you contact
+          the authors of the Document well before redistributing
+          any large number of copies, to give them a chance to
+          provide you with an updated version of the Document.
+        </p>
+      </item>
+      <item>
+        <bullet>4.</bullet>
+        MODIFICATIONS
+        <p>
+          You may copy and distribute a Modified Version of the Document under
+          the conditions of sections 2 and 3 above, provided that you release
+          the Modified Version under precisely this License, with the Modified
+          Version filling the role of the Document, thus licensing distribution
+          and modification of the Modified Version to whoever possesses a copy
+          of it. In addition, you must do these things in the Modified Version:
+        </p>
+        <list>
+          <item>
+            <bullet>A.</bullet>
+            Use in the Title Page (and on the covers, if any) a title distinct
+            from that of the Document, and from those of previous versions
+            (which should, if there were any, be listed in the History section
+            of the Document). You may use the same title as a previous version
+            if the original publisher of that version gives permission.
           </item>
-               <item>
-                  <bullet>B.</bullet>
-            List on the Title Page, as authors, one or more persons or entities responsible for
-               authorship of the modifications in the Modified Version, together with at least five of
-               the principal authors of the Document (all of its principal authors, if it has less than
-               five).
+          <item>
+            <bullet>B.</bullet>
+            List on the Title Page, as authors, one or more persons or entities
+            responsible for authorship of the modifications in the Modified
+            Version, together with at least five of the principal authors of the
+            Document (all of its principal authors, if it has less than five).
           </item>
-               <item>
-                  <bullet>C.</bullet>
-            State on the Title page the name of the publisher of the Modified Version, as the publisher.
+          <item>
+            <bullet>C.</bullet>
+            State on the Title page the name of the publisher
+            of the Modified Version, as the publisher.
           </item>
-               <item>
-                  <bullet>D.</bullet>
+          <item>
+            <bullet>D.</bullet>
             Preserve all the copyright notices of the Document.
           </item>
-               <item>
-                  <bullet>E.</bullet>
-            Add an appropriate copyright notice for your modifications adjacent to the other copyright notices.
+          <item>
+            <bullet>E.</bullet>
+            Add an appropriate copyright notice for your
+            modifications adjacent to the other copyright notices.
           </item>
-               <item>
-                  <bullet>F.</bullet>
-            Include, immediately after the copyright notices, a license notice giving the public
-               permission to use the Modified Version under the terms of this License, in the form shown
-               in the Addendum below.
+          <item>
+            <bullet>F.</bullet>
+            Include, immediately after the copyright notices, a license notice
+            giving the public permission to use the Modified Version under the
+            terms of this License, in the form shown in the Addendum below.
           </item>
-               <item>
-                  <bullet>G.</bullet>
-            Preserve in that license notice the full lists of Invariant Sections and required Cover Texts
-               given in the Document's license notice.
+          <item>
+            <bullet>G.</bullet>
+            Preserve in that license notice the full lists of Invariant Sections
+            and required Cover Texts given in the Document's license notice.
           </item>
-               <item>
-                  <bullet>H.</bullet>
+          <item>
+            <bullet>H.</bullet>
             Include an unaltered copy of this License.
           </item>
-               <item>
-                  <bullet>I.</bullet>
-            Preserve the section entitled "History", and its title, and add to it an item
-               stating at least the title, year, new authors, and publisher of the Modified Version as
-               given on the Title Page. If there is no section entitled "History" in the
-               Document, create one stating the title, year, authors, and publisher of the Document as
-               given on its Title Page, then add an item describing the Modified Version as stated in the
-               previous sentence.
+          <item>
+            <bullet>I.</bullet>
+            Preserve the section entitled "History", and its title, and add
+            to it an item stating at least the title, year, new authors,
+            and publisher of the Modified Version as given on the Title
+            Page. If there is no section entitled "History" in the Document,
+            create one stating the title, year, authors, and publisher
+            of the Document as given on its Title Page, then add an item
+            describing the Modified Version as stated in the previous sentence.
           </item>
-               <item>
-                  <bullet>J.</bullet>
-            Preserve the network location, if any, given in the Document for public access to a
-               Transparent copy of the Document, and likewise the network locations given in the Document
-               for previous versions it was based on. These may be placed in the "History"
-               section. You may omit a network location for a work that was published at least four years
-               before the Document itself, or if the original publisher of the version it refers to gives
-               permission.
+          <item>
+            <bullet>J.</bullet>
+            Preserve the network location, if any, given in the Document
+            for public access to a Transparent copy of the Document, and
+            likewise the network locations given in the Document for previous
+            versions it was based on. These may be placed in the "History"
+            section. You may omit a network location for a work that was
+            published at least four years before the Document itself, or if the
+            original publisher of the version it refers to gives permission.
           </item>
-               <item>
-                  <bullet>K.</bullet>
-            In any section entitled "Acknowledgements" or "Dedications", preserve the
-               section's title, and preserve in the section all the substance and tone of each of
-               the contributor acknowledgements and/or dedications given therein.
+          <item>
+            <bullet>K.</bullet>
+            In any section entitled "Acknowledgements" or "Dedications",
+            preserve the section's title, and preserve in the section
+            all the substance and tone of each of the contributor
+            acknowledgements and/or dedications given therein.
           </item>
-               <item>
-                  <bullet>L.</bullet>
-            Preserve all the Invariant Sections of the Document, unaltered in their text and in their
-               titles. Section numbers or the equivalent are not considered part of the section
-               titles.
+          <item>
+            <bullet>L.</bullet>
+            Preserve all the Invariant Sections of the Document, unaltered
+            in their text and in their titles. Section numbers or the
+            equivalent are not considered part of the section titles.
           </item>
-               <item>
-                  <bullet>M.</bullet>
-            Delete any section entitled "Endorsements". Such a section may not be included in
-               the Modified Version.
+          <item>
+            <bullet>M.</bullet>
+            Delete any section entitled "Endorsements". Such a
+            section may not be included in the Modified Version.
           </item>
-               <item>
-                  <bullet>N.</bullet>
-            Do not retitle any existing section as "Endorsements" or to conflict in title with
-               any Invariant Section.
+          <item>
+            <bullet>N.</bullet>
+            Do not retitle any existing section as "Endorsements"
+            or to conflict in title with any Invariant Section.
           </item>
-            </list>
-            <p>If the Modified Version includes new front-matter sections or appendices that qualify as
-               Secondary Sections and contain no material copied from the Document, you may at your
-               option designate some or all of these sections as invariant. To do this, add their titles
-               to the list of Invariant Sections in the Modified Version's license notice. These
-               titles must be distinct from any other section titles.</p>
-            <p>You may add a section entitled "Endorsements", provided it contains nothing but
-               endorsements of your Modified Version by various parties--for example, statements of peer
-               review or that the text has been approved by an organization as the authoritative
-               definition of a standard.</p>
-            <p>You may add a passage of up to five words as a Front-Cover Text, and a passage of up to 25
-               words as a Back-Cover Text, to the end of the list of Cover Texts in the Modified Version.
-               Only one passage of Front-Cover Text and one of Back-Cover Text may be added by (or
-               through arrangements made by) any one entity. If the Document already includes a cover
-               text for the same cover, previously added by you or by arrangement made by the same entity
-               you are acting on behalf of, you may not add another; but you may replace the old one, on
-               explicit permission from the previous publisher that added the old one.</p>
-            <p>The author(s) and publisher(s) of the Document do not by this License give permission to use
-               their names for publicity for or to assert or imply endorsement of any Modified
-               Version.</p>
-        </item>
-        <item>
-            <bullet>5.</bullet>
-          COMBINING DOCUMENTS
-          <p>You may combine the Document with other documents released under this License, under the terms
-             defined in section 4 above for modified versions, provided that you include in the combination
-             all of the Invariant Sections of all of the original documents, unmodified, and list them all
-             as Invariant Sections of your combined work in its license notice.</p>
-            <p>The combined work need only contain one copy of this License, and multiple identical Invariant
-             Sections may be replaced with a single copy. If there are multiple Invariant Sections with the
-             same name but different contents, make the title of each such section unique by adding at the
-             end of it, in parentheses, the name of the original author or publisher of that section if
-             known, or else a unique number. Make the same adjustment to the section titles in the list of
-             Invariant Sections in the license notice of the combined work.</p>
-            <p>In the combination, you must combine any sections entitled "History" in the various
-             original documents, forming one section entitled "History"; likewise combine any
-             sections entitled "Acknowledgements", and any sections entitled
-             "Dedications". You must delete all sections entitled "Endorsements."</p>
-        </item>
-        <item>
-            <bullet>6.</bullet>
-          COLLECTIONS OF DOCUMENTS
-          <p>You may make a collection consisting of the Document and other documents released under this
-             License, and replace the individual copies of this License in the various documents with a
-             single copy that is included in the collection, provided that you follow the rules of this
-             License for verbatim copying of each of the documents in all other respects.</p>
-            <p>You may extract a single document from such a collection, and distribute it individually under
-             this License, provided you insert a copy of this License into the extracted document, and
-             follow this License in all other respects regarding verbatim copying of that document.</p>
-        </item>
-        <item>
-            <bullet>7.</bullet>
-          AGGREGATION WITH INDEPENDENT WORKS
-          <p>A compilation of the Document or its derivatives with other separate and independent documents or
-             works, in or on a volume of a storage or distribution medium, does not as a whole count as a
-             Modified Version of the Document, provided no compilation copyright is claimed for the
-             compilation. Such a compilation is called an "aggregate", and this License does not
-             apply to the other self-contained works thus compiled with the Document, on account of their
-             being thus compiled, if they are not themselves derivative works of the Document.</p>
-            <p>If the Cover Text requirement of section 3 is applicable to these copies of the Document, then if
-             the Document is less than one quarter of the entire aggregate, the Document's Cover Texts
-             may be placed on covers that surround only the Document within the aggregate. Otherwise they
-             must appear on covers around the whole aggregate.</p>
-        </item>
-        <item>
-            <bullet>8.</bullet>
-          TRANSLATION
-          <p>Translation is considered a kind of modification, so you may distribute translations of the
-             Document under the terms of section 4. Replacing Invariant Sections with translations requires
-             special permission from their copyright holders, but you may include translations of some or
-             all Invariant Sections in addition to the original versions of these Invariant Sections. You
-             may include a translation of this License provided that you also include the original English
-             version of this License. In case of a disagreement between the translation and the original
-             English version of this License, the original English version will prevail.</p>
-        </item>
-        <item>
-            <bullet>9.</bullet>
-          TERMINATION
-          <p>You may not copy, modify, sublicense, or distribute the Document except as expressly provided for
-             under this License. Any other attempt to copy, modify, sublicense or distribute the Document
-             is void, and will automatically terminate your rights under this License. However, parties who
-             have received copies, or rights, from you under this License will not have their licenses
-             terminated so long as such parties remain in full compliance.</p>
-        </item>
-        <item>
-            <bullet>10.</bullet>
-          FUTURE REVISIONS OF THIS LICENSE
-
-      <p>The Free Software Foundation may publish new, revised versions of the GNU Free Documentation License from
-         time to time. Such new versions will be similar in spirit to the present version, but may differ in
-         detail to address new problems or concerns. See http://www.gnu.org/copyleft/.</p>
-            <p>Each version of the License is given a distinguishing version number. If the Document specifies that a
-         particular numbered version of this License "or any later version" applies to it, you have
-         the option of following the terms and conditions either of that specified version or of any later
-         version that has been published (not as a draft) by the Free Software Foundation. If the Document does
-         not specify a version number of this License, you may choose any version ever published (not as a
-         draft) by the Free Software Foundation.</p>
-        </item>
-      </list>
-      <optional>
-         <p>ADDENDUM: How to use this License for your documents</p>
-         <p>To use this License in a document you have written, include a copy of the License in the document and put
-         the following copyright and license notices just after the title page:</p>
-         <p>Copyright (c) YEAR YOUR NAME. Permission is granted to copy, distribute and/or modify this document under
-         the terms of the GNU Free Documentation License, Version 1.1 or any later version published by the
-         Free Software Foundation; with the Invariant Sections being LIST THEIR TITLES, with the Front-Cover
-         Texts being LIST, and with the Back-Cover Texts being LIST. A copy of the license is included in the
-         section entitled "GNU Free Documentation License".</p>
-         <p>If you have no Invariant Sections, write "with no Invariant Sections" instead of saying which
-         ones are invariant. If you have no Front-Cover Texts, write "no Front-Cover Texts" instead
-         of "Front-Cover Texts being LIST"; likewise for Back-Cover Texts.</p>
-         <p>If your document contains nontrivial examples of program code, we recommend releasing these examples in
-         parallel under your choice of free software license, such as the GNU General Public License, to permit
-         their use in free software.</p>
-      </optional>
+        </list>
+        <p>
+          If the Modified Version includes new front-matter sections or
+          appendices that qualify as Secondary Sections and contain no material
+          copied from the Document, you may at your option designate some or
+          all of these sections as invariant. To do this, add their titles
+          to the list of Invariant Sections in the Modified Version's license
+          notice. These titles must be distinct from any other section titles.
+        </p>
+        <p>
+          You may add a section entitled "Endorsements", provided
+          it contains nothing but endorsements of your Modified
+          Version by various parties--for example, statements of
+          peer review or that the text has been approved by an
+          organization as the authoritative definition of a standard.
+        </p>
+        <p>
+          You may add a passage of up to five words as a Front-Cover Text,
+          and a passage of up to 25 words as a Back-Cover Text, to the end of
+          the list of Cover Texts in the Modified Version. Only one passage
+          of Front-Cover Text and one of Back-Cover Text may be added by (or
+          through arrangements made by) any one entity. If the Document already
+          includes a cover text for the same cover, previously added by you or
+          by arrangement made by the same entity you are acting on behalf of,
+          you may not add another; but you may replace the old one, on explicit
+          permission from the previous publisher that added the old one.
+        </p>
+        <p>
+          The author(s) and publisher(s) of the Document do not by this
+          License give permission to use their names for publicity for
+          or to assert or imply endorsement of any Modified Version.
+        </p>
+      </item>
+      <item>
+        <bullet>5.</bullet>
+        COMBINING DOCUMENTS
+        <p>
+          You may combine the Document with other documents released
+          under this License, under the terms defined in section 4
+          above for modified versions, provided that you include in
+          the combination all of the Invariant Sections of all of
+          the original documents, unmodified, and list them all as
+          Invariant Sections of your combined work in its license notice.
+        </p>
+        <p>
+          The combined work need only contain one copy of this License, and
+          multiple identical Invariant Sections may be replaced with a single
+          copy. If there are multiple Invariant Sections with the same name
+          but different contents, make the title of each such section unique
+          by adding at the end of it, in parentheses, the name of the original
+          author or publisher of that section if known, or else a unique
+          number. Make the same adjustment to the section titles in the list
+          of Invariant Sections in the license notice of the combined work.
+        </p>
+        <p>
+          In the combination, you must combine any sections entitled
+          "History" in the various original documents, forming one section
+          entitled "History"; likewise combine any sections entitled
+          "Acknowledgements", and any sections entitled "Dedications".
+          You must delete all sections entitled "Endorsements."
+        </p>
+      </item>
+      <item>
+        <bullet>6.</bullet>
+        COLLECTIONS OF DOCUMENTS
+        <p>
+          You may make a collection consisting of the Document and
+          other documents released under this License, and replace the
+          individual copies of this License in the various documents
+          with a single copy that is included in the collection,
+          provided that you follow the rules of this License for verbatim
+          copying of each of the documents in all other respects.
+        </p>
+        <p>
+          You may extract a single document from such a collection,
+          and distribute it individually under this License,
+          provided you insert a copy of this License into the
+          extracted document, and follow this License in all other
+          respects regarding verbatim copying of that document.
+        </p>
+      </item>
+      <item>
+        <bullet>7.</bullet>
+        AGGREGATION WITH INDEPENDENT WORKS
+        <p>
+          A compilation of the Document or its derivatives with other separate
+          and independent documents or works, in or on a volume of a storage
+          or distribution medium, does not as a whole count as a Modified
+          Version of the Document, provided no compilation copyright is claimed
+          for the compilation. Such a compilation is called an "aggregate",
+          and this License does not apply to the other self-contained works
+          thus compiled with the Document, on account of their being thus
+          compiled, if they are not themselves derivative works of the Document.
+        </p>
+        <p>
+          If the Cover Text requirement of section 3 is applicable to these
+          copies of the Document, then if the Document is less than one quarter
+          of the entire aggregate, the Document's Cover Texts may be placed
+          on covers that surround only the Document within the aggregate.
+          Otherwise they must appear on covers around the whole aggregate.
+        </p>
+      </item>
+      <item>
+        <bullet>8.</bullet>
+        TRANSLATION
+        <p>
+          Translation is considered a kind of modification, so you may
+          distribute translations of the Document under the terms of
+          section 4. Replacing Invariant Sections with translations requires
+          special permission from their copyright holders, but you may
+          include translations of some or all Invariant Sections in addition
+          to the original versions of these Invariant Sections. You may
+          include a translation of this License provided that you also
+          include the original English version of this License. In case of
+          a disagreement between the translation and the original English
+          version of this License, the original English version will prevail.
+        </p>
+      </item>
+      <item>
+        <bullet>9.</bullet>
+        TERMINATION
+        <p>
+          You may not copy, modify, sublicense, or distribute the Document
+          except as expressly provided for under this License. Any other
+          attempt to copy, modify, sublicense or distribute the Document
+          is void, and will automatically terminate your rights under
+          this License. However, parties who have received copies, or
+          rights, from you under this License will not have their licenses
+          terminated so long as such parties remain in full compliance.
+        </p>
+      </item>
+      <item>
+        <bullet>10.</bullet>
+        FUTURE REVISIONS OF THIS LICENSE
+        <p>
+          The Free Software Foundation may publish new, revised
+          versions of the GNU Free Documentation License from time
+          to time. Such new versions will be similar in spirit to
+          the present version, but may differ in detail to address
+          new problems or concerns. See http://www.gnu.org/copyleft/.
+        </p>
+        <p>
+          Each version of the License is given a distinguishing version number.
+          If the Document specifies that a particular numbered version of this
+          License "or any later version" applies to it, you have the option
+          of following the terms and conditions either of that specified
+          version or of any later version that has been published (not as a
+          draft) by the Free Software Foundation. If the Document does not
+          specify a version number of this License, you may choose any version
+          ever published (not as a draft) by the Free Software Foundation.
+        </p>
+      </item>
+    </list>
+    <optional>
+      <p>
+        ADDENDUM: How to use this License for your documents
+      </p>
+      <p>
+        To use this License in a document you have written, include
+        a copy of the License in the document and put the following
+        copyright and license notices just after the title page:
+      </p>
+      <p>
+        Copyright (c) YEAR YOUR NAME. Permission is granted to copy,
+        distribute and/or modify this document under the terms of the
+        GNU Free Documentation License, Version 1.1 or any later version
+        published by the Free Software Foundation; with the Invariant Sections
+        being LIST THEIR TITLES, with the Front-Cover Texts being LIST,
+        and with the Back-Cover Texts being LIST. A copy of the license is
+        included in the section entitled "GNU Free Documentation License".
+      </p>
+      <p>
+        If you have no Invariant Sections, write "with no Invariant
+        Sections" instead of saying which ones are invariant. If you have
+        no Front-Cover Texts, write "no Front-Cover Texts" instead of
+        "Front-Cover Texts being LIST"; likewise for Back-Cover Texts.
+      </p>
+      <p>
+        If your document contains nontrivial examples of program
+        code, we recommend releasing these examples in parallel
+        under your choice of free software license, such as the GNU
+        General Public License, to permit their use in free software.
+      </p>
+    </optional>
   </license>
 </SPDXLicenseCollection>

--- a/src/GFDL-1.2-only.xml
+++ b/src/GFDL-1.2-only.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-  <license licenseId="GFDL-1.2" isOsiApproved="false"
-  name="GNU Free Documentation License v1.2">
+  <license licenseId="GFDL-1.2-only" isOsiApproved="false"
+  name="GNU Free Documentation License v1.2 only">
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/old-licenses/fdl-1.2.txt</crossRef>
     </crossRefs>

--- a/src/GFDL-1.2-only.xml
+++ b/src/GFDL-1.2-only.xml
@@ -9,8 +9,7 @@
       Copyright (c)<alt name="copyright" match=".+">YEAR YOUR NAME</alt>
       . Permission is granted to copy, distribute and/or modify this
       document under the terms of the GNU Free Documentation License,
-      Version 1.2 or any later version published by the Free Software
-      Foundation; with no Invariant Sections, no Front-Cover Texts,
+      Version 1.2; with no Invariant Sections, no Front-Cover Texts,
       and no Back-Cover Texts. A copy of the license is included
       in the section entitled "GNU Free Documentation License".
     </standardLicenseHeader>

--- a/src/GFDL-1.2-only.xml
+++ b/src/GFDL-1.2-only.xml
@@ -1,0 +1,529 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SPDXLicenseCollection xmlns="http://www.spdx.org/license">
+  <license licenseId="GFDL-1.2" isOsiApproved="false"
+  name="GNU Free Documentation License v1.2">
+    <crossRefs>
+      <crossRef>http://www.gnu.org/licenses/old-licenses/fdl-1.2.txt</crossRef>
+    </crossRefs>
+    <standardLicenseHeader>
+      Copyright (c)<alt name="copyright" match=".+">YEAR YOUR NAME</alt>
+      . Permission is granted to copy, distribute and/or modify this
+      document under the terms of the GNU Free Documentation License,
+      Version 1.2 or any later version published by the Free Software
+      Foundation; with no Invariant Sections, no Front-Cover Texts,
+      and no Back-Cover Texts. A copy of the license is included
+      in the section entitled "GNU Free Documentation License".
+    </standardLicenseHeader>
+    <notes>
+      This license was released November 2002
+    </notes>
+    <titleText>
+      <p>
+        GNU Free Documentation License<br></br>
+        Version 1.2, November 2002
+      </p>
+    </titleText>
+    <p>
+      Copyright (C) 2000,2001,2002 Free Software Foundation,
+      Inc. 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+    </p>
+    <p>
+      Everyone is permitted to copy and distribute verbatim copies
+      of this license document, but changing it is not allowed.
+    </p>
+    <list>
+      <item>
+        <bullet>0.</bullet>
+        PREAMBLE
+        <p>
+          The purpose of this License is to make a manual, textbook, or
+          other functional and useful document "free" in the sense of
+          freedom: to assure everyone the effective freedom to copy and
+          redistribute it, with or without modifying it, either commercially
+          or noncommercially. Secondarily, this License preserves for the
+          author and publisher a way to get credit for their work, while
+          not being considered responsible for modifications made by others.
+        </p>
+        <p>
+          This License is a kind of "copyleft", which means that
+          derivative works of the document must themselves be free in
+          the same sense. It complements the GNU General Public License,
+          which is a copyleft license designed for free software.
+        </p>
+        <p>
+          We have designed this License in order to use it for manuals for
+          free software, because free software needs free documentation: a free
+          program should come with manuals providing the same freedoms that the
+          software does. But this License is not limited to software manuals;
+          it can be used for any textual work, regardless of subject matter or
+          whether it is published as a printed book. We recommend this License
+          principally for works whose purpose is instruction or reference.
+        </p>
+      </item>
+      <item>
+        <bullet>1.</bullet>
+        APPLICABILITY AND DEFINITIONS
+        <p>
+          This License applies to any manual or other work, in any medium,
+          that contains a notice placed by the copyright holder saying
+          it can be distributed under the terms of this License. Such a
+          notice grants a world-wide, royalty-free license, unlimited in
+          duration, to use that work under the conditions stated herein.
+          The "Document", below, refers to any such manual or work.
+          Any member of the public is a licensee, and is addressed as
+          "you". You accept the license if you copy, modify or distribute
+          the work in a way requiring permission under copyright law.
+        </p>
+        <p>
+          A "Modified Version" of the Document means any work containing
+          the Document or a portion of it, either copied verbatim, or
+          with modifications and/or translated into another language.
+        </p>
+        <p>
+          A "Secondary Section" is a named appendix or a front-matter
+          section of the Document that deals exclusively with the
+          relationship of the publishers or authors of the Document to the
+          Document's overall subject (or to related matters) and contains
+          nothing that could fall directly within that overall subject.
+          (Thus, if the Document is in part a textbook of mathematics,
+          a Secondary Section may not explain any mathematics.) The
+          relationship could be a matter of historical connection with
+          the subject or with related matters, or of legal, commercial,
+          philosophical, ethical or political position regarding them.
+        </p>
+        <p>
+          The "Invariant Sections" are certain Secondary Sections whose
+          titles are designated, as being those of Invariant Sections,
+          in the notice that says that the Document is released under
+          this License. If a section does not fit the above definition of
+          Secondary then it is not allowed to be designated as Invariant.
+          The Document may contain zero Invariant Sections. If the Document
+          does not identify any Invariant Sections then there are none.
+        </p>
+        <p>
+          The "Cover Texts" are certain short passages of text that are listed,
+          as Front-Cover Texts or Back-Cover Texts, in the notice that says that
+          the Document is released under this License. A Front-Cover Text may
+          be at most 5 words, and a Back-Cover Text may be at most 25 words.
+        </p>
+        <p>
+          A "Transparent" copy of the Document means a machine-readable
+          copy, represented in a format whose specification is available
+          to the general public, that is suitable for revising the document
+          straightforwardly with generic text editors or (for images composed of
+          pixels) generic paint programs or (for drawings) some widely available
+          drawing editor, and that is suitable for input to text formatters or
+          for automatic translation to a variety of formats suitable for input
+          to text formatters. A copy made in an otherwise Transparent file
+          format whose markup, or absence of markup, has been arranged to thwart
+          or discourage subsequent modification by readers is not Transparent.
+          An image format is not Transparent if used for any substantial
+          amount of text. A copy that is not "Transparent" is called "Opaque".
+        </p>
+        <p>
+          Examples of suitable formats for Transparent copies include plain
+          ASCII without markup, Texinfo input format, LaTeX input format,
+          SGML or XML using a publicly available DTD, and standard-conforming
+          simple HTML, PostScript or PDF designed for human modification.
+          Examples of transparent image formats include PNG, XCF and JPG.
+          Opaque formats include proprietary formats that can be read
+          and edited only by proprietary word processors, SGML or XML
+          for which the DTD and/or processing tools are not generally
+          available, and the machine-generated HTML, PostScript or PDF
+          produced by some word processors for output purposes only.
+        </p>
+        <p>
+          The "Title Page" means, for a printed book, the title page itself,
+          plus such following pages as are needed to hold, legibly, the
+          material this License requires to appear in the title page. For
+          works in formats which do not have any title page as such, "Title
+          Page" means the text near the most prominent appearance of the
+          work's title, preceding the beginning of the body of the text.
+        </p>
+        <p>
+          A section "Entitled XYZ" means a named subunit of the Document whose
+          title either is precisely XYZ or contains XYZ in parentheses following
+          text that translates XYZ in another language. (Here XYZ stands for
+          a specific section name mentioned below, such as "Acknowledgements",
+          "Dedications", "Endorsements", or "History".) To "Preserve the
+          Title" of such a section when you modify the Document means that
+          it remains a section "Entitled XYZ" according to this definition.
+        </p>
+        <p>
+          The Document may include Warranty Disclaimers next to the notice
+          which states that this License applies to the Document. These
+          Warranty Disclaimers are considered to be included by reference
+          in this License, but only as regards disclaiming warranties:
+          any other implication that these Warranty Disclaimers may
+          have is void and has no effect on the meaning of this License.
+        </p>
+      </item>
+      <item>
+        <bullet>2.</bullet>
+        VERBATIM COPYING
+        <p>
+          You may copy and distribute the Document in any medium, either
+          commercially or noncommercially, provided that this License, the
+          copyright notices, and the license notice saying this License applies
+          to the Document are reproduced in all copies, and that you add no
+          other conditions whatsoever to those of this License. You may not
+          use technical measures to obstruct or control the reading or further
+          copying of the copies you make or distribute. However, you may accept
+          compensation in exchange for copies. If you distribute a large enough
+          number of copies you must also follow the conditions in section 3.
+        </p>
+        <p>
+          You may also lend copies, under the same conditions
+          stated above, and you may publicly display copies.
+        </p>
+      </item>
+      <item>
+        <bullet>3.</bullet>
+        COPYING IN QUANTITY
+        <p>
+          If you publish printed copies (or copies in media that commonly
+          have printed covers) of the Document, numbering more than 100,
+          and the Document's license notice requires Cover Texts, you must
+          enclose the copies in covers that carry, clearly and legibly,
+          all these Cover Texts: Front-Cover Texts on the front cover, and
+          Back-Cover Texts on the back cover. Both covers must also clearly
+          and legibly identify you as the publisher of these copies. The
+          front cover must present the full title with all words of the title
+          equally prominent and visible. You may add other material on the
+          covers in addition. Copying with changes limited to the covers, as
+          long as they preserve the title of the Document and satisfy these
+          conditions, can be treated as verbatim copying in other respects.
+        </p>
+        <p>
+          If the required texts for either cover are too
+          voluminous to fit legibly, you should put the first
+          ones listed (as many as fit reasonably) on the actual
+          cover, and continue the rest onto adjacent pages.
+        </p>
+        <p>
+          If you publish or distribute Opaque copies of the Document
+          numbering more than 100, you must either include a machine-readable
+          Transparent copy along with each Opaque copy, or state in or with
+          each Opaque copy a computer-network location from which the general
+          network-using public has access to download using public-standard
+          network protocols a complete Transparent copy of the Document,
+          free of added material. If you use the latter option, you must take
+          reasonably prudent steps, when you begin distribution of Opaque
+          copies in quantity, to ensure that this Transparent copy will
+          remain thus accessible at the stated location until at least one
+          year after the last time you distribute an Opaque copy (directly
+          or through your agents or retailers) of that edition to the public.
+        </p>
+        <p>
+          It is requested, but not required, that you contact
+          the authors of the Document well before redistributing
+          any large number of copies, to give them a chance to
+          provide you with an updated version of the Document.
+        </p>
+      </item>
+      <item>
+        <bullet>4.</bullet>
+        MODIFICATIONS
+        <p>
+          You may copy and distribute a Modified Version of the Document under
+          the conditions of sections 2 and 3 above, provided that you release
+          the Modified Version under precisely this License, with the Modified
+          Version filling the role of the Document, thus licensing distribution
+          and modification of the Modified Version to whoever possesses a copy
+          of it. In addition, you must do these things in the Modified Version:
+        </p>
+        <list>
+          <item>
+            <bullet>A.</bullet>
+            Use in the Title Page (and on the covers, if any) a title distinct
+            from that of the Document, and from those of previous versions
+            (which should, if there were any, be listed in the History section
+            of the Document). You may use the same title as a previous version
+            if the original publisher of that version gives permission.
+          </item>
+          <item>
+            <bullet>B.</bullet>
+            List on the Title Page, as authors, one or more persons or
+            entities responsible for authorship of the modifications in the
+            Modified Version, together with at least five of the principal
+            authors of the Document (all of its principal authors, if it has
+            fewer than five), unless they release you from this requirement.
+          </item>
+          <item>
+            <bullet>C.</bullet>
+            State on the Title page the name of the publisher
+            of the Modified Version, as the publisher.
+          </item>
+          <item>
+            <bullet>D.</bullet>
+            Preserve all the copyright notices of the Document.
+          </item>
+          <item>
+            <bullet>E.</bullet>
+            Add an appropriate copyright notice for your
+            modifications adjacent to the other copyright notices.
+          </item>
+          <item>
+            <bullet>F.</bullet>
+            Include, immediately after the copyright notices, a license notice
+            giving the public permission to use the Modified Version under the
+            terms of this License, in the form shown in the Addendum below.
+          </item>
+          <item>
+            <bullet>G.</bullet>
+            Preserve in that license notice the full lists of Invariant Sections
+            and required Cover Texts given in the Document's license notice.
+          </item>
+          <item>
+            <bullet>H.</bullet>
+            Include an unaltered copy of this License.
+          </item>
+          <item>
+            <bullet>I.</bullet>
+            Preserve the section Entitled "History", Preserve its Title, and
+            add to it an item stating at least the title, year, new authors,
+            and publisher of the Modified Version as given on the Title
+            Page. If there is no section Entitled "History" in the Document,
+            create one stating the title, year, authors, and publisher
+            of the Document as given on its Title Page, then add an item
+            describing the Modified Version as stated in the previous sentence.
+          </item>
+          <item>
+            <bullet>J.</bullet>
+            Preserve the network location, if any, given in the Document
+            for public access to a Transparent copy of the Document, and
+            likewise the network locations given in the Document for previous
+            versions it was based on. These may be placed in the "History"
+            section. You may omit a network location for a work that was
+            published at least four years before the Document itself, or if the
+            original publisher of the version it refers to gives permission.
+          </item>
+          <item>
+            <bullet>K.</bullet>
+            For any section Entitled "Acknowledgements" or "Dedications",
+            Preserve the Title of the section, and preserve in the
+            section all the substance and tone of each of the contributor
+            acknowledgements and/or dedications given therein.
+          </item>
+          <item>
+            <bullet>L.</bullet>
+            Preserve all the Invariant Sections of the Document, unaltered
+            in their text and in their titles. Section numbers or the
+            equivalent are not considered part of the section titles.
+          </item>
+          <item>
+            <bullet>M.</bullet>
+            Delete any section Entitled "Endorsements". Such a
+            section may not be included in the Modified Version.
+          </item>
+          <item>
+            <bullet>N.</bullet>
+            Do not retitle any existing section to be Entitled "Endorsements"
+            or to conflict in title with any Invariant Section.
+          </item>
+          <item>
+            <bullet>O.</bullet>
+            Preserve any Warranty Disclaimers.
+          </item>
+        </list>
+        <p>
+          If the Modified Version includes new front-matter sections or
+          appendices that qualify as Secondary Sections and contain no material
+          copied from the Document, you may at your option designate some or
+          all of these sections as invariant. To do this, add their titles
+          to the list of Invariant Sections in the Modified Version's license
+          notice. These titles must be distinct from any other section titles.
+        </p>
+        <p>
+          You may add a section Entitled "Endorsements", provided
+          it contains nothing but endorsements of your Modified
+          Version by various parties--for example, statements of
+          peer review or that the text has been approved by an
+          organization as the authoritative definition of a standard.
+        </p>
+        <p>
+          You may add a passage of up to five words as a Front-Cover Text,
+          and a passage of up to 25 words as a Back-Cover Text, to the end of
+          the list of Cover Texts in the Modified Version. Only one passage
+          of Front-Cover Text and one of Back-Cover Text may be added by (or
+          through arrangements made by) any one entity. If the Document already
+          includes a cover text for the same cover, previously added by you or
+          by arrangement made by the same entity you are acting on behalf of,
+          you may not add another; but you may replace the old one, on explicit
+          permission from the previous publisher that added the old one.
+        </p>
+        <p>
+          The author(s) and publisher(s) of the Document do not by this
+          License give permission to use their names for publicity for
+          or to assert or imply endorsement of any Modified Version.
+        </p>
+      </item>
+      <item>
+        <bullet>5.</bullet>
+        COMBINING DOCUMENTS
+        <p>
+          You may combine the Document with other documents released under
+          this License, under the terms defined in section 4 above for modified
+          versions, provided that you include in the combination all of the
+          Invariant Sections of all of the original documents, unmodified,
+          and list them all as Invariant Sections of your combined work in its
+          license notice, and that you preserve all their Warranty Disclaimers.
+        </p>
+        <p>
+          The combined work need only contain one copy of this License, and
+          multiple identical Invariant Sections may be replaced with a single
+          copy. If there are multiple Invariant Sections with the same name
+          but different contents, make the title of each such section unique
+          by adding at the end of it, in parentheses, the name of the original
+          author or publisher of that section if known, or else a unique
+          number. Make the same adjustment to the section titles in the list
+          of Invariant Sections in the license notice of the combined work.
+        </p>
+        <p>
+          In the combination, you must combine any sections Entitled
+          "History" in the various original documents, forming one section
+          Entitled "History"; likewise combine any sections Entitled
+          "Acknowledgements", and any sections Entitled "Dedications".
+          You must delete all sections Entitled "Endorsements".
+        </p>
+      </item>
+      <item>
+        <bullet>6.</bullet>
+        COLLECTIONS OF DOCUMENTS
+        <p>
+          You may make a collection consisting of the Document and
+          other documents released under this License, and replace the
+          individual copies of this License in the various documents
+          with a single copy that is included in the collection,
+          provided that you follow the rules of this License for verbatim
+          copying of each of the documents in all other respects.
+        </p>
+        <p>
+          You may extract a single document from such a collection,
+          and distribute it individually under this License,
+          provided you insert a copy of this License into the
+          extracted document, and follow this License in all other
+          respects regarding verbatim copying of that document.
+        </p>
+      </item>
+      <item>
+        <bullet>7.</bullet>
+        AGGREGATION WITH INDEPENDENT WORKS
+        <p>
+          A compilation of the Document or its derivatives with other
+          separate and independent documents or works, in or on a volume
+          of a storage or distribution medium, is called an "aggregate"
+          if the copyright resulting from the compilation is not used to
+          limit the legal rights of the compilation's users beyond what
+          the individual works permit. When the Document is included in an
+          aggregate, this License does not apply to the other works in the
+          aggregate which are not themselves derivative works of the Document.
+        </p>
+        <p>
+          If the Cover Text requirement of section 3 is applicable to
+          these copies of the Document, then if the Document is less
+          than one half of the entire aggregate, the Document's Cover
+          Texts may be placed on covers that bracket the Document
+          within the aggregate, or the electronic equivalent of covers
+          if the Document is in electronic form. Otherwise they must
+          appear on printed covers that bracket the whole aggregate.
+        </p>
+      </item>
+      <item>
+        <bullet>8.</bullet>
+        TRANSLATION
+        <p>
+          Translation is considered a kind of modification, so you may
+          distribute translations of the Document under the terms of section
+          4. Replacing Invariant Sections with translations requires special
+          permission from their copyright holders, but you may include
+          translations of some or all Invariant Sections in addition to the
+          original versions of these Invariant Sections. You may include a
+          translation of this License, and all the license notices in the
+          Document, and any Warranty Disclaimers, provided that you also
+          include the original English version of this License and the original
+          versions of those notices and disclaimers. In case of a disagreement
+          between the translation and the original version of this License
+          or a notice or disclaimer, the original version will prevail.
+        </p>
+        <p>
+          If a section in the Document is Entitled
+          "Acknowledgements", "Dedications", or "History", the
+          requirement (section 4) to Preserve its Title (section
+          1) will typically require changing the actual title.
+        </p>
+      </item>
+      <item>
+        <bullet>9.</bullet>
+        TERMINATION
+        <p>
+          You may not copy, modify, sublicense, or distribute the Document
+          except as expressly provided for under this License. Any other
+          attempt to copy, modify, sublicense or distribute the Document
+          is void, and will automatically terminate your rights under
+          this License. However, parties who have received copies, or
+          rights, from you under this License will not have their licenses
+          terminated so long as such parties remain in full compliance.
+        </p>
+      </item>
+      <item>
+        <bullet>10.</bullet>
+        FUTURE REVISIONS OF THIS LICENSE
+        <p>
+          The Free Software Foundation may publish new, revised
+          versions of the GNU Free Documentation License from time
+          to time. Such new versions will be similar in spirit to
+          the present version, but may differ in detail to address
+          new problems or concerns. See http://www.gnu.org/copyleft/.
+        </p>
+        <p>
+          Each version of the License is given a distinguishing version number.
+          If the Document specifies that a particular numbered version of this
+          License "or any later version" applies to it, you have the option
+          of following the terms and conditions either of that specified
+          version or of any later version that has been published (not as a
+          draft) by the Free Software Foundation. If the Document does not
+          specify a version number of this License, you may choose any version
+          ever published (not as a draft) by the Free Software Foundation.
+        </p>
+      </item>
+    </list>
+    <optional>
+      <p>
+        ADDENDUM: How to use this License for your documents
+      </p>
+      <p>
+        To use this License in a document you have written, include
+        a copy of the License in the document and put the following
+        copyright and license notices just after the title page:
+      </p>
+      <p>
+        Copyright (c) YEAR YOUR NAME. Permission is granted to copy,
+        distribute and/or modify this document under the terms of the GNU
+        Free Documentation License, Version 1.2 or any later version published
+        by the Free Software Foundation; with no Invariant Sections, no
+        Front-Cover Texts, and no Back-Cover Texts. A copy of the license is
+        included in the section entitled "GNU Free Documentation License".
+      </p>
+      <p>
+        If you have Invariant Sections, Front-Cover Texts and
+        Back-Cover Texts, replace the "with...Texts." line with this:
+      </p>
+      <p>
+        with the Invariant Sections being LIST THEIR TITLES, with the
+        Front-Cover Texts being LIST, and with the Back-Cover Texts being LIST.
+      </p>
+      <p>
+        If you have Invariant Sections without Cover Texts,
+        or some other combination of the three, merge
+        those two alternatives to suit the situation.
+      </p>
+      <p>
+        If your document contains nontrivial examples of program
+        code, we recommend releasing these examples in parallel
+        under your choice of free software license, such as the GNU
+        General Public License, to permit their use in free software.
+      </p>
+    </optional>
+  </license>
+</SPDXLicenseCollection>

--- a/src/GFDL-1.2-or-later.xml
+++ b/src/GFDL-1.2-or-later.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-  <license licenseId="GFDL-1.2" isOsiApproved="false"
-  name="GNU Free Documentation License v1.2">
+  <license licenseId="GFDL-1.2-or-later" isOsiApproved="false"
+  name="GNU Free Documentation License v1.2 or later">
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/old-licenses/fdl-1.2.txt</crossRef>
     </crossRefs>

--- a/src/GFDL-1.2-or-later.xml
+++ b/src/GFDL-1.2-or-later.xml
@@ -1,0 +1,529 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SPDXLicenseCollection xmlns="http://www.spdx.org/license">
+  <license licenseId="GFDL-1.2" isOsiApproved="false"
+  name="GNU Free Documentation License v1.2">
+    <crossRefs>
+      <crossRef>http://www.gnu.org/licenses/old-licenses/fdl-1.2.txt</crossRef>
+    </crossRefs>
+    <standardLicenseHeader>
+      Copyright (c)<alt name="copyright" match=".+">YEAR YOUR NAME</alt>
+      . Permission is granted to copy, distribute and/or modify this
+      document under the terms of the GNU Free Documentation License,
+      Version 1.2 or any later version published by the Free Software
+      Foundation; with no Invariant Sections, no Front-Cover Texts,
+      and no Back-Cover Texts. A copy of the license is included
+      in the section entitled "GNU Free Documentation License".
+    </standardLicenseHeader>
+    <notes>
+      This license was released November 2002
+    </notes>
+    <titleText>
+      <p>
+        GNU Free Documentation License<br></br>
+        Version 1.2, November 2002
+      </p>
+    </titleText>
+    <p>
+      Copyright (C) 2000,2001,2002 Free Software Foundation,
+      Inc. 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+    </p>
+    <p>
+      Everyone is permitted to copy and distribute verbatim copies
+      of this license document, but changing it is not allowed.
+    </p>
+    <list>
+      <item>
+        <bullet>0.</bullet>
+        PREAMBLE
+        <p>
+          The purpose of this License is to make a manual, textbook, or
+          other functional and useful document "free" in the sense of
+          freedom: to assure everyone the effective freedom to copy and
+          redistribute it, with or without modifying it, either commercially
+          or noncommercially. Secondarily, this License preserves for the
+          author and publisher a way to get credit for their work, while
+          not being considered responsible for modifications made by others.
+        </p>
+        <p>
+          This License is a kind of "copyleft", which means that
+          derivative works of the document must themselves be free in
+          the same sense. It complements the GNU General Public License,
+          which is a copyleft license designed for free software.
+        </p>
+        <p>
+          We have designed this License in order to use it for manuals for
+          free software, because free software needs free documentation: a free
+          program should come with manuals providing the same freedoms that the
+          software does. But this License is not limited to software manuals;
+          it can be used for any textual work, regardless of subject matter or
+          whether it is published as a printed book. We recommend this License
+          principally for works whose purpose is instruction or reference.
+        </p>
+      </item>
+      <item>
+        <bullet>1.</bullet>
+        APPLICABILITY AND DEFINITIONS
+        <p>
+          This License applies to any manual or other work, in any medium,
+          that contains a notice placed by the copyright holder saying
+          it can be distributed under the terms of this License. Such a
+          notice grants a world-wide, royalty-free license, unlimited in
+          duration, to use that work under the conditions stated herein.
+          The "Document", below, refers to any such manual or work.
+          Any member of the public is a licensee, and is addressed as
+          "you". You accept the license if you copy, modify or distribute
+          the work in a way requiring permission under copyright law.
+        </p>
+        <p>
+          A "Modified Version" of the Document means any work containing
+          the Document or a portion of it, either copied verbatim, or
+          with modifications and/or translated into another language.
+        </p>
+        <p>
+          A "Secondary Section" is a named appendix or a front-matter
+          section of the Document that deals exclusively with the
+          relationship of the publishers or authors of the Document to the
+          Document's overall subject (or to related matters) and contains
+          nothing that could fall directly within that overall subject.
+          (Thus, if the Document is in part a textbook of mathematics,
+          a Secondary Section may not explain any mathematics.) The
+          relationship could be a matter of historical connection with
+          the subject or with related matters, or of legal, commercial,
+          philosophical, ethical or political position regarding them.
+        </p>
+        <p>
+          The "Invariant Sections" are certain Secondary Sections whose
+          titles are designated, as being those of Invariant Sections,
+          in the notice that says that the Document is released under
+          this License. If a section does not fit the above definition of
+          Secondary then it is not allowed to be designated as Invariant.
+          The Document may contain zero Invariant Sections. If the Document
+          does not identify any Invariant Sections then there are none.
+        </p>
+        <p>
+          The "Cover Texts" are certain short passages of text that are listed,
+          as Front-Cover Texts or Back-Cover Texts, in the notice that says that
+          the Document is released under this License. A Front-Cover Text may
+          be at most 5 words, and a Back-Cover Text may be at most 25 words.
+        </p>
+        <p>
+          A "Transparent" copy of the Document means a machine-readable
+          copy, represented in a format whose specification is available
+          to the general public, that is suitable for revising the document
+          straightforwardly with generic text editors or (for images composed of
+          pixels) generic paint programs or (for drawings) some widely available
+          drawing editor, and that is suitable for input to text formatters or
+          for automatic translation to a variety of formats suitable for input
+          to text formatters. A copy made in an otherwise Transparent file
+          format whose markup, or absence of markup, has been arranged to thwart
+          or discourage subsequent modification by readers is not Transparent.
+          An image format is not Transparent if used for any substantial
+          amount of text. A copy that is not "Transparent" is called "Opaque".
+        </p>
+        <p>
+          Examples of suitable formats for Transparent copies include plain
+          ASCII without markup, Texinfo input format, LaTeX input format,
+          SGML or XML using a publicly available DTD, and standard-conforming
+          simple HTML, PostScript or PDF designed for human modification.
+          Examples of transparent image formats include PNG, XCF and JPG.
+          Opaque formats include proprietary formats that can be read
+          and edited only by proprietary word processors, SGML or XML
+          for which the DTD and/or processing tools are not generally
+          available, and the machine-generated HTML, PostScript or PDF
+          produced by some word processors for output purposes only.
+        </p>
+        <p>
+          The "Title Page" means, for a printed book, the title page itself,
+          plus such following pages as are needed to hold, legibly, the
+          material this License requires to appear in the title page. For
+          works in formats which do not have any title page as such, "Title
+          Page" means the text near the most prominent appearance of the
+          work's title, preceding the beginning of the body of the text.
+        </p>
+        <p>
+          A section "Entitled XYZ" means a named subunit of the Document whose
+          title either is precisely XYZ or contains XYZ in parentheses following
+          text that translates XYZ in another language. (Here XYZ stands for
+          a specific section name mentioned below, such as "Acknowledgements",
+          "Dedications", "Endorsements", or "History".) To "Preserve the
+          Title" of such a section when you modify the Document means that
+          it remains a section "Entitled XYZ" according to this definition.
+        </p>
+        <p>
+          The Document may include Warranty Disclaimers next to the notice
+          which states that this License applies to the Document. These
+          Warranty Disclaimers are considered to be included by reference
+          in this License, but only as regards disclaiming warranties:
+          any other implication that these Warranty Disclaimers may
+          have is void and has no effect on the meaning of this License.
+        </p>
+      </item>
+      <item>
+        <bullet>2.</bullet>
+        VERBATIM COPYING
+        <p>
+          You may copy and distribute the Document in any medium, either
+          commercially or noncommercially, provided that this License, the
+          copyright notices, and the license notice saying this License applies
+          to the Document are reproduced in all copies, and that you add no
+          other conditions whatsoever to those of this License. You may not
+          use technical measures to obstruct or control the reading or further
+          copying of the copies you make or distribute. However, you may accept
+          compensation in exchange for copies. If you distribute a large enough
+          number of copies you must also follow the conditions in section 3.
+        </p>
+        <p>
+          You may also lend copies, under the same conditions
+          stated above, and you may publicly display copies.
+        </p>
+      </item>
+      <item>
+        <bullet>3.</bullet>
+        COPYING IN QUANTITY
+        <p>
+          If you publish printed copies (or copies in media that commonly
+          have printed covers) of the Document, numbering more than 100,
+          and the Document's license notice requires Cover Texts, you must
+          enclose the copies in covers that carry, clearly and legibly,
+          all these Cover Texts: Front-Cover Texts on the front cover, and
+          Back-Cover Texts on the back cover. Both covers must also clearly
+          and legibly identify you as the publisher of these copies. The
+          front cover must present the full title with all words of the title
+          equally prominent and visible. You may add other material on the
+          covers in addition. Copying with changes limited to the covers, as
+          long as they preserve the title of the Document and satisfy these
+          conditions, can be treated as verbatim copying in other respects.
+        </p>
+        <p>
+          If the required texts for either cover are too
+          voluminous to fit legibly, you should put the first
+          ones listed (as many as fit reasonably) on the actual
+          cover, and continue the rest onto adjacent pages.
+        </p>
+        <p>
+          If you publish or distribute Opaque copies of the Document
+          numbering more than 100, you must either include a machine-readable
+          Transparent copy along with each Opaque copy, or state in or with
+          each Opaque copy a computer-network location from which the general
+          network-using public has access to download using public-standard
+          network protocols a complete Transparent copy of the Document,
+          free of added material. If you use the latter option, you must take
+          reasonably prudent steps, when you begin distribution of Opaque
+          copies in quantity, to ensure that this Transparent copy will
+          remain thus accessible at the stated location until at least one
+          year after the last time you distribute an Opaque copy (directly
+          or through your agents or retailers) of that edition to the public.
+        </p>
+        <p>
+          It is requested, but not required, that you contact
+          the authors of the Document well before redistributing
+          any large number of copies, to give them a chance to
+          provide you with an updated version of the Document.
+        </p>
+      </item>
+      <item>
+        <bullet>4.</bullet>
+        MODIFICATIONS
+        <p>
+          You may copy and distribute a Modified Version of the Document under
+          the conditions of sections 2 and 3 above, provided that you release
+          the Modified Version under precisely this License, with the Modified
+          Version filling the role of the Document, thus licensing distribution
+          and modification of the Modified Version to whoever possesses a copy
+          of it. In addition, you must do these things in the Modified Version:
+        </p>
+        <list>
+          <item>
+            <bullet>A.</bullet>
+            Use in the Title Page (and on the covers, if any) a title distinct
+            from that of the Document, and from those of previous versions
+            (which should, if there were any, be listed in the History section
+            of the Document). You may use the same title as a previous version
+            if the original publisher of that version gives permission.
+          </item>
+          <item>
+            <bullet>B.</bullet>
+            List on the Title Page, as authors, one or more persons or
+            entities responsible for authorship of the modifications in the
+            Modified Version, together with at least five of the principal
+            authors of the Document (all of its principal authors, if it has
+            fewer than five), unless they release you from this requirement.
+          </item>
+          <item>
+            <bullet>C.</bullet>
+            State on the Title page the name of the publisher
+            of the Modified Version, as the publisher.
+          </item>
+          <item>
+            <bullet>D.</bullet>
+            Preserve all the copyright notices of the Document.
+          </item>
+          <item>
+            <bullet>E.</bullet>
+            Add an appropriate copyright notice for your
+            modifications adjacent to the other copyright notices.
+          </item>
+          <item>
+            <bullet>F.</bullet>
+            Include, immediately after the copyright notices, a license notice
+            giving the public permission to use the Modified Version under the
+            terms of this License, in the form shown in the Addendum below.
+          </item>
+          <item>
+            <bullet>G.</bullet>
+            Preserve in that license notice the full lists of Invariant Sections
+            and required Cover Texts given in the Document's license notice.
+          </item>
+          <item>
+            <bullet>H.</bullet>
+            Include an unaltered copy of this License.
+          </item>
+          <item>
+            <bullet>I.</bullet>
+            Preserve the section Entitled "History", Preserve its Title, and
+            add to it an item stating at least the title, year, new authors,
+            and publisher of the Modified Version as given on the Title
+            Page. If there is no section Entitled "History" in the Document,
+            create one stating the title, year, authors, and publisher
+            of the Document as given on its Title Page, then add an item
+            describing the Modified Version as stated in the previous sentence.
+          </item>
+          <item>
+            <bullet>J.</bullet>
+            Preserve the network location, if any, given in the Document
+            for public access to a Transparent copy of the Document, and
+            likewise the network locations given in the Document for previous
+            versions it was based on. These may be placed in the "History"
+            section. You may omit a network location for a work that was
+            published at least four years before the Document itself, or if the
+            original publisher of the version it refers to gives permission.
+          </item>
+          <item>
+            <bullet>K.</bullet>
+            For any section Entitled "Acknowledgements" or "Dedications",
+            Preserve the Title of the section, and preserve in the
+            section all the substance and tone of each of the contributor
+            acknowledgements and/or dedications given therein.
+          </item>
+          <item>
+            <bullet>L.</bullet>
+            Preserve all the Invariant Sections of the Document, unaltered
+            in their text and in their titles. Section numbers or the
+            equivalent are not considered part of the section titles.
+          </item>
+          <item>
+            <bullet>M.</bullet>
+            Delete any section Entitled "Endorsements". Such a
+            section may not be included in the Modified Version.
+          </item>
+          <item>
+            <bullet>N.</bullet>
+            Do not retitle any existing section to be Entitled "Endorsements"
+            or to conflict in title with any Invariant Section.
+          </item>
+          <item>
+            <bullet>O.</bullet>
+            Preserve any Warranty Disclaimers.
+          </item>
+        </list>
+        <p>
+          If the Modified Version includes new front-matter sections or
+          appendices that qualify as Secondary Sections and contain no material
+          copied from the Document, you may at your option designate some or
+          all of these sections as invariant. To do this, add their titles
+          to the list of Invariant Sections in the Modified Version's license
+          notice. These titles must be distinct from any other section titles.
+        </p>
+        <p>
+          You may add a section Entitled "Endorsements", provided
+          it contains nothing but endorsements of your Modified
+          Version by various parties--for example, statements of
+          peer review or that the text has been approved by an
+          organization as the authoritative definition of a standard.
+        </p>
+        <p>
+          You may add a passage of up to five words as a Front-Cover Text,
+          and a passage of up to 25 words as a Back-Cover Text, to the end of
+          the list of Cover Texts in the Modified Version. Only one passage
+          of Front-Cover Text and one of Back-Cover Text may be added by (or
+          through arrangements made by) any one entity. If the Document already
+          includes a cover text for the same cover, previously added by you or
+          by arrangement made by the same entity you are acting on behalf of,
+          you may not add another; but you may replace the old one, on explicit
+          permission from the previous publisher that added the old one.
+        </p>
+        <p>
+          The author(s) and publisher(s) of the Document do not by this
+          License give permission to use their names for publicity for
+          or to assert or imply endorsement of any Modified Version.
+        </p>
+      </item>
+      <item>
+        <bullet>5.</bullet>
+        COMBINING DOCUMENTS
+        <p>
+          You may combine the Document with other documents released under
+          this License, under the terms defined in section 4 above for modified
+          versions, provided that you include in the combination all of the
+          Invariant Sections of all of the original documents, unmodified,
+          and list them all as Invariant Sections of your combined work in its
+          license notice, and that you preserve all their Warranty Disclaimers.
+        </p>
+        <p>
+          The combined work need only contain one copy of this License, and
+          multiple identical Invariant Sections may be replaced with a single
+          copy. If there are multiple Invariant Sections with the same name
+          but different contents, make the title of each such section unique
+          by adding at the end of it, in parentheses, the name of the original
+          author or publisher of that section if known, or else a unique
+          number. Make the same adjustment to the section titles in the list
+          of Invariant Sections in the license notice of the combined work.
+        </p>
+        <p>
+          In the combination, you must combine any sections Entitled
+          "History" in the various original documents, forming one section
+          Entitled "History"; likewise combine any sections Entitled
+          "Acknowledgements", and any sections Entitled "Dedications".
+          You must delete all sections Entitled "Endorsements".
+        </p>
+      </item>
+      <item>
+        <bullet>6.</bullet>
+        COLLECTIONS OF DOCUMENTS
+        <p>
+          You may make a collection consisting of the Document and
+          other documents released under this License, and replace the
+          individual copies of this License in the various documents
+          with a single copy that is included in the collection,
+          provided that you follow the rules of this License for verbatim
+          copying of each of the documents in all other respects.
+        </p>
+        <p>
+          You may extract a single document from such a collection,
+          and distribute it individually under this License,
+          provided you insert a copy of this License into the
+          extracted document, and follow this License in all other
+          respects regarding verbatim copying of that document.
+        </p>
+      </item>
+      <item>
+        <bullet>7.</bullet>
+        AGGREGATION WITH INDEPENDENT WORKS
+        <p>
+          A compilation of the Document or its derivatives with other
+          separate and independent documents or works, in or on a volume
+          of a storage or distribution medium, is called an "aggregate"
+          if the copyright resulting from the compilation is not used to
+          limit the legal rights of the compilation's users beyond what
+          the individual works permit. When the Document is included in an
+          aggregate, this License does not apply to the other works in the
+          aggregate which are not themselves derivative works of the Document.
+        </p>
+        <p>
+          If the Cover Text requirement of section 3 is applicable to
+          these copies of the Document, then if the Document is less
+          than one half of the entire aggregate, the Document's Cover
+          Texts may be placed on covers that bracket the Document
+          within the aggregate, or the electronic equivalent of covers
+          if the Document is in electronic form. Otherwise they must
+          appear on printed covers that bracket the whole aggregate.
+        </p>
+      </item>
+      <item>
+        <bullet>8.</bullet>
+        TRANSLATION
+        <p>
+          Translation is considered a kind of modification, so you may
+          distribute translations of the Document under the terms of section
+          4. Replacing Invariant Sections with translations requires special
+          permission from their copyright holders, but you may include
+          translations of some or all Invariant Sections in addition to the
+          original versions of these Invariant Sections. You may include a
+          translation of this License, and all the license notices in the
+          Document, and any Warranty Disclaimers, provided that you also
+          include the original English version of this License and the original
+          versions of those notices and disclaimers. In case of a disagreement
+          between the translation and the original version of this License
+          or a notice or disclaimer, the original version will prevail.
+        </p>
+        <p>
+          If a section in the Document is Entitled
+          "Acknowledgements", "Dedications", or "History", the
+          requirement (section 4) to Preserve its Title (section
+          1) will typically require changing the actual title.
+        </p>
+      </item>
+      <item>
+        <bullet>9.</bullet>
+        TERMINATION
+        <p>
+          You may not copy, modify, sublicense, or distribute the Document
+          except as expressly provided for under this License. Any other
+          attempt to copy, modify, sublicense or distribute the Document
+          is void, and will automatically terminate your rights under
+          this License. However, parties who have received copies, or
+          rights, from you under this License will not have their licenses
+          terminated so long as such parties remain in full compliance.
+        </p>
+      </item>
+      <item>
+        <bullet>10.</bullet>
+        FUTURE REVISIONS OF THIS LICENSE
+        <p>
+          The Free Software Foundation may publish new, revised
+          versions of the GNU Free Documentation License from time
+          to time. Such new versions will be similar in spirit to
+          the present version, but may differ in detail to address
+          new problems or concerns. See http://www.gnu.org/copyleft/.
+        </p>
+        <p>
+          Each version of the License is given a distinguishing version number.
+          If the Document specifies that a particular numbered version of this
+          License "or any later version" applies to it, you have the option
+          of following the terms and conditions either of that specified
+          version or of any later version that has been published (not as a
+          draft) by the Free Software Foundation. If the Document does not
+          specify a version number of this License, you may choose any version
+          ever published (not as a draft) by the Free Software Foundation.
+        </p>
+      </item>
+    </list>
+    <optional>
+      <p>
+        ADDENDUM: How to use this License for your documents
+      </p>
+      <p>
+        To use this License in a document you have written, include
+        a copy of the License in the document and put the following
+        copyright and license notices just after the title page:
+      </p>
+      <p>
+        Copyright (c) YEAR YOUR NAME. Permission is granted to copy,
+        distribute and/or modify this document under the terms of the GNU
+        Free Documentation License, Version 1.2 or any later version published
+        by the Free Software Foundation; with no Invariant Sections, no
+        Front-Cover Texts, and no Back-Cover Texts. A copy of the license is
+        included in the section entitled "GNU Free Documentation License".
+      </p>
+      <p>
+        If you have Invariant Sections, Front-Cover Texts and
+        Back-Cover Texts, replace the "with...Texts." line with this:
+      </p>
+      <p>
+        with the Invariant Sections being LIST THEIR TITLES, with the
+        Front-Cover Texts being LIST, and with the Back-Cover Texts being LIST.
+      </p>
+      <p>
+        If you have Invariant Sections without Cover Texts,
+        or some other combination of the three, merge
+        those two alternatives to suit the situation.
+      </p>
+      <p>
+        If your document contains nontrivial examples of program
+        code, we recommend releasing these examples in parallel
+        under your choice of free software license, such as the GNU
+        General Public License, to permit their use in free software.
+      </p>
+    </optional>
+  </license>
+</SPDXLicenseCollection>

--- a/src/GFDL-1.2-or-later.xml
+++ b/src/GFDL-1.2-or-later.xml
@@ -7,7 +7,7 @@
     </crossRefs>
     <standardLicenseHeader>
       Copyright (c)<alt name="copyright" match=".+">YEAR YOUR NAME</alt>
-      . Permission is granted to copy, distribute and/or modify this
+      Permission is granted to copy, distribute and/or modify this
       document under the terms of the GNU Free Documentation License,
       Version 1.2 or any later version published by the Free Software
       Foundation; with no Invariant Sections, no Front-Cover Texts,

--- a/src/GFDL-1.2.xml
+++ b/src/GFDL-1.2.xml
@@ -1,364 +1,529 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isOsiApproved="false" licenseId="GFDL-1.2"
-            name="GNU Free Documentation License v1.2">
-      <crossRefs>
-         <crossRef>http://www.gnu.org/licenses/old-licenses/fdl-1.2.txt</crossRef>
-      </crossRefs>
-      <standardLicenseHeader> Copyright (c) 
-    <alt match=".+" name="copyright">YEAR YOUR NAME</alt>. Permission is granted to copy, distribute and/or modify
-    this document under the terms of the GNU Free Documentation License, Version 1.2 or any later version published
-    by the Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts. A
-    copy of the license is included in the section entitled "GNU Free Documentation License". 
-  </standardLicenseHeader>
-      <notes>This license was released November 2002</notes>
-      <titleText>
-         <p>GNU Free Documentation License 
-        <br/>Version 1.2, November 2002 
+  <license licenseId="GFDL-1.2" isOsiApproved="false"
+  name="GNU Free Documentation License v1.2">
+    <crossRefs>
+      <crossRef>http://www.gnu.org/licenses/old-licenses/fdl-1.2.txt</crossRef>
+    </crossRefs>
+    <standardLicenseHeader>
+      Copyright (c)<alt name="copyright" match=".+">YEAR YOUR NAME</alt>
+      . Permission is granted to copy, distribute and/or modify this
+      document under the terms of the GNU Free Documentation License,
+      Version 1.2 or any later version published by the Free Software
+      Foundation; with no Invariant Sections, no Front-Cover Texts,
+      and no Back-Cover Texts. A copy of the license is included
+      in the section entitled "GNU Free Documentation License".
+    </standardLicenseHeader>
+    <notes>
+      This license was released November 2002
+    </notes>
+    <titleText>
+      <p>
+        GNU Free Documentation License<br></br>
+        Version 1.2, November 2002
       </p>
-      </titleText>
-      <p>Copyright (C) 2000,2001,2002 Free Software Foundation, Inc. 51 Franklin St, Fifth Floor, Boston, MA
-         02110-1301 USA</p>
-      <p>Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is
-         not allowed.</p>
-      <list>
-        <item>
-            <bullet>0.</bullet>
-          PREAMBLE
-          <p>The purpose of this License is to make a manual, textbook, or other functional and useful document
-             "free" in the sense of freedom: to assure everyone the effective freedom to copy and
-             redistribute it, with or without modifying it, either commercially or noncommercially. Secondarily,
-             this License preserves for the author and publisher a way to get credit for their work, while not
-             being considered responsible for modifications made by others.</p>
-            <p>This License is a kind of "copyleft", which means that derivative works of the document must
-             themselves be free in the same sense. It complements the GNU General Public License, which is a
-             copyleft license designed for free software.</p>
-            <p>We have designed this License in order to use it for manuals for free software, because free software
-             needs free documentation: a free program should come with manuals providing the same freedoms that the
-             software does. But this License is not limited to software manuals; it can be used for any textual
-             work, regardless of subject matter or whether it is published as a printed book. We recommend this
-             License principally for works whose purpose is instruction or reference.</p>
-        </item>
-        <item>
-            <bullet>1.</bullet>
-          APPLICABILITY AND DEFINITIONS
-          <p>This License applies to any manual or other work, in any medium, that contains a notice placed by
-             the copyright holder saying it can be distributed under the terms of this License. Such a
-             notice grants a world-wide, royalty-free license, unlimited in duration, to use that work
-             under the conditions stated herein. The "Document", below, refers to any such manual
-             or work. Any member of the public is a licensee, and is addressed as "you". You
-             accept the license if you copy, modify or distribute the work in a way requiring permission
-             under copyright law.</p>
-            <p>A "Modified Version" of the Document means any work containing the Document or a
-             portion of it, either copied verbatim, or with modifications and/or translated into another
-             language.</p>
-            <p>A "Secondary Section" is a named appendix or a front-matter section of the Document
-             that deals exclusively with the relationship of the publishers or authors of the Document to
-             the Document's overall subject (or to related matters) and contains nothing that could
-             fall directly within that overall subject. (Thus, if the Document is in part a textbook of
-             mathematics, a Secondary Section may not explain any mathematics.) The relationship could be a
-             matter of historical connection with the subject or with related matters, or of legal,
-             commercial, philosophical, ethical or political position regarding them.</p>
-            <p>The "Invariant Sections" are certain Secondary Sections whose titles are designated, as
-             being those of Invariant Sections, in the notice that says that the Document is released under
-             this License. If a section does not fit the above definition of Secondary then it is not
-             allowed to be designated as Invariant. The Document may contain zero Invariant Sections. If
-             the Document does not identify any Invariant Sections then there are none.</p>
-            <p>The "Cover Texts" are certain short passages of text that are listed, as Front-Cover
-             Texts or Back-Cover Texts, in the notice that says that the Document is released under this
-             License. A Front-Cover Text may be at most 5 words, and a Back-Cover Text may be at most 25
-             words.</p>
-            <p>A "Transparent" copy of the Document means a machine-readable copy, represented in a
-             format whose specification is available to the general public, that is suitable for revising
-             the document straightforwardly with generic text editors or (for images composed of pixels)
-             generic paint programs or (for drawings) some widely available drawing editor, and that is
-             suitable for input to text formatters or for automatic translation to a variety of formats
-             suitable for input to text formatters. A copy made in an otherwise Transparent file format
-             whose markup, or absence of markup, has been arranged to thwart or discourage subsequent
-             modification by readers is not Transparent. An image format is not Transparent if used for any
-             substantial amount of text. A copy that is not "Transparent" is called
-             "Opaque".</p>
-            <p>Examples of suitable formats for Transparent copies include plain ASCII without markup, Texinfo
-             input format, LaTeX input format, SGML or XML using a publicly available DTD, and
-             standard-conforming simple HTML, PostScript or PDF designed for human modification. Examples
-             of transparent image formats include PNG, XCF and JPG. Opaque formats include proprietary
-             formats that can be read and edited only by proprietary word processors, SGML or XML for which
-             the DTD and/or processing tools are not generally available, and the machine-generated HTML,
-             PostScript or PDF produced by some word processors for output purposes only.</p>
-            <p>The "Title Page" means, for a printed book, the title page itself, plus such following
-             pages as are needed to hold, legibly, the material this License requires to appear in the
-             title page. For works in formats which do not have any title page as such, "Title
-             Page" means the text near the most prominent appearance of the work's title,
-             preceding the beginning of the body of the text.</p>
-            <p>A section "Entitled XYZ" means a named subunit of the Document whose title either is
-             precisely XYZ or contains XYZ in parentheses following text that translates XYZ in another
-             language. (Here XYZ stands for a specific section name mentioned below, such as
-             "Acknowledgements", "Dedications", "Endorsements", or
-             "History".) To "Preserve the Title" of such a section when you modify the
-             Document means that it remains a section "Entitled XYZ" according to this
-             definition.</p>
-            <p>The Document may include Warranty Disclaimers next to the notice which states that this License
-             applies to the Document. These Warranty Disclaimers are considered to be included by reference
-             in this License, but only as regards disclaiming warranties: any other implication that these
-             Warranty Disclaimers may have is void and has no effect on the meaning of this License.</p>
-        </item>
-        <item>
-            <bullet>2.</bullet>
-          VERBATIM COPYING
-          <p>You may copy and distribute the Document in any medium, either commercially or noncommercially,
-             provided that this License, the copyright notices, and the license notice saying this License
-             applies to the Document are reproduced in all copies, and that you add no other conditions
-             whatsoever to those of this License. You may not use technical measures to obstruct or control
-             the reading or further copying of the copies you make or distribute. However, you may accept
-             compensation in exchange for copies. If you distribute a large enough number of copies you
-             must also follow the conditions in section 3.</p>
-            <p>You may also lend copies, under the same conditions stated above, and you may publicly display copies.</p>
-        </item>
-        <item>
-            <bullet>3.</bullet>
-          COPYING IN QUANTITY
-          <p>If you publish printed copies (or copies in media that commonly have printed covers) of the
-             Document, numbering more than 100, and the Document's license notice requires Cover
-             Texts, you must enclose the copies in covers that carry, clearly and legibly, all these Cover
-             Texts: Front-Cover Texts on the front cover, and Back-Cover Texts on the back cover. Both
-             covers must also clearly and legibly identify you as the publisher of these copies. The front
-             cover must present the full title with all words of the title equally prominent and visible.
-             You may add other material on the covers in addition. Copying with changes limited to the
-             covers, as long as they preserve the title of the Document and satisfy these conditions, can
-             be treated as verbatim copying in other respects.</p>
-            <p>If the required texts for either cover are too voluminous to fit legibly, you should put the
-             first ones listed (as many as fit reasonably) on the actual cover, and continue the rest onto
-             adjacent pages.</p>
-            <p>If you publish or distribute Opaque copies of the Document numbering more than 100, you must
-             either include a machine-readable Transparent copy along with each Opaque copy, or state in or
-             with each Opaque copy a computer-network location from which the general network-using public
-             has access to download using public-standard network protocols a complete Transparent copy of
-             the Document, free of added material. If you use the latter option, you must take reasonably
-             prudent steps, when you begin distribution of Opaque copies in quantity, to ensure that this
-             Transparent copy will remain thus accessible at the stated location until at least one year
-             after the last time you distribute an Opaque copy (directly or through your agents or
-             retailers) of that edition to the public.</p>
-            <p>It is requested, but not required, that you contact the authors of the Document well before
-             redistributing any large number of copies, to give them a chance to provide you with an
-             updated version of the Document.</p>
-        </item>
-        <item>
-            <bullet>4.</bullet>
-          MODIFICATIONS
-          <p>You may copy and distribute a Modified Version of the Document under the conditions of sections 2
-             and 3 above, provided that you release the Modified Version under precisely this License, with
-             the Modified Version filling the role of the Document, thus licensing distribution and
-             modification of the Modified Version to whoever possesses a copy of it. In addition, you must
-             do these things in the Modified Version:</p>
-            <list>
-               <item>
-                  <bullet>A.</bullet>
-              Use in the Title Page (and on the covers, if any) a title distinct from that of the Document,
-                 and from those of previous versions (which should, if there were any, be listed in the
-                 History section of the Document). You may use the same title as a previous version if the
-                 original publisher of that version gives permission.
-            </item>
-               <item>
-                  <bullet>B.</bullet>
-              List on the Title Page, as authors, one or more persons or entities responsible for
-                 authorship of the modifications in the Modified Version, together with at least five of
-                 the principal authors of the Document (all of its principal authors, if it has fewer than
-                 five), unless they release you from this requirement.
-            </item>
-               <item>
-                  <bullet>C.</bullet>
-              State on the Title page the name of the publisher of the Modified Version, as the publisher.
-            </item>
-               <item>
-                  <bullet>D.</bullet>
-              Preserve all the copyright notices of the Document.
-            </item>
-               <item>
-                  <bullet>E.</bullet>
-              Add an appropriate copyright notice for your modifications adjacent to the other copyright notices.
-            </item>
-               <item>
-                  <bullet>F.</bullet>
-              Include, immediately after the copyright notices, a license notice giving the public
-                 permission to use the Modified Version under the terms of this License, in the form shown
-                 in the Addendum below.
-            </item>
-               <item>
-                  <bullet>G.</bullet>
-              Preserve in that license notice the full lists of Invariant Sections and required Cover Texts
-                 given in the Document's license notice.
-            </item>
-               <item>
-                  <bullet>H.</bullet>
-              Include an unaltered copy of this License.
-            </item>
-               <item>
-                  <bullet>I.</bullet>
-              Preserve the section Entitled "History", Preserve its Title, and add to it an item
-                 stating at least the title, year, new authors, and publisher of the Modified Version as
-                 given on the Title Page. If there is no section Entitled "History" in the
-                 Document, create one stating the title, year, authors, and publisher of the Document as
-                 given on its Title Page, then add an item describing the Modified Version as stated in the
-                 previous sentence.
-            </item>
-               <item>
-                  <bullet>J.</bullet>
-              Preserve the network location, if any, given in the Document for public access to a
-                 Transparent copy of the Document, and likewise the network locations given in the Document
-                 for previous versions it was based on. These may be placed in the "History"
-                 section. You may omit a network location for a work that was published at least four years
-                 before the Document itself, or if the original publisher of the version it refers to gives
-                 permission.
-            </item>
-               <item>
-                  <bullet>K.</bullet>
-              For any section Entitled "Acknowledgements" or "Dedications", Preserve
-                 the Title of the section, and preserve in the section all the substance and tone of each
-                 of the contributor acknowledgements and/or dedications given therein.
-            </item>
-               <item>
-                  <bullet>L.</bullet>
-              Preserve all the Invariant Sections of the Document, unaltered in their text and in their
-                 titles. Section numbers or the equivalent are not considered part of the section
-                 titles.
-            </item>
-               <item>
-                  <bullet>M.</bullet>
-              Delete any section Entitled "Endorsements". Such a section may not be included in
-                 the Modified Version.
-            </item>
-               <item>
-                  <bullet>N.</bullet>
-              Do not retitle any existing section to be Entitled "Endorsements" or to conflict in
-                 title with any Invariant Section.
-            </item>
-               <item>
-                  <bullet>O.</bullet>
-              Preserve any Warranty Disclaimers.
-            </item>
-            </list>
-            <p>If the Modified Version includes new front-matter sections or appendices that qualify as
-             Secondary Sections and contain no material copied from the Document, you may at your
-             option designate some or all of these sections as invariant. To do this, add their titles
-             to the list of Invariant Sections in the Modified Version's license notice. These
-             titles must be distinct from any other section titles.</p>
-            <p>You may add a section Entitled "Endorsements", provided it contains nothing but
-             endorsements of your Modified Version by various parties--for example, statements of peer
-             review or that the text has been approved by an organization as the authoritative
-             definition of a standard.</p>
-            <p>You may add a passage of up to five words as a Front-Cover Text, and a passage of up to 25
-             words as a Back-Cover Text, to the end of the list of Cover Texts in the Modified Version.
-             Only one passage of Front-Cover Text and one of Back-Cover Text may be added by (or
-             through arrangements made by) any one entity. If the Document already includes a cover
-             text for the same cover, previously added by you or by arrangement made by the same entity
-             you are acting on behalf of, you may not add another; but you may replace the old one, on
-             explicit permission from the previous publisher that added the old one.</p>
-            <p>The author(s) and publisher(s) of the Document do not by this License give permission to use
-             their names for publicity for or to assert or imply endorsement of any Modified
-             Version.</p>
-        </item>
-        <item>
-            <bullet>5.</bullet>
-          COMBINING DOCUMENTS
-          <p>You may combine the Document with other documents released under this License, under the terms
-             defined in section 4 above for modified versions, provided that you include in the combination
-             all of the Invariant Sections of all of the original documents, unmodified, and list them all
-             as Invariant Sections of your combined work in its license notice, and that you preserve all
-             their Warranty Disclaimers.</p>
-            <p>The combined work need only contain one copy of this License, and multiple identical Invariant
-             Sections may be replaced with a single copy. If there are multiple Invariant Sections with the
-             same name but different contents, make the title of each such section unique by adding at the
-             end of it, in parentheses, the name of the original author or publisher of that section if
-             known, or else a unique number. Make the same adjustment to the section titles in the list of
-             Invariant Sections in the license notice of the combined work.</p>
-            <p>In the combination, you must combine any sections Entitled "History" in the various
-             original documents, forming one section Entitled "History"; likewise combine any
-             sections Entitled "Acknowledgements", and any sections Entitled
-             "Dedications". You must delete all sections Entitled "Endorsements".</p>
-        </item>
-        <item>
-            <bullet>6.</bullet>
-          COLLECTIONS OF DOCUMENTS
-          <p>You may make a collection consisting of the Document and other documents released under this
-             License, and replace the individual copies of this License in the various documents with a
-             single copy that is included in the collection, provided that you follow the rules of this
-             License for verbatim copying of each of the documents in all other respects.</p>
-            <p>You may extract a single document from such a collection, and distribute it individually under
-             this License, provided you insert a copy of this License into the extracted document, and
-             follow this License in all other respects regarding verbatim copying of that document.</p>
-        </item>
-        <item>
-            <bullet>7.</bullet>
-          AGGREGATION WITH INDEPENDENT WORKS
-          <p>A compilation of the Document or its derivatives with other separate and independent documents or
-             works, in or on a volume of a storage or distribution medium, is called an
-             "aggregate" if the copyright resulting from the compilation is not used to limit the
-             legal rights of the compilation's users beyond what the individual works permit. When the
-             Document is included in an aggregate, this License does not apply to the other works in the
-             aggregate which are not themselves derivative works of the Document.</p>
-            <p>If the Cover Text requirement of section 3 is applicable to these copies of the Document, then if
-             the Document is less than one half of the entire aggregate, the Document's Cover Texts
-             may be placed on covers that bracket the Document within the aggregate, or the electronic
-             equivalent of covers if the Document is in electronic form. Otherwise they must appear on
-             printed covers that bracket the whole aggregate.</p>
-        </item>
-        <item>
-            <bullet>8.</bullet>
-          TRANSLATION
-          <p>Translation is considered a kind of modification, so you may distribute translations of the
-             Document under the terms of section 4. Replacing Invariant Sections with translations requires
-             special permission from their copyright holders, but you may include translations of some or
-             all Invariant Sections in addition to the original versions of these Invariant Sections. You
-             may include a translation of this License, and all the license notices in the Document, and
-             any Warranty Disclaimers, provided that you also include the original English version of this
-             License and the original versions of those notices and disclaimers. In case of a disagreement
-             between the translation and the original version of this License or a notice or disclaimer,
-             the original version will prevail.</p>
-            <p>If a section in the Document is Entitled "Acknowledgements", "Dedications",
-             or "History", the requirement (section 4) to Preserve its Title (section 1) will
-             typically require changing the actual title.</p>
-        </item>
-        <item>
-            <bullet>9.</bullet>
-          TERMINATION
-          <p>You may not copy, modify, sublicense, or distribute the Document except as expressly provided for
-             under this License. Any other attempt to copy, modify, sublicense or distribute the Document
-             is void, and will automatically terminate your rights under this License. However, parties who
-             have received copies, or rights, from you under this License will not have their licenses
-             terminated so long as such parties remain in full compliance.</p>
-        </item>
-        <item>
-            <bullet>10.</bullet>
-          FUTURE REVISIONS OF THIS LICENSE
-          <p>The Free Software Foundation may publish new, revised versions of the GNU Free Documentation License from
-             time to time. Such new versions will be similar in spirit to the present version, but may differ in
-             detail to address new problems or concerns. See http://www.gnu.org/copyleft/.</p>
-            <p>Each version of the License is given a distinguishing version number. If the Document specifies that a
-             particular numbered version of this License "or any later version" applies to it, you have
-             the option of following the terms and conditions either of that specified version or of any later
-             version that has been published (not as a draft) by the Free Software Foundation. If the Document does
-             not specify a version number of this License, you may choose any version ever published (not as a
-             draft) by the Free Software Foundation.</p>
-        </item>
-      </list>
-      <optional>
-        <p>ADDENDUM: How to use this License for your documents</p>
-        <p>To use this License in a document you have written, include a copy of the License in the document and put
-           the following copyright and license notices just after the title page:</p>
-        <p>Copyright (c) YEAR YOUR NAME. Permission is granted to copy, distribute and/or modify this document under
-           the terms of the GNU Free Documentation License, Version 1.2 or any later version published by the
-           Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts. A
-           copy of the license is included in the section entitled "GNU Free Documentation
-           License".</p>
-        <p>If you have Invariant Sections, Front-Cover Texts and Back-Cover Texts, replace the
-           "with...Texts." line with this:</p>
-        <p>with the Invariant Sections being LIST THEIR TITLES, with the Front-Cover Texts being LIST, and with the
-           Back-Cover Texts being LIST.</p>
-        <p>If you have Invariant Sections without Cover Texts, or some other combination of the three, merge those
-           two alternatives to suit the situation.</p>
-        <p>If your document contains nontrivial examples of program code, we recommend releasing these examples in
-           parallel under your choice of free software license, such as the GNU General Public License, to permit
-           their use in free software.</p>
-      </optional>
+    </titleText>
+    <p>
+      Copyright (C) 2000,2001,2002 Free Software Foundation,
+      Inc. 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+    </p>
+    <p>
+      Everyone is permitted to copy and distribute verbatim copies
+      of this license document, but changing it is not allowed.
+    </p>
+    <list>
+      <item>
+        <bullet>0.</bullet>
+        PREAMBLE
+        <p>
+          The purpose of this License is to make a manual, textbook, or
+          other functional and useful document "free" in the sense of
+          freedom: to assure everyone the effective freedom to copy and
+          redistribute it, with or without modifying it, either commercially
+          or noncommercially. Secondarily, this License preserves for the
+          author and publisher a way to get credit for their work, while
+          not being considered responsible for modifications made by others.
+        </p>
+        <p>
+          This License is a kind of "copyleft", which means that
+          derivative works of the document must themselves be free in
+          the same sense. It complements the GNU General Public License,
+          which is a copyleft license designed for free software.
+        </p>
+        <p>
+          We have designed this License in order to use it for manuals for
+          free software, because free software needs free documentation: a free
+          program should come with manuals providing the same freedoms that the
+          software does. But this License is not limited to software manuals;
+          it can be used for any textual work, regardless of subject matter or
+          whether it is published as a printed book. We recommend this License
+          principally for works whose purpose is instruction or reference.
+        </p>
+      </item>
+      <item>
+        <bullet>1.</bullet>
+        APPLICABILITY AND DEFINITIONS
+        <p>
+          This License applies to any manual or other work, in any medium,
+          that contains a notice placed by the copyright holder saying
+          it can be distributed under the terms of this License. Such a
+          notice grants a world-wide, royalty-free license, unlimited in
+          duration, to use that work under the conditions stated herein.
+          The "Document", below, refers to any such manual or work.
+          Any member of the public is a licensee, and is addressed as
+          "you". You accept the license if you copy, modify or distribute
+          the work in a way requiring permission under copyright law.
+        </p>
+        <p>
+          A "Modified Version" of the Document means any work containing
+          the Document or a portion of it, either copied verbatim, or
+          with modifications and/or translated into another language.
+        </p>
+        <p>
+          A "Secondary Section" is a named appendix or a front-matter
+          section of the Document that deals exclusively with the
+          relationship of the publishers or authors of the Document to the
+          Document's overall subject (or to related matters) and contains
+          nothing that could fall directly within that overall subject.
+          (Thus, if the Document is in part a textbook of mathematics,
+          a Secondary Section may not explain any mathematics.) The
+          relationship could be a matter of historical connection with
+          the subject or with related matters, or of legal, commercial,
+          philosophical, ethical or political position regarding them.
+        </p>
+        <p>
+          The "Invariant Sections" are certain Secondary Sections whose
+          titles are designated, as being those of Invariant Sections,
+          in the notice that says that the Document is released under
+          this License. If a section does not fit the above definition of
+          Secondary then it is not allowed to be designated as Invariant.
+          The Document may contain zero Invariant Sections. If the Document
+          does not identify any Invariant Sections then there are none.
+        </p>
+        <p>
+          The "Cover Texts" are certain short passages of text that are listed,
+          as Front-Cover Texts or Back-Cover Texts, in the notice that says that
+          the Document is released under this License. A Front-Cover Text may
+          be at most 5 words, and a Back-Cover Text may be at most 25 words.
+        </p>
+        <p>
+          A "Transparent" copy of the Document means a machine-readable
+          copy, represented in a format whose specification is available
+          to the general public, that is suitable for revising the document
+          straightforwardly with generic text editors or (for images composed of
+          pixels) generic paint programs or (for drawings) some widely available
+          drawing editor, and that is suitable for input to text formatters or
+          for automatic translation to a variety of formats suitable for input
+          to text formatters. A copy made in an otherwise Transparent file
+          format whose markup, or absence of markup, has been arranged to thwart
+          or discourage subsequent modification by readers is not Transparent.
+          An image format is not Transparent if used for any substantial
+          amount of text. A copy that is not "Transparent" is called "Opaque".
+        </p>
+        <p>
+          Examples of suitable formats for Transparent copies include plain
+          ASCII without markup, Texinfo input format, LaTeX input format,
+          SGML or XML using a publicly available DTD, and standard-conforming
+          simple HTML, PostScript or PDF designed for human modification.
+          Examples of transparent image formats include PNG, XCF and JPG.
+          Opaque formats include proprietary formats that can be read
+          and edited only by proprietary word processors, SGML or XML
+          for which the DTD and/or processing tools are not generally
+          available, and the machine-generated HTML, PostScript or PDF
+          produced by some word processors for output purposes only.
+        </p>
+        <p>
+          The "Title Page" means, for a printed book, the title page itself,
+          plus such following pages as are needed to hold, legibly, the
+          material this License requires to appear in the title page. For
+          works in formats which do not have any title page as such, "Title
+          Page" means the text near the most prominent appearance of the
+          work's title, preceding the beginning of the body of the text.
+        </p>
+        <p>
+          A section "Entitled XYZ" means a named subunit of the Document whose
+          title either is precisely XYZ or contains XYZ in parentheses following
+          text that translates XYZ in another language. (Here XYZ stands for
+          a specific section name mentioned below, such as "Acknowledgements",
+          "Dedications", "Endorsements", or "History".) To "Preserve the
+          Title" of such a section when you modify the Document means that
+          it remains a section "Entitled XYZ" according to this definition.
+        </p>
+        <p>
+          The Document may include Warranty Disclaimers next to the notice
+          which states that this License applies to the Document. These
+          Warranty Disclaimers are considered to be included by reference
+          in this License, but only as regards disclaiming warranties:
+          any other implication that these Warranty Disclaimers may
+          have is void and has no effect on the meaning of this License.
+        </p>
+      </item>
+      <item>
+        <bullet>2.</bullet>
+        VERBATIM COPYING
+        <p>
+          You may copy and distribute the Document in any medium, either
+          commercially or noncommercially, provided that this License, the
+          copyright notices, and the license notice saying this License applies
+          to the Document are reproduced in all copies, and that you add no
+          other conditions whatsoever to those of this License. You may not
+          use technical measures to obstruct or control the reading or further
+          copying of the copies you make or distribute. However, you may accept
+          compensation in exchange for copies. If you distribute a large enough
+          number of copies you must also follow the conditions in section 3.
+        </p>
+        <p>
+          You may also lend copies, under the same conditions
+          stated above, and you may publicly display copies.
+        </p>
+      </item>
+      <item>
+        <bullet>3.</bullet>
+        COPYING IN QUANTITY
+        <p>
+          If you publish printed copies (or copies in media that commonly
+          have printed covers) of the Document, numbering more than 100,
+          and the Document's license notice requires Cover Texts, you must
+          enclose the copies in covers that carry, clearly and legibly,
+          all these Cover Texts: Front-Cover Texts on the front cover, and
+          Back-Cover Texts on the back cover. Both covers must also clearly
+          and legibly identify you as the publisher of these copies. The
+          front cover must present the full title with all words of the title
+          equally prominent and visible. You may add other material on the
+          covers in addition. Copying with changes limited to the covers, as
+          long as they preserve the title of the Document and satisfy these
+          conditions, can be treated as verbatim copying in other respects.
+        </p>
+        <p>
+          If the required texts for either cover are too
+          voluminous to fit legibly, you should put the first
+          ones listed (as many as fit reasonably) on the actual
+          cover, and continue the rest onto adjacent pages.
+        </p>
+        <p>
+          If you publish or distribute Opaque copies of the Document
+          numbering more than 100, you must either include a machine-readable
+          Transparent copy along with each Opaque copy, or state in or with
+          each Opaque copy a computer-network location from which the general
+          network-using public has access to download using public-standard
+          network protocols a complete Transparent copy of the Document,
+          free of added material. If you use the latter option, you must take
+          reasonably prudent steps, when you begin distribution of Opaque
+          copies in quantity, to ensure that this Transparent copy will
+          remain thus accessible at the stated location until at least one
+          year after the last time you distribute an Opaque copy (directly
+          or through your agents or retailers) of that edition to the public.
+        </p>
+        <p>
+          It is requested, but not required, that you contact
+          the authors of the Document well before redistributing
+          any large number of copies, to give them a chance to
+          provide you with an updated version of the Document.
+        </p>
+      </item>
+      <item>
+        <bullet>4.</bullet>
+        MODIFICATIONS
+        <p>
+          You may copy and distribute a Modified Version of the Document under
+          the conditions of sections 2 and 3 above, provided that you release
+          the Modified Version under precisely this License, with the Modified
+          Version filling the role of the Document, thus licensing distribution
+          and modification of the Modified Version to whoever possesses a copy
+          of it. In addition, you must do these things in the Modified Version:
+        </p>
+        <list>
+          <item>
+            <bullet>A.</bullet>
+            Use in the Title Page (and on the covers, if any) a title distinct
+            from that of the Document, and from those of previous versions
+            (which should, if there were any, be listed in the History section
+            of the Document). You may use the same title as a previous version
+            if the original publisher of that version gives permission.
+          </item>
+          <item>
+            <bullet>B.</bullet>
+            List on the Title Page, as authors, one or more persons or
+            entities responsible for authorship of the modifications in the
+            Modified Version, together with at least five of the principal
+            authors of the Document (all of its principal authors, if it has
+            fewer than five), unless they release you from this requirement.
+          </item>
+          <item>
+            <bullet>C.</bullet>
+            State on the Title page the name of the publisher
+            of the Modified Version, as the publisher.
+          </item>
+          <item>
+            <bullet>D.</bullet>
+            Preserve all the copyright notices of the Document.
+          </item>
+          <item>
+            <bullet>E.</bullet>
+            Add an appropriate copyright notice for your
+            modifications adjacent to the other copyright notices.
+          </item>
+          <item>
+            <bullet>F.</bullet>
+            Include, immediately after the copyright notices, a license notice
+            giving the public permission to use the Modified Version under the
+            terms of this License, in the form shown in the Addendum below.
+          </item>
+          <item>
+            <bullet>G.</bullet>
+            Preserve in that license notice the full lists of Invariant Sections
+            and required Cover Texts given in the Document's license notice.
+          </item>
+          <item>
+            <bullet>H.</bullet>
+            Include an unaltered copy of this License.
+          </item>
+          <item>
+            <bullet>I.</bullet>
+            Preserve the section Entitled "History", Preserve its Title, and
+            add to it an item stating at least the title, year, new authors,
+            and publisher of the Modified Version as given on the Title
+            Page. If there is no section Entitled "History" in the Document,
+            create one stating the title, year, authors, and publisher
+            of the Document as given on its Title Page, then add an item
+            describing the Modified Version as stated in the previous sentence.
+          </item>
+          <item>
+            <bullet>J.</bullet>
+            Preserve the network location, if any, given in the Document
+            for public access to a Transparent copy of the Document, and
+            likewise the network locations given in the Document for previous
+            versions it was based on. These may be placed in the "History"
+            section. You may omit a network location for a work that was
+            published at least four years before the Document itself, or if the
+            original publisher of the version it refers to gives permission.
+          </item>
+          <item>
+            <bullet>K.</bullet>
+            For any section Entitled "Acknowledgements" or "Dedications",
+            Preserve the Title of the section, and preserve in the
+            section all the substance and tone of each of the contributor
+            acknowledgements and/or dedications given therein.
+          </item>
+          <item>
+            <bullet>L.</bullet>
+            Preserve all the Invariant Sections of the Document, unaltered
+            in their text and in their titles. Section numbers or the
+            equivalent are not considered part of the section titles.
+          </item>
+          <item>
+            <bullet>M.</bullet>
+            Delete any section Entitled "Endorsements". Such a
+            section may not be included in the Modified Version.
+          </item>
+          <item>
+            <bullet>N.</bullet>
+            Do not retitle any existing section to be Entitled "Endorsements"
+            or to conflict in title with any Invariant Section.
+          </item>
+          <item>
+            <bullet>O.</bullet>
+            Preserve any Warranty Disclaimers.
+          </item>
+        </list>
+        <p>
+          If the Modified Version includes new front-matter sections or
+          appendices that qualify as Secondary Sections and contain no material
+          copied from the Document, you may at your option designate some or
+          all of these sections as invariant. To do this, add their titles
+          to the list of Invariant Sections in the Modified Version's license
+          notice. These titles must be distinct from any other section titles.
+        </p>
+        <p>
+          You may add a section Entitled "Endorsements", provided
+          it contains nothing but endorsements of your Modified
+          Version by various parties--for example, statements of
+          peer review or that the text has been approved by an
+          organization as the authoritative definition of a standard.
+        </p>
+        <p>
+          You may add a passage of up to five words as a Front-Cover Text,
+          and a passage of up to 25 words as a Back-Cover Text, to the end of
+          the list of Cover Texts in the Modified Version. Only one passage
+          of Front-Cover Text and one of Back-Cover Text may be added by (or
+          through arrangements made by) any one entity. If the Document already
+          includes a cover text for the same cover, previously added by you or
+          by arrangement made by the same entity you are acting on behalf of,
+          you may not add another; but you may replace the old one, on explicit
+          permission from the previous publisher that added the old one.
+        </p>
+        <p>
+          The author(s) and publisher(s) of the Document do not by this
+          License give permission to use their names for publicity for
+          or to assert or imply endorsement of any Modified Version.
+        </p>
+      </item>
+      <item>
+        <bullet>5.</bullet>
+        COMBINING DOCUMENTS
+        <p>
+          You may combine the Document with other documents released under
+          this License, under the terms defined in section 4 above for modified
+          versions, provided that you include in the combination all of the
+          Invariant Sections of all of the original documents, unmodified,
+          and list them all as Invariant Sections of your combined work in its
+          license notice, and that you preserve all their Warranty Disclaimers.
+        </p>
+        <p>
+          The combined work need only contain one copy of this License, and
+          multiple identical Invariant Sections may be replaced with a single
+          copy. If there are multiple Invariant Sections with the same name
+          but different contents, make the title of each such section unique
+          by adding at the end of it, in parentheses, the name of the original
+          author or publisher of that section if known, or else a unique
+          number. Make the same adjustment to the section titles in the list
+          of Invariant Sections in the license notice of the combined work.
+        </p>
+        <p>
+          In the combination, you must combine any sections Entitled
+          "History" in the various original documents, forming one section
+          Entitled "History"; likewise combine any sections Entitled
+          "Acknowledgements", and any sections Entitled "Dedications".
+          You must delete all sections Entitled "Endorsements".
+        </p>
+      </item>
+      <item>
+        <bullet>6.</bullet>
+        COLLECTIONS OF DOCUMENTS
+        <p>
+          You may make a collection consisting of the Document and
+          other documents released under this License, and replace the
+          individual copies of this License in the various documents
+          with a single copy that is included in the collection,
+          provided that you follow the rules of this License for verbatim
+          copying of each of the documents in all other respects.
+        </p>
+        <p>
+          You may extract a single document from such a collection,
+          and distribute it individually under this License,
+          provided you insert a copy of this License into the
+          extracted document, and follow this License in all other
+          respects regarding verbatim copying of that document.
+        </p>
+      </item>
+      <item>
+        <bullet>7.</bullet>
+        AGGREGATION WITH INDEPENDENT WORKS
+        <p>
+          A compilation of the Document or its derivatives with other
+          separate and independent documents or works, in or on a volume
+          of a storage or distribution medium, is called an "aggregate"
+          if the copyright resulting from the compilation is not used to
+          limit the legal rights of the compilation's users beyond what
+          the individual works permit. When the Document is included in an
+          aggregate, this License does not apply to the other works in the
+          aggregate which are not themselves derivative works of the Document.
+        </p>
+        <p>
+          If the Cover Text requirement of section 3 is applicable to
+          these copies of the Document, then if the Document is less
+          than one half of the entire aggregate, the Document's Cover
+          Texts may be placed on covers that bracket the Document
+          within the aggregate, or the electronic equivalent of covers
+          if the Document is in electronic form. Otherwise they must
+          appear on printed covers that bracket the whole aggregate.
+        </p>
+      </item>
+      <item>
+        <bullet>8.</bullet>
+        TRANSLATION
+        <p>
+          Translation is considered a kind of modification, so you may
+          distribute translations of the Document under the terms of section
+          4. Replacing Invariant Sections with translations requires special
+          permission from their copyright holders, but you may include
+          translations of some or all Invariant Sections in addition to the
+          original versions of these Invariant Sections. You may include a
+          translation of this License, and all the license notices in the
+          Document, and any Warranty Disclaimers, provided that you also
+          include the original English version of this License and the original
+          versions of those notices and disclaimers. In case of a disagreement
+          between the translation and the original version of this License
+          or a notice or disclaimer, the original version will prevail.
+        </p>
+        <p>
+          If a section in the Document is Entitled
+          "Acknowledgements", "Dedications", or "History", the
+          requirement (section 4) to Preserve its Title (section
+          1) will typically require changing the actual title.
+        </p>
+      </item>
+      <item>
+        <bullet>9.</bullet>
+        TERMINATION
+        <p>
+          You may not copy, modify, sublicense, or distribute the Document
+          except as expressly provided for under this License. Any other
+          attempt to copy, modify, sublicense or distribute the Document
+          is void, and will automatically terminate your rights under
+          this License. However, parties who have received copies, or
+          rights, from you under this License will not have their licenses
+          terminated so long as such parties remain in full compliance.
+        </p>
+      </item>
+      <item>
+        <bullet>10.</bullet>
+        FUTURE REVISIONS OF THIS LICENSE
+        <p>
+          The Free Software Foundation may publish new, revised
+          versions of the GNU Free Documentation License from time
+          to time. Such new versions will be similar in spirit to
+          the present version, but may differ in detail to address
+          new problems or concerns. See http://www.gnu.org/copyleft/.
+        </p>
+        <p>
+          Each version of the License is given a distinguishing version number.
+          If the Document specifies that a particular numbered version of this
+          License "or any later version" applies to it, you have the option
+          of following the terms and conditions either of that specified
+          version or of any later version that has been published (not as a
+          draft) by the Free Software Foundation. If the Document does not
+          specify a version number of this License, you may choose any version
+          ever published (not as a draft) by the Free Software Foundation.
+        </p>
+      </item>
+    </list>
+    <optional>
+      <p>
+        ADDENDUM: How to use this License for your documents
+      </p>
+      <p>
+        To use this License in a document you have written, include
+        a copy of the License in the document and put the following
+        copyright and license notices just after the title page:
+      </p>
+      <p>
+        Copyright (c) YEAR YOUR NAME. Permission is granted to copy,
+        distribute and/or modify this document under the terms of the GNU
+        Free Documentation License, Version 1.2 or any later version published
+        by the Free Software Foundation; with no Invariant Sections, no
+        Front-Cover Texts, and no Back-Cover Texts. A copy of the license is
+        included in the section entitled "GNU Free Documentation License".
+      </p>
+      <p>
+        If you have Invariant Sections, Front-Cover Texts and
+        Back-Cover Texts, replace the "with...Texts." line with this:
+      </p>
+      <p>
+        with the Invariant Sections being LIST THEIR TITLES, with the
+        Front-Cover Texts being LIST, and with the Back-Cover Texts being LIST.
+      </p>
+      <p>
+        If you have Invariant Sections without Cover Texts,
+        or some other combination of the three, merge
+        those two alternatives to suit the situation.
+      </p>
+      <p>
+        If your document contains nontrivial examples of program
+        code, we recommend releasing these examples in parallel
+        under your choice of free software license, such as the GNU
+        General Public License, to permit their use in free software.
+      </p>
+    </optional>
   </license>
 </SPDXLicenseCollection>

--- a/src/GFDL-1.2.xml
+++ b/src/GFDL-1.2.xml
@@ -1,10 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
   <license licenseId="GFDL-1.2" isOsiApproved="false"
-  name="GNU Free Documentation License v1.2">
+  name="GNU Free Documentation License v1.2"
+  isDeprecated="true" deprecatedVersion="3.0">
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/old-licenses/fdl-1.2.txt</crossRef>
     </crossRefs>
+    <notes>
+      DEPRECATED: Deprecated in lieu of more
+      explicit license identifier of GFDL-1.2-only
+    </notes>
     <standardLicenseHeader>
       Copyright (c)<alt name="copyright" match=".+">YEAR YOUR NAME</alt>
       . Permission is granted to copy, distribute and/or modify this

--- a/src/GFDL-1.3-only.xml
+++ b/src/GFDL-1.3-only.xml
@@ -1,0 +1,590 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SPDXLicenseCollection xmlns="http://www.spdx.org/license">
+  <license licenseId="GFDL-1.3" isOsiApproved="false"
+  name="GNU Free Documentation License v1.3">
+    <crossRefs>
+      <crossRef>http://www.gnu.org/licenses/fdl-1.3.txt</crossRef>
+    </crossRefs>
+    <standardLicenseHeader>
+      Copyright (c)<alt name="copyright" match=".+">YEAR YOUR NAME</alt>
+      Permission is granted to copy, distribute and/or modify this
+      document under the terms of the GNU Free Documentation License,
+      Version 1.3 or any later version published by the Free Software
+      Foundation; with no Invariant Sections, no Front-Cover Texts,
+      and no Back-Cover Texts. A copy of the license is included
+      in the section entitled "GNU Free Documentation License".
+    </standardLicenseHeader>
+    <notes>
+      This license was released 3 November 2008.
+    </notes>
+    <titleText>
+      <p>
+        GNU Free Documentation License<br></br>
+        Version 1.3, 3 November 2008
+      </p>
+    </titleText>
+    <copyrightText>
+      <p>
+        Copyright (C) 2000, 2001, 2002, 2007, 2008 Free
+        Software Foundation, Inc. &lt;http://fsf.org/&gt;
+      </p>
+    </copyrightText>
+    <p>
+      Everyone is permitted to copy and distribute verbatim copies
+      of this license document, but changing it is not allowed.
+    </p>
+    <list>
+      <item>
+        <bullet>0.</bullet>
+        PREAMBLE
+        <p>
+          The purpose of this License is to make a manual, textbook, or
+          other functional and useful document "free" in the sense of
+          freedom: to assure everyone the effective freedom to copy and
+          redistribute it, with or without modifying it, either commercially
+          or noncommercially. Secondarily, this License preserves for the
+          author and publisher a way to get credit for their work, while
+          not being considered responsible for modifications made by others.
+        </p>
+        <p>
+          This License is a kind of "copyleft", which means that
+          derivative works of the document must themselves be free in
+          the same sense. It complements the GNU General Public License,
+          which is a copyleft license designed for free software.
+        </p>
+        <p>
+          We have designed this License in order to use it for manuals for
+          free software, because free software needs free documentation: a free
+          program should come with manuals providing the same freedoms that the
+          software does. But this License is not limited to software manuals;
+          it can be used for any textual work, regardless of subject matter or
+          whether it is published as a printed book. We recommend this License
+          principally for works whose purpose is instruction or reference.
+        </p>
+      </item>
+      <item>
+        <bullet>1.</bullet>
+        APPLICABILITY AND DEFINITIONS
+        <p>
+          This License applies to any manual or other work, in any medium,
+          that contains a notice placed by the copyright holder saying
+          it can be distributed under the terms of this License. Such a
+          notice grants a world-wide, royalty-free license, unlimited in
+          duration, to use that work under the conditions stated herein.
+          The "Document", below, refers to any such manual or work.
+          Any member of the public is a licensee, and is addressed as
+          "you". You accept the license if you copy, modify or distribute
+          the work in a way requiring permission under copyright law.
+        </p>
+        <p>
+          A "Modified Version" of the Document means any work containing
+          the Document or a portion of it, either copied verbatim, or
+          with modifications and/or translated into another language.
+        </p>
+        <p>
+          A "Secondary Section" is a named appendix or a front-matter
+          section of the Document that deals exclusively with the
+          relationship of the publishers or authors of the Document to the
+          Document's overall subject (or to related matters) and contains
+          nothing that could fall directly within that overall subject.
+          (Thus, if the Document is in part a textbook of mathematics,
+          a Secondary Section may not explain any mathematics.) The
+          relationship could be a matter of historical connection with
+          the subject or with related matters, or of legal, commercial,
+          philosophical, ethical or political position regarding them.
+        </p>
+        <p>
+          The "Invariant Sections" are certain Secondary Sections whose
+          titles are designated, as being those of Invariant Sections,
+          in the notice that says that the Document is released under
+          this License. If a section does not fit the above definition of
+          Secondary then it is not allowed to be designated as Invariant.
+          The Document may contain zero Invariant Sections. If the Document
+          does not identify any Invariant Sections then there are none.
+        </p>
+        <p>
+          The "Cover Texts" are certain short passages of text that are listed,
+          as Front-Cover Texts or Back-Cover Texts, in the notice that says that
+          the Document is released under this License. A Front-Cover Text may
+          be at most 5 words, and a Back-Cover Text may be at most 25 words.
+        </p>
+        <p>
+          A "Transparent" copy of the Document means a machine-readable
+          copy, represented in a format whose specification is available
+          to the general public, that is suitable for revising the document
+          straightforwardly with generic text editors or (for images composed of
+          pixels) generic paint programs or (for drawings) some widely available
+          drawing editor, and that is suitable for input to text formatters or
+          for automatic translation to a variety of formats suitable for input
+          to text formatters. A copy made in an otherwise Transparent file
+          format whose markup, or absence of markup, has been arranged to thwart
+          or discourage subsequent modification by readers is not Transparent.
+          An image format is not Transparent if used for any substantial
+          amount of text. A copy that is not "Transparent" is called "Opaque".
+        </p>
+        <p>
+          Examples of suitable formats for Transparent copies include plain
+          ASCII without markup, Texinfo input format, LaTeX input format,
+          SGML or XML using a publicly available DTD, and standard-conforming
+          simple HTML, PostScript or PDF designed for human modification.
+          Examples of transparent image formats include PNG, XCF and JPG.
+          Opaque formats include proprietary formats that can be read
+          and edited only by proprietary word processors, SGML or XML
+          for which the DTD and/or processing tools are not generally
+          available, and the machine-generated HTML, PostScript or PDF
+          produced by some word processors for output purposes only.
+        </p>
+        <p>
+          The "Title Page" means, for a printed book, the title page itself,
+          plus such following pages as are needed to hold, legibly, the
+          material this License requires to appear in the title page. For
+          works in formats which do not have any title page as such, "Title
+          Page" means the text near the most prominent appearance of the
+          work's title, preceding the beginning of the body of the text.
+        </p>
+        <p>
+          The "publisher" means any person or entity that
+          distributes copies of the Document to the public.
+        </p>
+        <p>
+          A section "Entitled XYZ" means a named subunit of the Document whose
+          title either is precisely XYZ or contains XYZ in parentheses following
+          text that translates XYZ in another language. (Here XYZ stands for
+          a specific section name mentioned below, such as "Acknowledgements",
+          "Dedications", "Endorsements", or "History".) To "Preserve the
+          Title" of such a section when you modify the Document means that
+          it remains a section "Entitled XYZ" according to this definition.
+        </p>
+        <p>
+          The Document may include Warranty Disclaimers next to the notice
+          which states that this License applies to the Document. These
+          Warranty Disclaimers are considered to be included by reference
+          in this License, but only as regards disclaiming warranties:
+          any other implication that these Warranty Disclaimers may
+          have is void and has no effect on the meaning of this License.
+        </p>
+      </item>
+      <item>
+        <bullet>2.</bullet>
+        VERBATIM COPYING
+        <p>
+          You may copy and distribute the Document in any medium, either
+          commercially or noncommercially, provided that this License, the
+          copyright notices, and the license notice saying this License applies
+          to the Document are reproduced in all copies, and that you add no
+          other conditions whatsoever to those of this License. You may not
+          use technical measures to obstruct or control the reading or further
+          copying of the copies you make or distribute. However, you may accept
+          compensation in exchange for copies. If you distribute a large enough
+          number of copies you must also follow the conditions in section 3.
+        </p>
+        <p>
+          You may also lend copies, under the same conditions
+          stated above, and you may publicly display copies.
+        </p>
+      </item>
+      <item>
+        <bullet>3.</bullet>
+        COPYING IN QUANTITY
+        <p>
+          If you publish printed copies (or copies in media that commonly
+          have printed covers) of the Document, numbering more than 100,
+          and the Document's license notice requires Cover Texts, you must
+          enclose the copies in covers that carry, clearly and legibly,
+          all these Cover Texts: Front-Cover Texts on the front cover, and
+          Back-Cover Texts on the back cover. Both covers must also clearly
+          and legibly identify you as the publisher of these copies. The
+          front cover must present the full title with all words of the title
+          equally prominent and visible. You may add other material on the
+          covers in addition. Copying with changes limited to the covers, as
+          long as they preserve the title of the Document and satisfy these
+          conditions, can be treated as verbatim copying in other respects.
+        </p>
+        <p>
+          If the required texts for either cover are too
+          voluminous to fit legibly, you should put the first
+          ones listed (as many as fit reasonably) on the actual
+          cover, and continue the rest onto adjacent pages.
+        </p>
+        <p>
+          If you publish or distribute Opaque copies of the Document
+          numbering more than 100, you must either include a machine-readable
+          Transparent copy along with each Opaque copy, or state in or with
+          each Opaque copy a computer-network location from which the general
+          network-using public has access to download using public-standard
+          network protocols a complete Transparent copy of the Document,
+          free of added material. If you use the latter option, you must take
+          reasonably prudent steps, when you begin distribution of Opaque
+          copies in quantity, to ensure that this Transparent copy will
+          remain thus accessible at the stated location until at least one
+          year after the last time you distribute an Opaque copy (directly
+          or through your agents or retailers) of that edition to the public.
+        </p>
+        <p>
+          It is requested, but not required, that you contact
+          the authors of the Document well before redistributing
+          any large number of copies, to give them a chance to
+          provide you with an updated version of the Document.
+        </p>
+      </item>
+      <item>
+        <bullet>4.</bullet>
+        MODIFICATIONS
+        <p>
+          You may copy and distribute a Modified Version of the Document under
+          the conditions of sections 2 and 3 above, provided that you release
+          the Modified Version under precisely this License, with the Modified
+          Version filling the role of the Document, thus licensing distribution
+          and modification of the Modified Version to whoever possesses a copy
+          of it. In addition, you must do these things in the Modified Version:
+        </p>
+        <list>
+          <item>
+            <bullet>A.</bullet>
+            Use in the Title Page (and on the covers, if any) a title distinct
+            from that of the Document, and from those of previous versions
+            (which should, if there were any, be listed in the History section
+            of the Document). You may use the same title as a previous version
+            if the original publisher of that version gives permission.
+          </item>
+          <item>
+            <bullet>B.</bullet>
+            List on the Title Page, as authors, one or more persons or
+            entities responsible for authorship of the modifications in the
+            Modified Version, together with at least five of the principal
+            authors of the Document (all of its principal authors, if it has
+            fewer than five), unless they release you from this requirement.
+          </item>
+          <item>
+            <bullet>C.</bullet>
+            State on the Title page the name of the publisher
+            of the Modified Version, as the publisher.
+          </item>
+          <item>
+            <bullet>D.</bullet>
+            Preserve all the copyright notices of the Document.
+          </item>
+          <item>
+            <bullet>E.</bullet>
+            Add an appropriate copyright notice for your
+            modifications adjacent to the other copyright notices.
+          </item>
+          <item>
+            <bullet>F.</bullet>
+            Include, immediately after the copyright notices, a license notice
+            giving the public permission to use the Modified Version under the
+            terms of this License, in the form shown in the Addendum below.
+          </item>
+          <item>
+            <bullet>G.</bullet>
+            Preserve in that license notice the full lists of Invariant
+            Sections and required Cover Texts given in the Document's
+            license notice. H. Include an unaltered copy of this License.
+          </item>
+          <item>
+            <bullet>I.</bullet>
+            Preserve the section Entitled "History", Preserve its Title, and
+            add to it an item stating at least the title, year, new authors,
+            and publisher of the Modified Version as given on the Title
+            Page. If there is no section Entitled "History" in the Document,
+            create one stating the title, year, authors, and publisher
+            of the Document as given on its Title Page, then add an item
+            describing the Modified Version as stated in the previous sentence.
+          </item>
+          <item>
+            <bullet>J.</bullet>
+            Preserve the network location, if any, given in the Document
+            for public access to a Transparent copy of the Document, and
+            likewise the network locations given in the Document for previous
+            versions it was based on. These may be placed in the "History"
+            section. You may omit a network location for a work that was
+            published at least four years before the Document itself, or if the
+            original publisher of the version it refers to gives permission.
+          </item>
+          <item>
+            <bullet>K.</bullet>
+            For any section Entitled "Acknowledgements" or "Dedications",
+            Preserve the Title of the section, and preserve in the
+            section all the substance and tone of each of the contributor
+            acknowledgements and/or dedications given therein.
+          </item>
+          <item>
+            <bullet>L.</bullet>
+            Preserve all the Invariant Sections of the Document, unaltered
+            in their text and in their titles. Section numbers or the
+            equivalent are not considered part of the section titles.
+          </item>
+          <item>
+            <bullet>M.</bullet>
+            Delete any section Entitled "Endorsements". Such a
+            section may not be included in the Modified Version.
+          </item>
+          <item>
+            <bullet>N.</bullet>
+            Do not retitle any existing section to be Entitled "Endorsements"
+            or to conflict in title with any Invariant Section.
+          </item>
+          <item>
+            <bullet>O.</bullet>
+            Preserve any Warranty Disclaimers.
+          </item>
+        </list>
+        <p>
+          If the Modified Version includes new front-matter sections or
+          appendices that qualify as Secondary Sections and contain no material
+          copied from the Document, you may at your option designate some or
+          all of these sections as invariant. To do this, add their titles
+          to the list of Invariant Sections in the Modified Version's license
+          notice. These titles must be distinct from any other section titles.
+        </p>
+        <p>
+          You may add a section Entitled "Endorsements", provided
+          it contains nothing but endorsements of your Modified
+          Version by various parties--for example, statements of
+          peer review or that the text has been approved by an
+          organization as the authoritative definition of a standard.
+        </p>
+        <p>
+          You may add a passage of up to five words as a Front-Cover Text,
+          and a passage of up to 25 words as a Back-Cover Text, to the end of
+          the list of Cover Texts in the Modified Version. Only one passage
+          of Front-Cover Text and one of Back-Cover Text may be added by (or
+          through arrangements made by) any one entity. If the Document already
+          includes a cover text for the same cover, previously added by you or
+          by arrangement made by the same entity you are acting on behalf of,
+          you may not add another; but you may replace the old one, on explicit
+          permission from the previous publisher that added the old one.
+        </p>
+        <p>
+          The author(s) and publisher(s) of the Document do not by this
+          License give permission to use their names for publicity for
+          or to assert or imply endorsement of any Modified Version.
+        </p>
+      </item>
+      <item>
+        <bullet>5.</bullet>
+        COMBINING DOCUMENTS
+        <p>
+          You may combine the Document with other documents released under
+          this License, under the terms defined in section 4 above for modified
+          versions, provided that you include in the combination all of the
+          Invariant Sections of all of the original documents, unmodified,
+          and list them all as Invariant Sections of your combined work in its
+          license notice, and that you preserve all their Warranty Disclaimers.
+        </p>
+        <p>
+          The combined work need only contain one copy of this License, and
+          multiple identical Invariant Sections may be replaced with a single
+          copy. If there are multiple Invariant Sections with the same name
+          but different contents, make the title of each such section unique
+          by adding at the end of it, in parentheses, the name of the original
+          author or publisher of that section if known, or else a unique
+          number. Make the same adjustment to the section titles in the list
+          of Invariant Sections in the license notice of the combined work.
+        </p>
+        <p>
+          In the combination, you must combine any sections Entitled
+          "History" in the various original documents, forming one section
+          Entitled "History"; likewise combine any sections Entitled
+          "Acknowledgements", and any sections Entitled "Dedications".
+          You must delete all sections Entitled "Endorsements".
+        </p>
+      </item>
+      <item>
+        <bullet>6.</bullet>
+        COLLECTIONS OF DOCUMENTS
+        <p>
+          You may make a collection consisting of the Document and
+          other documents released under this License, and replace the
+          individual copies of this License in the various documents
+          with a single copy that is included in the collection,
+          provided that you follow the rules of this License for verbatim
+          copying of each of the documents in all other respects.
+        </p>
+        <p>
+          You may extract a single document from such a collection,
+          and distribute it individually under this License,
+          provided you insert a copy of this License into the
+          extracted document, and follow this License in all other
+          respects regarding verbatim copying of that document.
+        </p>
+      </item>
+      <item>
+        <bullet>7.</bullet>
+        AGGREGATION WITH INDEPENDENT WORKS
+        <p>
+          A compilation of the Document or its derivatives with other
+          separate and independent documents or works, in or on a volume
+          of a storage or distribution medium, is called an "aggregate"
+          if the copyright resulting from the compilation is not used to
+          limit the legal rights of the compilation's users beyond what
+          the individual works permit. When the Document is included in an
+          aggregate, this License does not apply to the other works in the
+          aggregate which are not themselves derivative works of the Document.
+        </p>
+        <p>
+          If the Cover Text requirement of section 3 is applicable to
+          these copies of the Document, then if the Document is less
+          than one half of the entire aggregate, the Document's Cover
+          Texts may be placed on covers that bracket the Document
+          within the aggregate, or the electronic equivalent of covers
+          if the Document is in electronic form. Otherwise they must
+          appear on printed covers that bracket the whole aggregate.
+        </p>
+      </item>
+      <item>
+        <bullet>8.</bullet>
+        TRANSLATION
+        <p>
+          Translation is considered a kind of modification, so you may
+          distribute translations of the Document under the terms of section
+          4. Replacing Invariant Sections with translations requires special
+          permission from their copyright holders, but you may include
+          translations of some or all Invariant Sections in addition to the
+          original versions of these Invariant Sections. You may include a
+          translation of this License, and all the license notices in the
+          Document, and any Warranty Disclaimers, provided that you also
+          include the original English version of this License and the original
+          versions of those notices and disclaimers. In case of a disagreement
+          between the translation and the original version of this License
+          or a notice or disclaimer, the original version will prevail.
+        </p>
+        <p>
+          If a section in the Document is Entitled
+          "Acknowledgements", "Dedications", or "History", the
+          requirement (section 4) to Preserve its Title (section
+          1) will typically require changing the actual title.
+        </p>
+      </item>
+      <item>
+        <bullet>9.</bullet>
+        TERMINATION
+        <p>
+          You may not copy, modify, sublicense, or distribute the Document
+          except as expressly provided under this License. Any attempt
+          otherwise to copy, modify, sublicense, or distribute it is void,
+          and will automatically terminate your rights under this License.
+        </p>
+        <p>
+          However, if you cease all violation of this License, then your
+          license from a particular copyright holder is reinstated (a)
+          provisionally, unless and until the copyright holder explicitly
+          and finally terminates your license, and (b) permanently, if
+          the copyright holder fails to notify you of the violation by
+          some reasonable means prior to 60 days after the cessation.
+        </p>
+        <p>
+          Moreover, your license from a particular copyright holder is
+          reinstated permanently if the copyright holder notifies you
+          of the violation by some reasonable means, this is the first
+          time you have received notice of violation of this License
+          (for any work) from that copyright holder, and you cure the
+          violation prior to 30 days after your receipt of the notice.
+        </p>
+        <p>
+          Termination of your rights under this section does not terminate
+          the licenses of parties who have received copies or rights from
+          you under this License. If your rights have been terminated and
+          not permanently reinstated, receipt of a copy of some or all
+          of the same material does not give you any rights to use it.
+        </p>
+      </item>
+      <item>
+        <bullet>10.</bullet>
+        FUTURE REVISIONS OF THIS LICENSE
+        <p>
+          The Free Software Foundation may publish new, revised
+          versions of the GNU Free Documentation License from time
+          to time. Such new versions will be similar in spirit to
+          the present version, but may differ in detail to address
+          new problems or concerns. See http://www.gnu.org/copyleft/.
+        </p>
+        <p>
+          Each version of the License is given a distinguishing version number.
+          If the Document specifies that a particular numbered version of this
+          License "or any later version" applies to it, you have the option of
+          following the terms and conditions either of that specified version or
+          of any later version that has been published (not as a draft) by the
+          Free Software Foundation. If the Document does not specify a version
+          number of this License, you may choose any version ever published (not
+          as a draft) by the Free Software Foundation. If the Document specifies
+          that a proxy can decide which future versions of this License can
+          be used, that proxy's public statement of acceptance of a version
+          permanently authorizes you to choose that version for the Document.
+        </p>
+      </item>
+      <item>
+        <bullet>11.</bullet>
+        RELICENSING
+        <p>
+          "Massive Multiauthor Collaboration Site" (or "MMC Site") means any
+          World Wide Web server that publishes copyrightable works and also
+          provides prominent facilities for anybody to edit those works. A
+          public wiki that anybody can edit is an example of such a server. A
+          "Massive Multiauthor Collaboration" (or "MMC") contained in the site
+          means any set of copyrightable works thus published on the MMC site.
+        </p>
+        <p>
+          "CC-BY-SA" means the Creative Commons Attribution-Share Alike
+          3.0 license published by Creative Commons Corporation, a
+          not-for-profit corporation with a principal place of business
+          in San Francisco, California, as well as future copyleft
+          versions of that license published by that same organization.
+        </p>
+        <p>
+          "Incorporate" means to publish or republish a Document,
+          in whole or in part, as part of another Document.
+        </p>
+        <p>
+          An MMC is "eligible for relicensing" if it is licensed under this
+          License, and if all works that were first published under this License
+          somewhere other than this MMC, and subsequently incorporated in
+          whole or in part into the MMC, (1) had no cover texts or invariant
+          sections, and (2) were thus incorporated prior to November 1, 2008.
+        </p>
+        <p>
+          The operator of an MMC Site may republish an MMC contained in
+          the site under CC-BY-SA on the same site at any time before
+          August 1, 2009, provided the MMC is eligible for relicensing.
+        </p>
+      </item>
+    </list>
+    <optional>
+      <p>
+        ADDENDUM: How to use this License for your documents
+      </p>
+      <p>
+        To use this License in a document you have written, include
+        a copy of the License in the document and put the following
+        copyright and license notices just after the title page:
+      </p>
+      <p>
+        Copyright (c) YEAR YOUR NAME. Permission is granted to copy,
+        distribute and/or modify this document under the terms of the GNU
+        Free Documentation License, Version 1.3 or any later version published
+        by the Free Software Foundation; with no Invariant Sections, no
+        Front-Cover Texts, and no Back-Cover Texts. A copy of the license is
+        included in the section entitled "GNU Free Documentation License".
+      </p>
+      <p>
+        If you have Invariant Sections, Front-Cover Texts and
+        Back-Cover Texts, replace the "with...Texts." line with this:
+      </p>
+      <p>
+        with the Invariant Sections being LIST THEIR TITLES, with the
+        Front-Cover Texts being LIST, and with the Back-Cover Texts being LIST.
+      </p>
+      <p>
+        If you have Invariant Sections without Cover Texts,
+        or some other combination of the three, merge
+        those two alternatives to suit the situation.
+      </p>
+      <p>
+        If your document contains nontrivial examples of program
+        code, we recommend releasing these examples in parallel
+        under your choice of free software license, such as the GNU
+        General Public License, to permit their use in free software.
+      </p>
+    </optional>
+  </license>
+</SPDXLicenseCollection>

--- a/src/GFDL-1.3-only.xml
+++ b/src/GFDL-1.3-only.xml
@@ -9,8 +9,7 @@
       Copyright (c)<alt name="copyright" match=".+">YEAR YOUR NAME</alt>
       Permission is granted to copy, distribute and/or modify this
       document under the terms of the GNU Free Documentation License,
-      Version 1.3 or any later version published by the Free Software
-      Foundation; with no Invariant Sections, no Front-Cover Texts,
+      Version 1.3; with no Invariant Sections, no Front-Cover Texts,
       and no Back-Cover Texts. A copy of the license is included
       in the section entitled "GNU Free Documentation License".
     </standardLicenseHeader>

--- a/src/GFDL-1.3-only.xml
+++ b/src/GFDL-1.3-only.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-  <license licenseId="GFDL-1.3" isOsiApproved="false"
-  name="GNU Free Documentation License v1.3">
+  <license licenseId="GFDL-1.3-only" isOsiApproved="false"
+  name="GNU Free Documentation License v1.3 only">
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/fdl-1.3.txt</crossRef>
     </crossRefs>

--- a/src/GFDL-1.3-or-later.xml
+++ b/src/GFDL-1.3-or-later.xml
@@ -1,0 +1,590 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SPDXLicenseCollection xmlns="http://www.spdx.org/license">
+  <license licenseId="GFDL-1.3" isOsiApproved="false"
+  name="GNU Free Documentation License v1.3">
+    <crossRefs>
+      <crossRef>http://www.gnu.org/licenses/fdl-1.3.txt</crossRef>
+    </crossRefs>
+    <standardLicenseHeader>
+      Copyright (c)<alt name="copyright" match=".+">YEAR YOUR NAME</alt>
+      Permission is granted to copy, distribute and/or modify this
+      document under the terms of the GNU Free Documentation License,
+      Version 1.3 or any later version published by the Free Software
+      Foundation; with no Invariant Sections, no Front-Cover Texts,
+      and no Back-Cover Texts. A copy of the license is included
+      in the section entitled "GNU Free Documentation License".
+    </standardLicenseHeader>
+    <notes>
+      This license was released 3 November 2008.
+    </notes>
+    <titleText>
+      <p>
+        GNU Free Documentation License<br></br>
+        Version 1.3, 3 November 2008
+      </p>
+    </titleText>
+    <copyrightText>
+      <p>
+        Copyright (C) 2000, 2001, 2002, 2007, 2008 Free
+        Software Foundation, Inc. &lt;http://fsf.org/&gt;
+      </p>
+    </copyrightText>
+    <p>
+      Everyone is permitted to copy and distribute verbatim copies
+      of this license document, but changing it is not allowed.
+    </p>
+    <list>
+      <item>
+        <bullet>0.</bullet>
+        PREAMBLE
+        <p>
+          The purpose of this License is to make a manual, textbook, or
+          other functional and useful document "free" in the sense of
+          freedom: to assure everyone the effective freedom to copy and
+          redistribute it, with or without modifying it, either commercially
+          or noncommercially. Secondarily, this License preserves for the
+          author and publisher a way to get credit for their work, while
+          not being considered responsible for modifications made by others.
+        </p>
+        <p>
+          This License is a kind of "copyleft", which means that
+          derivative works of the document must themselves be free in
+          the same sense. It complements the GNU General Public License,
+          which is a copyleft license designed for free software.
+        </p>
+        <p>
+          We have designed this License in order to use it for manuals for
+          free software, because free software needs free documentation: a free
+          program should come with manuals providing the same freedoms that the
+          software does. But this License is not limited to software manuals;
+          it can be used for any textual work, regardless of subject matter or
+          whether it is published as a printed book. We recommend this License
+          principally for works whose purpose is instruction or reference.
+        </p>
+      </item>
+      <item>
+        <bullet>1.</bullet>
+        APPLICABILITY AND DEFINITIONS
+        <p>
+          This License applies to any manual or other work, in any medium,
+          that contains a notice placed by the copyright holder saying
+          it can be distributed under the terms of this License. Such a
+          notice grants a world-wide, royalty-free license, unlimited in
+          duration, to use that work under the conditions stated herein.
+          The "Document", below, refers to any such manual or work.
+          Any member of the public is a licensee, and is addressed as
+          "you". You accept the license if you copy, modify or distribute
+          the work in a way requiring permission under copyright law.
+        </p>
+        <p>
+          A "Modified Version" of the Document means any work containing
+          the Document or a portion of it, either copied verbatim, or
+          with modifications and/or translated into another language.
+        </p>
+        <p>
+          A "Secondary Section" is a named appendix or a front-matter
+          section of the Document that deals exclusively with the
+          relationship of the publishers or authors of the Document to the
+          Document's overall subject (or to related matters) and contains
+          nothing that could fall directly within that overall subject.
+          (Thus, if the Document is in part a textbook of mathematics,
+          a Secondary Section may not explain any mathematics.) The
+          relationship could be a matter of historical connection with
+          the subject or with related matters, or of legal, commercial,
+          philosophical, ethical or political position regarding them.
+        </p>
+        <p>
+          The "Invariant Sections" are certain Secondary Sections whose
+          titles are designated, as being those of Invariant Sections,
+          in the notice that says that the Document is released under
+          this License. If a section does not fit the above definition of
+          Secondary then it is not allowed to be designated as Invariant.
+          The Document may contain zero Invariant Sections. If the Document
+          does not identify any Invariant Sections then there are none.
+        </p>
+        <p>
+          The "Cover Texts" are certain short passages of text that are listed,
+          as Front-Cover Texts or Back-Cover Texts, in the notice that says that
+          the Document is released under this License. A Front-Cover Text may
+          be at most 5 words, and a Back-Cover Text may be at most 25 words.
+        </p>
+        <p>
+          A "Transparent" copy of the Document means a machine-readable
+          copy, represented in a format whose specification is available
+          to the general public, that is suitable for revising the document
+          straightforwardly with generic text editors or (for images composed of
+          pixels) generic paint programs or (for drawings) some widely available
+          drawing editor, and that is suitable for input to text formatters or
+          for automatic translation to a variety of formats suitable for input
+          to text formatters. A copy made in an otherwise Transparent file
+          format whose markup, or absence of markup, has been arranged to thwart
+          or discourage subsequent modification by readers is not Transparent.
+          An image format is not Transparent if used for any substantial
+          amount of text. A copy that is not "Transparent" is called "Opaque".
+        </p>
+        <p>
+          Examples of suitable formats for Transparent copies include plain
+          ASCII without markup, Texinfo input format, LaTeX input format,
+          SGML or XML using a publicly available DTD, and standard-conforming
+          simple HTML, PostScript or PDF designed for human modification.
+          Examples of transparent image formats include PNG, XCF and JPG.
+          Opaque formats include proprietary formats that can be read
+          and edited only by proprietary word processors, SGML or XML
+          for which the DTD and/or processing tools are not generally
+          available, and the machine-generated HTML, PostScript or PDF
+          produced by some word processors for output purposes only.
+        </p>
+        <p>
+          The "Title Page" means, for a printed book, the title page itself,
+          plus such following pages as are needed to hold, legibly, the
+          material this License requires to appear in the title page. For
+          works in formats which do not have any title page as such, "Title
+          Page" means the text near the most prominent appearance of the
+          work's title, preceding the beginning of the body of the text.
+        </p>
+        <p>
+          The "publisher" means any person or entity that
+          distributes copies of the Document to the public.
+        </p>
+        <p>
+          A section "Entitled XYZ" means a named subunit of the Document whose
+          title either is precisely XYZ or contains XYZ in parentheses following
+          text that translates XYZ in another language. (Here XYZ stands for
+          a specific section name mentioned below, such as "Acknowledgements",
+          "Dedications", "Endorsements", or "History".) To "Preserve the
+          Title" of such a section when you modify the Document means that
+          it remains a section "Entitled XYZ" according to this definition.
+        </p>
+        <p>
+          The Document may include Warranty Disclaimers next to the notice
+          which states that this License applies to the Document. These
+          Warranty Disclaimers are considered to be included by reference
+          in this License, but only as regards disclaiming warranties:
+          any other implication that these Warranty Disclaimers may
+          have is void and has no effect on the meaning of this License.
+        </p>
+      </item>
+      <item>
+        <bullet>2.</bullet>
+        VERBATIM COPYING
+        <p>
+          You may copy and distribute the Document in any medium, either
+          commercially or noncommercially, provided that this License, the
+          copyright notices, and the license notice saying this License applies
+          to the Document are reproduced in all copies, and that you add no
+          other conditions whatsoever to those of this License. You may not
+          use technical measures to obstruct or control the reading or further
+          copying of the copies you make or distribute. However, you may accept
+          compensation in exchange for copies. If you distribute a large enough
+          number of copies you must also follow the conditions in section 3.
+        </p>
+        <p>
+          You may also lend copies, under the same conditions
+          stated above, and you may publicly display copies.
+        </p>
+      </item>
+      <item>
+        <bullet>3.</bullet>
+        COPYING IN QUANTITY
+        <p>
+          If you publish printed copies (or copies in media that commonly
+          have printed covers) of the Document, numbering more than 100,
+          and the Document's license notice requires Cover Texts, you must
+          enclose the copies in covers that carry, clearly and legibly,
+          all these Cover Texts: Front-Cover Texts on the front cover, and
+          Back-Cover Texts on the back cover. Both covers must also clearly
+          and legibly identify you as the publisher of these copies. The
+          front cover must present the full title with all words of the title
+          equally prominent and visible. You may add other material on the
+          covers in addition. Copying with changes limited to the covers, as
+          long as they preserve the title of the Document and satisfy these
+          conditions, can be treated as verbatim copying in other respects.
+        </p>
+        <p>
+          If the required texts for either cover are too
+          voluminous to fit legibly, you should put the first
+          ones listed (as many as fit reasonably) on the actual
+          cover, and continue the rest onto adjacent pages.
+        </p>
+        <p>
+          If you publish or distribute Opaque copies of the Document
+          numbering more than 100, you must either include a machine-readable
+          Transparent copy along with each Opaque copy, or state in or with
+          each Opaque copy a computer-network location from which the general
+          network-using public has access to download using public-standard
+          network protocols a complete Transparent copy of the Document,
+          free of added material. If you use the latter option, you must take
+          reasonably prudent steps, when you begin distribution of Opaque
+          copies in quantity, to ensure that this Transparent copy will
+          remain thus accessible at the stated location until at least one
+          year after the last time you distribute an Opaque copy (directly
+          or through your agents or retailers) of that edition to the public.
+        </p>
+        <p>
+          It is requested, but not required, that you contact
+          the authors of the Document well before redistributing
+          any large number of copies, to give them a chance to
+          provide you with an updated version of the Document.
+        </p>
+      </item>
+      <item>
+        <bullet>4.</bullet>
+        MODIFICATIONS
+        <p>
+          You may copy and distribute a Modified Version of the Document under
+          the conditions of sections 2 and 3 above, provided that you release
+          the Modified Version under precisely this License, with the Modified
+          Version filling the role of the Document, thus licensing distribution
+          and modification of the Modified Version to whoever possesses a copy
+          of it. In addition, you must do these things in the Modified Version:
+        </p>
+        <list>
+          <item>
+            <bullet>A.</bullet>
+            Use in the Title Page (and on the covers, if any) a title distinct
+            from that of the Document, and from those of previous versions
+            (which should, if there were any, be listed in the History section
+            of the Document). You may use the same title as a previous version
+            if the original publisher of that version gives permission.
+          </item>
+          <item>
+            <bullet>B.</bullet>
+            List on the Title Page, as authors, one or more persons or
+            entities responsible for authorship of the modifications in the
+            Modified Version, together with at least five of the principal
+            authors of the Document (all of its principal authors, if it has
+            fewer than five), unless they release you from this requirement.
+          </item>
+          <item>
+            <bullet>C.</bullet>
+            State on the Title page the name of the publisher
+            of the Modified Version, as the publisher.
+          </item>
+          <item>
+            <bullet>D.</bullet>
+            Preserve all the copyright notices of the Document.
+          </item>
+          <item>
+            <bullet>E.</bullet>
+            Add an appropriate copyright notice for your
+            modifications adjacent to the other copyright notices.
+          </item>
+          <item>
+            <bullet>F.</bullet>
+            Include, immediately after the copyright notices, a license notice
+            giving the public permission to use the Modified Version under the
+            terms of this License, in the form shown in the Addendum below.
+          </item>
+          <item>
+            <bullet>G.</bullet>
+            Preserve in that license notice the full lists of Invariant
+            Sections and required Cover Texts given in the Document's
+            license notice. H. Include an unaltered copy of this License.
+          </item>
+          <item>
+            <bullet>I.</bullet>
+            Preserve the section Entitled "History", Preserve its Title, and
+            add to it an item stating at least the title, year, new authors,
+            and publisher of the Modified Version as given on the Title
+            Page. If there is no section Entitled "History" in the Document,
+            create one stating the title, year, authors, and publisher
+            of the Document as given on its Title Page, then add an item
+            describing the Modified Version as stated in the previous sentence.
+          </item>
+          <item>
+            <bullet>J.</bullet>
+            Preserve the network location, if any, given in the Document
+            for public access to a Transparent copy of the Document, and
+            likewise the network locations given in the Document for previous
+            versions it was based on. These may be placed in the "History"
+            section. You may omit a network location for a work that was
+            published at least four years before the Document itself, or if the
+            original publisher of the version it refers to gives permission.
+          </item>
+          <item>
+            <bullet>K.</bullet>
+            For any section Entitled "Acknowledgements" or "Dedications",
+            Preserve the Title of the section, and preserve in the
+            section all the substance and tone of each of the contributor
+            acknowledgements and/or dedications given therein.
+          </item>
+          <item>
+            <bullet>L.</bullet>
+            Preserve all the Invariant Sections of the Document, unaltered
+            in their text and in their titles. Section numbers or the
+            equivalent are not considered part of the section titles.
+          </item>
+          <item>
+            <bullet>M.</bullet>
+            Delete any section Entitled "Endorsements". Such a
+            section may not be included in the Modified Version.
+          </item>
+          <item>
+            <bullet>N.</bullet>
+            Do not retitle any existing section to be Entitled "Endorsements"
+            or to conflict in title with any Invariant Section.
+          </item>
+          <item>
+            <bullet>O.</bullet>
+            Preserve any Warranty Disclaimers.
+          </item>
+        </list>
+        <p>
+          If the Modified Version includes new front-matter sections or
+          appendices that qualify as Secondary Sections and contain no material
+          copied from the Document, you may at your option designate some or
+          all of these sections as invariant. To do this, add their titles
+          to the list of Invariant Sections in the Modified Version's license
+          notice. These titles must be distinct from any other section titles.
+        </p>
+        <p>
+          You may add a section Entitled "Endorsements", provided
+          it contains nothing but endorsements of your Modified
+          Version by various parties--for example, statements of
+          peer review or that the text has been approved by an
+          organization as the authoritative definition of a standard.
+        </p>
+        <p>
+          You may add a passage of up to five words as a Front-Cover Text,
+          and a passage of up to 25 words as a Back-Cover Text, to the end of
+          the list of Cover Texts in the Modified Version. Only one passage
+          of Front-Cover Text and one of Back-Cover Text may be added by (or
+          through arrangements made by) any one entity. If the Document already
+          includes a cover text for the same cover, previously added by you or
+          by arrangement made by the same entity you are acting on behalf of,
+          you may not add another; but you may replace the old one, on explicit
+          permission from the previous publisher that added the old one.
+        </p>
+        <p>
+          The author(s) and publisher(s) of the Document do not by this
+          License give permission to use their names for publicity for
+          or to assert or imply endorsement of any Modified Version.
+        </p>
+      </item>
+      <item>
+        <bullet>5.</bullet>
+        COMBINING DOCUMENTS
+        <p>
+          You may combine the Document with other documents released under
+          this License, under the terms defined in section 4 above for modified
+          versions, provided that you include in the combination all of the
+          Invariant Sections of all of the original documents, unmodified,
+          and list them all as Invariant Sections of your combined work in its
+          license notice, and that you preserve all their Warranty Disclaimers.
+        </p>
+        <p>
+          The combined work need only contain one copy of this License, and
+          multiple identical Invariant Sections may be replaced with a single
+          copy. If there are multiple Invariant Sections with the same name
+          but different contents, make the title of each such section unique
+          by adding at the end of it, in parentheses, the name of the original
+          author or publisher of that section if known, or else a unique
+          number. Make the same adjustment to the section titles in the list
+          of Invariant Sections in the license notice of the combined work.
+        </p>
+        <p>
+          In the combination, you must combine any sections Entitled
+          "History" in the various original documents, forming one section
+          Entitled "History"; likewise combine any sections Entitled
+          "Acknowledgements", and any sections Entitled "Dedications".
+          You must delete all sections Entitled "Endorsements".
+        </p>
+      </item>
+      <item>
+        <bullet>6.</bullet>
+        COLLECTIONS OF DOCUMENTS
+        <p>
+          You may make a collection consisting of the Document and
+          other documents released under this License, and replace the
+          individual copies of this License in the various documents
+          with a single copy that is included in the collection,
+          provided that you follow the rules of this License for verbatim
+          copying of each of the documents in all other respects.
+        </p>
+        <p>
+          You may extract a single document from such a collection,
+          and distribute it individually under this License,
+          provided you insert a copy of this License into the
+          extracted document, and follow this License in all other
+          respects regarding verbatim copying of that document.
+        </p>
+      </item>
+      <item>
+        <bullet>7.</bullet>
+        AGGREGATION WITH INDEPENDENT WORKS
+        <p>
+          A compilation of the Document or its derivatives with other
+          separate and independent documents or works, in or on a volume
+          of a storage or distribution medium, is called an "aggregate"
+          if the copyright resulting from the compilation is not used to
+          limit the legal rights of the compilation's users beyond what
+          the individual works permit. When the Document is included in an
+          aggregate, this License does not apply to the other works in the
+          aggregate which are not themselves derivative works of the Document.
+        </p>
+        <p>
+          If the Cover Text requirement of section 3 is applicable to
+          these copies of the Document, then if the Document is less
+          than one half of the entire aggregate, the Document's Cover
+          Texts may be placed on covers that bracket the Document
+          within the aggregate, or the electronic equivalent of covers
+          if the Document is in electronic form. Otherwise they must
+          appear on printed covers that bracket the whole aggregate.
+        </p>
+      </item>
+      <item>
+        <bullet>8.</bullet>
+        TRANSLATION
+        <p>
+          Translation is considered a kind of modification, so you may
+          distribute translations of the Document under the terms of section
+          4. Replacing Invariant Sections with translations requires special
+          permission from their copyright holders, but you may include
+          translations of some or all Invariant Sections in addition to the
+          original versions of these Invariant Sections. You may include a
+          translation of this License, and all the license notices in the
+          Document, and any Warranty Disclaimers, provided that you also
+          include the original English version of this License and the original
+          versions of those notices and disclaimers. In case of a disagreement
+          between the translation and the original version of this License
+          or a notice or disclaimer, the original version will prevail.
+        </p>
+        <p>
+          If a section in the Document is Entitled
+          "Acknowledgements", "Dedications", or "History", the
+          requirement (section 4) to Preserve its Title (section
+          1) will typically require changing the actual title.
+        </p>
+      </item>
+      <item>
+        <bullet>9.</bullet>
+        TERMINATION
+        <p>
+          You may not copy, modify, sublicense, or distribute the Document
+          except as expressly provided under this License. Any attempt
+          otherwise to copy, modify, sublicense, or distribute it is void,
+          and will automatically terminate your rights under this License.
+        </p>
+        <p>
+          However, if you cease all violation of this License, then your
+          license from a particular copyright holder is reinstated (a)
+          provisionally, unless and until the copyright holder explicitly
+          and finally terminates your license, and (b) permanently, if
+          the copyright holder fails to notify you of the violation by
+          some reasonable means prior to 60 days after the cessation.
+        </p>
+        <p>
+          Moreover, your license from a particular copyright holder is
+          reinstated permanently if the copyright holder notifies you
+          of the violation by some reasonable means, this is the first
+          time you have received notice of violation of this License
+          (for any work) from that copyright holder, and you cure the
+          violation prior to 30 days after your receipt of the notice.
+        </p>
+        <p>
+          Termination of your rights under this section does not terminate
+          the licenses of parties who have received copies or rights from
+          you under this License. If your rights have been terminated and
+          not permanently reinstated, receipt of a copy of some or all
+          of the same material does not give you any rights to use it.
+        </p>
+      </item>
+      <item>
+        <bullet>10.</bullet>
+        FUTURE REVISIONS OF THIS LICENSE
+        <p>
+          The Free Software Foundation may publish new, revised
+          versions of the GNU Free Documentation License from time
+          to time. Such new versions will be similar in spirit to
+          the present version, but may differ in detail to address
+          new problems or concerns. See http://www.gnu.org/copyleft/.
+        </p>
+        <p>
+          Each version of the License is given a distinguishing version number.
+          If the Document specifies that a particular numbered version of this
+          License "or any later version" applies to it, you have the option of
+          following the terms and conditions either of that specified version or
+          of any later version that has been published (not as a draft) by the
+          Free Software Foundation. If the Document does not specify a version
+          number of this License, you may choose any version ever published (not
+          as a draft) by the Free Software Foundation. If the Document specifies
+          that a proxy can decide which future versions of this License can
+          be used, that proxy's public statement of acceptance of a version
+          permanently authorizes you to choose that version for the Document.
+        </p>
+      </item>
+      <item>
+        <bullet>11.</bullet>
+        RELICENSING
+        <p>
+          "Massive Multiauthor Collaboration Site" (or "MMC Site") means any
+          World Wide Web server that publishes copyrightable works and also
+          provides prominent facilities for anybody to edit those works. A
+          public wiki that anybody can edit is an example of such a server. A
+          "Massive Multiauthor Collaboration" (or "MMC") contained in the site
+          means any set of copyrightable works thus published on the MMC site.
+        </p>
+        <p>
+          "CC-BY-SA" means the Creative Commons Attribution-Share Alike
+          3.0 license published by Creative Commons Corporation, a
+          not-for-profit corporation with a principal place of business
+          in San Francisco, California, as well as future copyleft
+          versions of that license published by that same organization.
+        </p>
+        <p>
+          "Incorporate" means to publish or republish a Document,
+          in whole or in part, as part of another Document.
+        </p>
+        <p>
+          An MMC is "eligible for relicensing" if it is licensed under this
+          License, and if all works that were first published under this License
+          somewhere other than this MMC, and subsequently incorporated in
+          whole or in part into the MMC, (1) had no cover texts or invariant
+          sections, and (2) were thus incorporated prior to November 1, 2008.
+        </p>
+        <p>
+          The operator of an MMC Site may republish an MMC contained in
+          the site under CC-BY-SA on the same site at any time before
+          August 1, 2009, provided the MMC is eligible for relicensing.
+        </p>
+      </item>
+    </list>
+    <optional>
+      <p>
+        ADDENDUM: How to use this License for your documents
+      </p>
+      <p>
+        To use this License in a document you have written, include
+        a copy of the License in the document and put the following
+        copyright and license notices just after the title page:
+      </p>
+      <p>
+        Copyright (c) YEAR YOUR NAME. Permission is granted to copy,
+        distribute and/or modify this document under the terms of the GNU
+        Free Documentation License, Version 1.3 or any later version published
+        by the Free Software Foundation; with no Invariant Sections, no
+        Front-Cover Texts, and no Back-Cover Texts. A copy of the license is
+        included in the section entitled "GNU Free Documentation License".
+      </p>
+      <p>
+        If you have Invariant Sections, Front-Cover Texts and
+        Back-Cover Texts, replace the "with...Texts." line with this:
+      </p>
+      <p>
+        with the Invariant Sections being LIST THEIR TITLES, with the
+        Front-Cover Texts being LIST, and with the Back-Cover Texts being LIST.
+      </p>
+      <p>
+        If you have Invariant Sections without Cover Texts,
+        or some other combination of the three, merge
+        those two alternatives to suit the situation.
+      </p>
+      <p>
+        If your document contains nontrivial examples of program
+        code, we recommend releasing these examples in parallel
+        under your choice of free software license, such as the GNU
+        General Public License, to permit their use in free software.
+      </p>
+    </optional>
+  </license>
+</SPDXLicenseCollection>

--- a/src/GFDL-1.3-or-later.xml
+++ b/src/GFDL-1.3-or-later.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-  <license licenseId="GFDL-1.3" isOsiApproved="false"
-  name="GNU Free Documentation License v1.3">
+  <license licenseId="GFDL-1.3-or-later" isOsiApproved="false"
+  name="GNU Free Documentation License v1.3 or later">
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/fdl-1.3.txt</crossRef>
     </crossRefs>

--- a/src/GFDL-1.3.xml
+++ b/src/GFDL-1.3.xml
@@ -1,10 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
   <license licenseId="GFDL-1.3" isOsiApproved="false"
-  name="GNU Free Documentation License v1.3">
+  name="GNU Free Documentation License v1.3"
+  isDeprecated="true" deprecatedVersion="3.0">
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/fdl-1.3.txt</crossRef>
     </crossRefs>
+    <notes>
+      DEPRECATED: Deprecated in lieu of more
+      explicit license identifier of GFDL-1.3-only
+    </notes>
     <standardLicenseHeader>
       Copyright (c)<alt name="copyright" match=".+">YEAR YOUR NAME</alt>
       Permission is granted to copy, distribute and/or modify this

--- a/src/GFDL-1.3.xml
+++ b/src/GFDL-1.3.xml
@@ -1,401 +1,590 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isOsiApproved="false" licenseId="GFDL-1.3"
-            name="GNU Free Documentation License v1.3">
-      <crossRefs>
-         <crossRef>http://www.gnu.org/licenses/fdl-1.3.txt</crossRef>
-      </crossRefs>
-      <standardLicenseHeader> Copyright (c) 
-    <alt match=".+" name="copyright">YEAR YOUR NAME</alt>. Permission is granted to copy, distribute and/or modify
-    this document under the terms of the GNU Free Documentation License, Version 1.3 or any later version published
-    by the Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts. A
-    copy of the license is included in the section entitled "GNU Free Documentation License". 
-  </standardLicenseHeader>
-      <notes>This license was released 3 November 2008.</notes>
-      <titleText>
-         <p>GNU Free Documentation License 
-        <br/>Version 1.3, 3 November 2008 
+  <license licenseId="GFDL-1.3" isOsiApproved="false"
+  name="GNU Free Documentation License v1.3">
+    <crossRefs>
+      <crossRef>http://www.gnu.org/licenses/fdl-1.3.txt</crossRef>
+    </crossRefs>
+    <standardLicenseHeader>
+      Copyright (c)<alt name="copyright" match=".+">YEAR YOUR NAME</alt>
+      Permission is granted to copy, distribute and/or modify this
+      document under the terms of the GNU Free Documentation License,
+      Version 1.3 or any later version published by the Free Software
+      Foundation; with no Invariant Sections, no Front-Cover Texts,
+      and no Back-Cover Texts. A copy of the license is included
+      in the section entitled "GNU Free Documentation License".
+    </standardLicenseHeader>
+    <notes>
+      This license was released 3 November 2008.
+    </notes>
+    <titleText>
+      <p>
+        GNU Free Documentation License<br></br>
+        Version 1.3, 3 November 2008
       </p>
-      </titleText>
-      <copyrightText>
-         <p>Copyright (C) 2000, 2001, 2002, 2007, 2008 Free Software Foundation, Inc. &lt;http://fsf.org/&gt;</p>
-      </copyrightText>
-      <p>Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is
-         not allowed.</p>
-      <list>
-        <item>
-            <bullet>0.</bullet>
-          PREAMBLE
-      <p>The purpose of this License is to make a manual, textbook, or other functional and useful document
-         "free" in the sense of freedom: to assure everyone the effective freedom to copy and
-         redistribute it, with or without modifying it, either commercially or noncommercially. Secondarily,
-         this License preserves for the author and publisher a way to get credit for their work, while not
-         being considered responsible for modifications made by others.</p>
-            <p>This License is a kind of "copyleft", which means that derivative works of the document must
-         themselves be free in the same sense. It complements the GNU General Public License, which is a
-         copyleft license designed for free software.</p>
-            <p>We have designed this License in order to use it for manuals for free software, because free software
-         needs free documentation: a free program should come with manuals providing the same freedoms that the
-         software does. But this License is not limited to software manuals; it can be used for any textual
-         work, regardless of subject matter or whether it is published as a printed book. We recommend this
-         License principally for works whose purpose is instruction or reference.</p>
-        </item>
-        <item>
-            <bullet>1.</bullet>
-          APPLICABILITY AND DEFINITIONS
-          <p>This License applies to any manual or other work, in any medium, that contains a notice placed by
-             the copyright holder saying it can be distributed under the terms of this License. Such a
-             notice grants a world-wide, royalty-free license, unlimited in duration, to use that work
-             under the conditions stated herein. The "Document", below, refers to any such manual
-             or work. Any member of the public is a licensee, and is addressed as "you". You
-             accept the license if you copy, modify or distribute the work in a way requiring permission
-             under copyright law.</p>
-            <p>A "Modified Version" of the Document means any work containing the Document or a
-             portion of it, either copied verbatim, or with modifications and/or translated into another
-             language.</p>
-            <p>A "Secondary Section" is a named appendix or a front-matter section of the Document
-             that deals exclusively with the relationship of the publishers or authors of the Document to
-             the Document's overall subject (or to related matters) and contains nothing that could
-             fall directly within that overall subject. (Thus, if the Document is in part a textbook of
-             mathematics, a Secondary Section may not explain any mathematics.) The relationship could be a
-             matter of historical connection with the subject or with related matters, or of legal,
-             commercial, philosophical, ethical or political position regarding them.</p>
-            <p>The "Invariant Sections" are certain Secondary Sections whose titles are designated, as
-             being those of Invariant Sections, in the notice that says that the Document is released under
-             this License. If a section does not fit the above definition of Secondary then it is not
-             allowed to be designated as Invariant. The Document may contain zero Invariant Sections. If
-             the Document does not identify any Invariant Sections then there are none.</p>
-            <p>The "Cover Texts" are certain short passages of text that are listed, as Front-Cover
-             Texts or Back-Cover Texts, in the notice that says that the Document is released under this
-             License. A Front-Cover Text may be at most 5 words, and a Back-Cover Text may be at most 25
-             words.</p>
-            <p>A "Transparent" copy of the Document means a machine-readable copy, represented in a
-             format whose specification is available to the general public, that is suitable for revising
-             the document straightforwardly with generic text editors or (for images composed of pixels)
-             generic paint programs or (for drawings) some widely available drawing editor, and that is
-             suitable for input to text formatters or for automatic translation to a variety of formats
-             suitable for input to text formatters. A copy made in an otherwise Transparent file format
-             whose markup, or absence of markup, has been arranged to thwart or discourage subsequent
-             modification by readers is not Transparent. An image format is not Transparent if used for any
-             substantial amount of text. A copy that is not "Transparent" is called
-             "Opaque".</p>
-            <p>Examples of suitable formats for Transparent copies include plain ASCII without markup, Texinfo
-             input format, LaTeX input format, SGML or XML using a publicly available DTD, and
-             standard-conforming simple HTML, PostScript or PDF designed for human modification. Examples
-             of transparent image formats include PNG, XCF and JPG. Opaque formats include proprietary
-             formats that can be read and edited only by proprietary word processors, SGML or XML for which
-             the DTD and/or processing tools are not generally available, and the machine-generated HTML,
-             PostScript or PDF produced by some word processors for output purposes only.</p>
-            <p>The "Title Page" means, for a printed book, the title page itself, plus such following
-             pages as are needed to hold, legibly, the material this License requires to appear in the
-             title page. For works in formats which do not have any title page as such, "Title
-             Page" means the text near the most prominent appearance of the work's title,
-             preceding the beginning of the body of the text.</p>
-            <p>The "publisher" means any person or entity that distributes copies of the Document to
-             the public.</p>
-            <p>A section "Entitled XYZ" means a named subunit of the Document whose title either is
-             precisely XYZ or contains XYZ in parentheses following text that translates XYZ in another
-             language. (Here XYZ stands for a specific section name mentioned below, such as
-             "Acknowledgements", "Dedications", "Endorsements", or
-             "History".) To "Preserve the Title" of such a section when you modify the
-             Document means that it remains a section "Entitled XYZ" according to this
-             definition.</p>
-            <p>The Document may include Warranty Disclaimers next to the notice which states that this License
-             applies to the Document. These Warranty Disclaimers are considered to be included by reference
-             in this License, but only as regards disclaiming warranties: any other implication that these
-             Warranty Disclaimers may have is void and has no effect on the meaning of this License.</p>
-        </item>
-        <item>
-            <bullet>2.</bullet>
-          VERBATIM COPYING
-          <p>You may copy and distribute the Document in any medium, either commercially or noncommercially,
-             provided that this License, the copyright notices, and the license notice saying this License
-             applies to the Document are reproduced in all copies, and that you add no other conditions
-             whatsoever to those of this License. You may not use technical measures to obstruct or control
-             the reading or further copying of the copies you make or distribute. However, you may accept
-             compensation in exchange for copies. If you distribute a large enough number of copies you
-             must also follow the conditions in section 3.</p>
-            <p>You may also lend copies, under the same conditions stated above, and you may publicly display copies.</p>
-        </item>
-        <item>
-            <bullet>3.</bullet>
-          COPYING IN QUANTITY
-          <p>If you publish printed copies (or copies in media that commonly have printed covers) of the
-             Document, numbering more than 100, and the Document's license notice requires Cover
-             Texts, you must enclose the copies in covers that carry, clearly and legibly, all these Cover
-             Texts: Front-Cover Texts on the front cover, and Back-Cover Texts on the back cover. Both
-             covers must also clearly and legibly identify you as the publisher of these copies. The front
-             cover must present the full title with all words of the title equally prominent and visible.
-             You may add other material on the covers in addition. Copying with changes limited to the
-             covers, as long as they preserve the title of the Document and satisfy these conditions, can
-             be treated as verbatim copying in other respects.</p>
-            <p>If the required texts for either cover are too voluminous to fit legibly, you should put the
-             first ones listed (as many as fit reasonably) on the actual cover, and continue the rest onto
-             adjacent pages.</p>
-            <p>If you publish or distribute Opaque copies of the Document numbering more than 100, you must
-             either include a machine-readable Transparent copy along with each Opaque copy, or state in or
-             with each Opaque copy a computer-network location from which the general network-using public
-             has access to download using public-standard network protocols a complete Transparent copy of
-             the Document, free of added material. If you use the latter option, you must take reasonably
-             prudent steps, when you begin distribution of Opaque copies in quantity, to ensure that this
-             Transparent copy will remain thus accessible at the stated location until at least one year
-             after the last time you distribute an Opaque copy (directly or through your agents or
-             retailers) of that edition to the public.</p>
-            <p>It is requested, but not required, that you contact the authors of the Document well before
-             redistributing any large number of copies, to give them a chance to provide you with an
-             updated version of the Document.</p>
-        </item>
-        <item>
-            <bullet>4.</bullet>
-          MODIFICATIONS
-          <p>You may copy and distribute a Modified Version of the Document under the conditions of sections 2
-             and 3 above, provided that you release the Modified Version under precisely this License, with
-             the Modified Version filling the role of the Document, thus licensing distribution and
-             modification of the Modified Version to whoever possesses a copy of it. In addition, you must
-             do these things in the Modified Version:</p>
-            <list>
-               <item>
-                  <bullet>A.</bullet>
-            Use in the Title Page (and on the covers, if any) a title distinct from that of the Document,
-               and from those of previous versions (which should, if there were any, be listed in the
-               History section of the Document). You may use the same title as a previous version if the
-               original publisher of that version gives permission.
+    </titleText>
+    <copyrightText>
+      <p>
+        Copyright (C) 2000, 2001, 2002, 2007, 2008 Free
+        Software Foundation, Inc. &lt;http://fsf.org/&gt;
+      </p>
+    </copyrightText>
+    <p>
+      Everyone is permitted to copy and distribute verbatim copies
+      of this license document, but changing it is not allowed.
+    </p>
+    <list>
+      <item>
+        <bullet>0.</bullet>
+        PREAMBLE
+        <p>
+          The purpose of this License is to make a manual, textbook, or
+          other functional and useful document "free" in the sense of
+          freedom: to assure everyone the effective freedom to copy and
+          redistribute it, with or without modifying it, either commercially
+          or noncommercially. Secondarily, this License preserves for the
+          author and publisher a way to get credit for their work, while
+          not being considered responsible for modifications made by others.
+        </p>
+        <p>
+          This License is a kind of "copyleft", which means that
+          derivative works of the document must themselves be free in
+          the same sense. It complements the GNU General Public License,
+          which is a copyleft license designed for free software.
+        </p>
+        <p>
+          We have designed this License in order to use it for manuals for
+          free software, because free software needs free documentation: a free
+          program should come with manuals providing the same freedoms that the
+          software does. But this License is not limited to software manuals;
+          it can be used for any textual work, regardless of subject matter or
+          whether it is published as a printed book. We recommend this License
+          principally for works whose purpose is instruction or reference.
+        </p>
+      </item>
+      <item>
+        <bullet>1.</bullet>
+        APPLICABILITY AND DEFINITIONS
+        <p>
+          This License applies to any manual or other work, in any medium,
+          that contains a notice placed by the copyright holder saying
+          it can be distributed under the terms of this License. Such a
+          notice grants a world-wide, royalty-free license, unlimited in
+          duration, to use that work under the conditions stated herein.
+          The "Document", below, refers to any such manual or work.
+          Any member of the public is a licensee, and is addressed as
+          "you". You accept the license if you copy, modify or distribute
+          the work in a way requiring permission under copyright law.
+        </p>
+        <p>
+          A "Modified Version" of the Document means any work containing
+          the Document or a portion of it, either copied verbatim, or
+          with modifications and/or translated into another language.
+        </p>
+        <p>
+          A "Secondary Section" is a named appendix or a front-matter
+          section of the Document that deals exclusively with the
+          relationship of the publishers or authors of the Document to the
+          Document's overall subject (or to related matters) and contains
+          nothing that could fall directly within that overall subject.
+          (Thus, if the Document is in part a textbook of mathematics,
+          a Secondary Section may not explain any mathematics.) The
+          relationship could be a matter of historical connection with
+          the subject or with related matters, or of legal, commercial,
+          philosophical, ethical or political position regarding them.
+        </p>
+        <p>
+          The "Invariant Sections" are certain Secondary Sections whose
+          titles are designated, as being those of Invariant Sections,
+          in the notice that says that the Document is released under
+          this License. If a section does not fit the above definition of
+          Secondary then it is not allowed to be designated as Invariant.
+          The Document may contain zero Invariant Sections. If the Document
+          does not identify any Invariant Sections then there are none.
+        </p>
+        <p>
+          The "Cover Texts" are certain short passages of text that are listed,
+          as Front-Cover Texts or Back-Cover Texts, in the notice that says that
+          the Document is released under this License. A Front-Cover Text may
+          be at most 5 words, and a Back-Cover Text may be at most 25 words.
+        </p>
+        <p>
+          A "Transparent" copy of the Document means a machine-readable
+          copy, represented in a format whose specification is available
+          to the general public, that is suitable for revising the document
+          straightforwardly with generic text editors or (for images composed of
+          pixels) generic paint programs or (for drawings) some widely available
+          drawing editor, and that is suitable for input to text formatters or
+          for automatic translation to a variety of formats suitable for input
+          to text formatters. A copy made in an otherwise Transparent file
+          format whose markup, or absence of markup, has been arranged to thwart
+          or discourage subsequent modification by readers is not Transparent.
+          An image format is not Transparent if used for any substantial
+          amount of text. A copy that is not "Transparent" is called "Opaque".
+        </p>
+        <p>
+          Examples of suitable formats for Transparent copies include plain
+          ASCII without markup, Texinfo input format, LaTeX input format,
+          SGML or XML using a publicly available DTD, and standard-conforming
+          simple HTML, PostScript or PDF designed for human modification.
+          Examples of transparent image formats include PNG, XCF and JPG.
+          Opaque formats include proprietary formats that can be read
+          and edited only by proprietary word processors, SGML or XML
+          for which the DTD and/or processing tools are not generally
+          available, and the machine-generated HTML, PostScript or PDF
+          produced by some word processors for output purposes only.
+        </p>
+        <p>
+          The "Title Page" means, for a printed book, the title page itself,
+          plus such following pages as are needed to hold, legibly, the
+          material this License requires to appear in the title page. For
+          works in formats which do not have any title page as such, "Title
+          Page" means the text near the most prominent appearance of the
+          work's title, preceding the beginning of the body of the text.
+        </p>
+        <p>
+          The "publisher" means any person or entity that
+          distributes copies of the Document to the public.
+        </p>
+        <p>
+          A section "Entitled XYZ" means a named subunit of the Document whose
+          title either is precisely XYZ or contains XYZ in parentheses following
+          text that translates XYZ in another language. (Here XYZ stands for
+          a specific section name mentioned below, such as "Acknowledgements",
+          "Dedications", "Endorsements", or "History".) To "Preserve the
+          Title" of such a section when you modify the Document means that
+          it remains a section "Entitled XYZ" according to this definition.
+        </p>
+        <p>
+          The Document may include Warranty Disclaimers next to the notice
+          which states that this License applies to the Document. These
+          Warranty Disclaimers are considered to be included by reference
+          in this License, but only as regards disclaiming warranties:
+          any other implication that these Warranty Disclaimers may
+          have is void and has no effect on the meaning of this License.
+        </p>
+      </item>
+      <item>
+        <bullet>2.</bullet>
+        VERBATIM COPYING
+        <p>
+          You may copy and distribute the Document in any medium, either
+          commercially or noncommercially, provided that this License, the
+          copyright notices, and the license notice saying this License applies
+          to the Document are reproduced in all copies, and that you add no
+          other conditions whatsoever to those of this License. You may not
+          use technical measures to obstruct or control the reading or further
+          copying of the copies you make or distribute. However, you may accept
+          compensation in exchange for copies. If you distribute a large enough
+          number of copies you must also follow the conditions in section 3.
+        </p>
+        <p>
+          You may also lend copies, under the same conditions
+          stated above, and you may publicly display copies.
+        </p>
+      </item>
+      <item>
+        <bullet>3.</bullet>
+        COPYING IN QUANTITY
+        <p>
+          If you publish printed copies (or copies in media that commonly
+          have printed covers) of the Document, numbering more than 100,
+          and the Document's license notice requires Cover Texts, you must
+          enclose the copies in covers that carry, clearly and legibly,
+          all these Cover Texts: Front-Cover Texts on the front cover, and
+          Back-Cover Texts on the back cover. Both covers must also clearly
+          and legibly identify you as the publisher of these copies. The
+          front cover must present the full title with all words of the title
+          equally prominent and visible. You may add other material on the
+          covers in addition. Copying with changes limited to the covers, as
+          long as they preserve the title of the Document and satisfy these
+          conditions, can be treated as verbatim copying in other respects.
+        </p>
+        <p>
+          If the required texts for either cover are too
+          voluminous to fit legibly, you should put the first
+          ones listed (as many as fit reasonably) on the actual
+          cover, and continue the rest onto adjacent pages.
+        </p>
+        <p>
+          If you publish or distribute Opaque copies of the Document
+          numbering more than 100, you must either include a machine-readable
+          Transparent copy along with each Opaque copy, or state in or with
+          each Opaque copy a computer-network location from which the general
+          network-using public has access to download using public-standard
+          network protocols a complete Transparent copy of the Document,
+          free of added material. If you use the latter option, you must take
+          reasonably prudent steps, when you begin distribution of Opaque
+          copies in quantity, to ensure that this Transparent copy will
+          remain thus accessible at the stated location until at least one
+          year after the last time you distribute an Opaque copy (directly
+          or through your agents or retailers) of that edition to the public.
+        </p>
+        <p>
+          It is requested, but not required, that you contact
+          the authors of the Document well before redistributing
+          any large number of copies, to give them a chance to
+          provide you with an updated version of the Document.
+        </p>
+      </item>
+      <item>
+        <bullet>4.</bullet>
+        MODIFICATIONS
+        <p>
+          You may copy and distribute a Modified Version of the Document under
+          the conditions of sections 2 and 3 above, provided that you release
+          the Modified Version under precisely this License, with the Modified
+          Version filling the role of the Document, thus licensing distribution
+          and modification of the Modified Version to whoever possesses a copy
+          of it. In addition, you must do these things in the Modified Version:
+        </p>
+        <list>
+          <item>
+            <bullet>A.</bullet>
+            Use in the Title Page (and on the covers, if any) a title distinct
+            from that of the Document, and from those of previous versions
+            (which should, if there were any, be listed in the History section
+            of the Document). You may use the same title as a previous version
+            if the original publisher of that version gives permission.
           </item>
-               <item>
-                  <bullet>B.</bullet>
-            List on the Title Page, as authors, one or more persons or entities responsible for
-               authorship of the modifications in the Modified Version, together with at least five of
-               the principal authors of the Document (all of its principal authors, if it has fewer than
-               five), unless they release you from this requirement.
+          <item>
+            <bullet>B.</bullet>
+            List on the Title Page, as authors, one or more persons or
+            entities responsible for authorship of the modifications in the
+            Modified Version, together with at least five of the principal
+            authors of the Document (all of its principal authors, if it has
+            fewer than five), unless they release you from this requirement.
           </item>
-               <item>
-                  <bullet>C.</bullet>
-            State on the Title page the name of the publisher of the Modified Version, as the publisher.
+          <item>
+            <bullet>C.</bullet>
+            State on the Title page the name of the publisher
+            of the Modified Version, as the publisher.
           </item>
-               <item>
-                  <bullet>D.</bullet>
+          <item>
+            <bullet>D.</bullet>
             Preserve all the copyright notices of the Document.
           </item>
-               <item>
-                  <bullet>E.</bullet>
-            Add an appropriate copyright notice for your modifications adjacent to the other copyright notices.
+          <item>
+            <bullet>E.</bullet>
+            Add an appropriate copyright notice for your
+            modifications adjacent to the other copyright notices.
           </item>
-               <item>
-                  <bullet>F.</bullet>
-            Include, immediately after the copyright notices, a license notice giving the public
-               permission to use the Modified Version under the terms of this License, in the form shown
-               in the Addendum below.
+          <item>
+            <bullet>F.</bullet>
+            Include, immediately after the copyright notices, a license notice
+            giving the public permission to use the Modified Version under the
+            terms of this License, in the form shown in the Addendum below.
           </item>
-               <item>
-                  <bullet>G.</bullet>
-            Preserve in that license notice the full lists of Invariant Sections and required Cover Texts
-               given in the Document's license notice. H. Include an unaltered copy of this
-               License.
+          <item>
+            <bullet>G.</bullet>
+            Preserve in that license notice the full lists of Invariant
+            Sections and required Cover Texts given in the Document's
+            license notice. H. Include an unaltered copy of this License.
           </item>
-               <item>
-                  <bullet>I.</bullet>
-            Preserve the section Entitled "History", Preserve its Title, and add to it an item
-               stating at least the title, year, new authors, and publisher of the Modified Version as
-               given on the Title Page. If there is no section Entitled "History" in the
-               Document, create one stating the title, year, authors, and publisher of the Document as
-               given on its Title Page, then add an item describing the Modified Version as stated in the
-               previous sentence.
+          <item>
+            <bullet>I.</bullet>
+            Preserve the section Entitled "History", Preserve its Title, and
+            add to it an item stating at least the title, year, new authors,
+            and publisher of the Modified Version as given on the Title
+            Page. If there is no section Entitled "History" in the Document,
+            create one stating the title, year, authors, and publisher
+            of the Document as given on its Title Page, then add an item
+            describing the Modified Version as stated in the previous sentence.
           </item>
-               <item>
-                  <bullet>J.</bullet>
-            Preserve the network location, if any, given in the Document for public access to a
-               Transparent copy of the Document, and likewise the network locations given in the Document
-               for previous versions it was based on. These may be placed in the "History"
-               section. You may omit a network location for a work that was published at least four years
-               before the Document itself, or if the original publisher of the version it refers to gives
-               permission.
+          <item>
+            <bullet>J.</bullet>
+            Preserve the network location, if any, given in the Document
+            for public access to a Transparent copy of the Document, and
+            likewise the network locations given in the Document for previous
+            versions it was based on. These may be placed in the "History"
+            section. You may omit a network location for a work that was
+            published at least four years before the Document itself, or if the
+            original publisher of the version it refers to gives permission.
           </item>
-               <item>
-                  <bullet>K.</bullet>
-            For any section Entitled "Acknowledgements" or "Dedications", Preserve
-               the Title of the section, and preserve in the section all the substance and tone of each
-               of the contributor acknowledgements and/or dedications given therein.
+          <item>
+            <bullet>K.</bullet>
+            For any section Entitled "Acknowledgements" or "Dedications",
+            Preserve the Title of the section, and preserve in the
+            section all the substance and tone of each of the contributor
+            acknowledgements and/or dedications given therein.
           </item>
-               <item>
-                  <bullet>L.</bullet>
-            Preserve all the Invariant Sections of the Document, unaltered in their text and in their
-               titles. Section numbers or the equivalent are not considered part of the section
-               titles.
+          <item>
+            <bullet>L.</bullet>
+            Preserve all the Invariant Sections of the Document, unaltered
+            in their text and in their titles. Section numbers or the
+            equivalent are not considered part of the section titles.
           </item>
-               <item>
-                  <bullet>M.</bullet>
-            Delete any section Entitled "Endorsements". Such a section may not be included in
-               the Modified Version.
+          <item>
+            <bullet>M.</bullet>
+            Delete any section Entitled "Endorsements". Such a
+            section may not be included in the Modified Version.
           </item>
-               <item>
-                  <bullet>N.</bullet>
-            Do not retitle any existing section to be Entitled "Endorsements" or to conflict in
-               title with any Invariant Section.
+          <item>
+            <bullet>N.</bullet>
+            Do not retitle any existing section to be Entitled "Endorsements"
+            or to conflict in title with any Invariant Section.
           </item>
-               <item>
-                  <bullet>O.</bullet>
+          <item>
+            <bullet>O.</bullet>
             Preserve any Warranty Disclaimers.
           </item>
-            </list>
-            <p>If the Modified Version includes new front-matter sections or appendices that qualify as
-               Secondary Sections and contain no material copied from the Document, you may at your
-               option designate some or all of these sections as invariant. To do this, add their titles
-               to the list of Invariant Sections in the Modified Version's license notice. These
-               titles must be distinct from any other section titles.</p>
-            <p>You may add a section Entitled "Endorsements", provided it contains nothing but
-               endorsements of your Modified Version by various parties--for example, statements of peer
-               review or that the text has been approved by an organization as the authoritative
-               definition of a standard.</p>
-            <p>You may add a passage of up to five words as a Front-Cover Text, and a passage of up to 25
-               words as a Back-Cover Text, to the end of the list of Cover Texts in the Modified Version.
-               Only one passage of Front-Cover Text and one of Back-Cover Text may be added by (or
-               through arrangements made by) any one entity. If the Document already includes a cover
-               text for the same cover, previously added by you or by arrangement made by the same entity
-               you are acting on behalf of, you may not add another; but you may replace the old one, on
-               explicit permission from the previous publisher that added the old one.</p>
-            <p>The author(s) and publisher(s) of the Document do not by this License give permission to use
-               their names for publicity for or to assert or imply endorsement of any Modified
-               Version.</p>
-        </item>
-        <item>
-            <bullet>5.</bullet>
-          COMBINING DOCUMENTS
-          <p>You may combine the Document with other documents released under this License, under the terms
-             defined in section 4 above for modified versions, provided that you include in the combination
-             all of the Invariant Sections of all of the original documents, unmodified, and list them all
-             as Invariant Sections of your combined work in its license notice, and that you preserve all
-             their Warranty Disclaimers.</p>
-            <p>The combined work need only contain one copy of this License, and multiple identical Invariant
-             Sections may be replaced with a single copy. If there are multiple Invariant Sections with the
-             same name but different contents, make the title of each such section unique by adding at the
-             end of it, in parentheses, the name of the original author or publisher of that section if
-             known, or else a unique number. Make the same adjustment to the section titles in the list of
-             Invariant Sections in the license notice of the combined work.</p>
-            <p>In the combination, you must combine any sections Entitled "History" in the various
-             original documents, forming one section Entitled "History"; likewise combine any
-             sections Entitled "Acknowledgements", and any sections Entitled
-             "Dedications". You must delete all sections Entitled "Endorsements".</p>
-        </item>
-        <item>
-            <bullet>6.</bullet>
-          COLLECTIONS OF DOCUMENTS
-          <p>You may make a collection consisting of the Document and other documents released under this
-             License, and replace the individual copies of this License in the various documents with a
-             single copy that is included in the collection, provided that you follow the rules of this
-             License for verbatim copying of each of the documents in all other respects.</p>
-            <p>You may extract a single document from such a collection, and distribute it individually under
-             this License, provided you insert a copy of this License into the extracted document, and
-             follow this License in all other respects regarding verbatim copying of that document.</p>
-        </item>
-        <item>
-            <bullet>7.</bullet>
-          AGGREGATION WITH INDEPENDENT WORKS
-          <p>A compilation of the Document or its derivatives with other separate and independent documents or
-             works, in or on a volume of a storage or distribution medium, is called an
-             "aggregate" if the copyright resulting from the compilation is not used to limit the
-             legal rights of the compilation's users beyond what the individual works permit. When the
-             Document is included in an aggregate, this License does not apply to the other works in the
-             aggregate which are not themselves derivative works of the Document.</p>
-            <p>If the Cover Text requirement of section 3 is applicable to these copies of the Document, then if
-             the Document is less than one half of the entire aggregate, the Document's Cover Texts
-             may be placed on covers that bracket the Document within the aggregate, or the electronic
-             equivalent of covers if the Document is in electronic form. Otherwise they must appear on
-             printed covers that bracket the whole aggregate.</p>
-        </item>
-        <item>
-            <bullet>8.</bullet>
-          TRANSLATION
-          <p>Translation is considered a kind of modification, so you may distribute translations of the
-             Document under the terms of section 4. Replacing Invariant Sections with translations requires
-             special permission from their copyright holders, but you may include translations of some or
-             all Invariant Sections in addition to the original versions of these Invariant Sections. You
-             may include a translation of this License, and all the license notices in the Document, and
-             any Warranty Disclaimers, provided that you also include the original English version of this
-             License and the original versions of those notices and disclaimers. In case of a disagreement
-             between the translation and the original version of this License or a notice or disclaimer,
-             the original version will prevail.</p>
-            <p>If a section in the Document is Entitled "Acknowledgements", "Dedications",
-             or "History", the requirement (section 4) to Preserve its Title (section 1) will
-             typically require changing the actual title.</p>
-        </item>
-        <item>
-            <bullet>9.</bullet>
-          TERMINATION
-          <p>You may not copy, modify, sublicense, or distribute the Document except as expressly provided
-             under this License. Any attempt otherwise to copy, modify, sublicense, or distribute it is
-             void, and will automatically terminate your rights under this License.</p>
-            <p>However, if you cease all violation of this License, then your license from a particular
-             copyright holder is reinstated (a) provisionally, unless and until the copyright holder
-             explicitly and finally terminates your license, and (b) permanently, if the copyright holder
-             fails to notify you of the violation by some reasonable means prior to 60 days after the
-             cessation.</p>
-            <p>Moreover, your license from a particular copyright holder is reinstated permanently if the
-             copyright holder notifies you of the violation by some reasonable means, this is the first
-             time you have received notice of violation of this License (for any work) from that copyright
-             holder, and you cure the violation prior to 30 days after your receipt of the notice.</p>
-            <p>Termination of your rights under this section does not terminate the licenses of parties who have
-             received copies or rights from you under this License. If your rights have been terminated and
-             not permanently reinstated, receipt of a copy of some or all of the same material does not
-             give you any rights to use it.</p>
-        </item>
-        <item>
-            <bullet>10.</bullet>
-          FUTURE REVISIONS OF THIS LICENSE
-          <p>The Free Software Foundation may publish new, revised versions of the GNU Free Documentation
-             License from time to time. Such new versions will be similar in spirit to the present version,
-             but may differ in detail to address new problems or concerns. See
-             http://www.gnu.org/copyleft/.</p>
-            <p>Each version of the License is given a distinguishing version number. If the Document specifies
-             that a particular numbered version of this License "or any later version" applies to
-             it, you have the option of following the terms and conditions either of that specified version
-             or of any later version that has been published (not as a draft) by the Free Software
-             Foundation. If the Document does not specify a version number of this License, you may choose
-             any version ever published (not as a draft) by the Free Software Foundation. If the Document
-             specifies that a proxy can decide which future versions of this License can be used, that
-             proxy's public statement of acceptance of a version permanently authorizes you to choose
-             that version for the Document.</p>
-        </item>
-        <item>
-            <bullet>11.</bullet>
-          RELICENSING
-
-      <p>"Massive Multiauthor Collaboration Site" (or "MMC Site") means any World Wide Web
-         server that publishes copyrightable works and also provides prominent facilities for anybody to edit
-         those works. A public wiki that anybody can edit is an example of such a server. A "Massive
-         Multiauthor Collaboration" (or "MMC") contained in the site means any set of
-         copyrightable works thus published on the MMC site.</p>
-            <p>"CC-BY-SA" means the Creative Commons Attribution-Share Alike 3.0 license published by Creative
-         Commons Corporation, a not-for-profit corporation with a principal place of business in San Francisco,
-         California, as well as future copyleft versions of that license published by that same
-         organization.</p>
-            <p>"Incorporate" means to publish or republish a Document, in whole or in part, as part of another
-         Document.</p>
-            <p>An MMC is "eligible for relicensing" if it is licensed under this License, and if all works
-         that were first published under this License somewhere other than this MMC, and subsequently
-         incorporated in whole or in part into the MMC, (1) had no cover texts or invariant sections, and (2)
-         were thus incorporated prior to November 1, 2008.</p>
-            <p>The operator of an MMC Site may republish an MMC contained in the site under CC-BY-SA on the same site at
-         any time before August 1, 2009, provided the MMC is eligible for relicensing.</p>
-        </item>
-      </list>
-      <optional>
-         <p>ADDENDUM: How to use this License for your documents</p>
-         <p>To use this License in a document you have written, include a copy of the License in the document and put
-         the following copyright and license notices just after the title page:</p>
-         <p>Copyright (c) YEAR YOUR NAME. Permission is granted to copy, distribute and/or modify this document under
-         the terms of the GNU Free Documentation License, Version 1.3 or any later version published by the
-         Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts. A
-         copy of the license is included in the section entitled "GNU Free Documentation
-         License".</p>
-         <p>If you have Invariant Sections, Front-Cover Texts and Back-Cover Texts, replace the
-         "with...Texts." line with this:</p>
-         <p>with the Invariant Sections being LIST THEIR TITLES, with the Front-Cover Texts being LIST, and with the
-         Back-Cover Texts being LIST.</p>
-         <p>If you have Invariant Sections without Cover Texts, or some other combination of the three, merge those
-         two alternatives to suit the situation.</p>
-         <p>If your document contains nontrivial examples of program code, we recommend releasing these examples in
-         parallel under your choice of free software license, such as the GNU General Public License, to permit
-         their use in free software.</p>
-      </optional>
+        </list>
+        <p>
+          If the Modified Version includes new front-matter sections or
+          appendices that qualify as Secondary Sections and contain no material
+          copied from the Document, you may at your option designate some or
+          all of these sections as invariant. To do this, add their titles
+          to the list of Invariant Sections in the Modified Version's license
+          notice. These titles must be distinct from any other section titles.
+        </p>
+        <p>
+          You may add a section Entitled "Endorsements", provided
+          it contains nothing but endorsements of your Modified
+          Version by various parties--for example, statements of
+          peer review or that the text has been approved by an
+          organization as the authoritative definition of a standard.
+        </p>
+        <p>
+          You may add a passage of up to five words as a Front-Cover Text,
+          and a passage of up to 25 words as a Back-Cover Text, to the end of
+          the list of Cover Texts in the Modified Version. Only one passage
+          of Front-Cover Text and one of Back-Cover Text may be added by (or
+          through arrangements made by) any one entity. If the Document already
+          includes a cover text for the same cover, previously added by you or
+          by arrangement made by the same entity you are acting on behalf of,
+          you may not add another; but you may replace the old one, on explicit
+          permission from the previous publisher that added the old one.
+        </p>
+        <p>
+          The author(s) and publisher(s) of the Document do not by this
+          License give permission to use their names for publicity for
+          or to assert or imply endorsement of any Modified Version.
+        </p>
+      </item>
+      <item>
+        <bullet>5.</bullet>
+        COMBINING DOCUMENTS
+        <p>
+          You may combine the Document with other documents released under
+          this License, under the terms defined in section 4 above for modified
+          versions, provided that you include in the combination all of the
+          Invariant Sections of all of the original documents, unmodified,
+          and list them all as Invariant Sections of your combined work in its
+          license notice, and that you preserve all their Warranty Disclaimers.
+        </p>
+        <p>
+          The combined work need only contain one copy of this License, and
+          multiple identical Invariant Sections may be replaced with a single
+          copy. If there are multiple Invariant Sections with the same name
+          but different contents, make the title of each such section unique
+          by adding at the end of it, in parentheses, the name of the original
+          author or publisher of that section if known, or else a unique
+          number. Make the same adjustment to the section titles in the list
+          of Invariant Sections in the license notice of the combined work.
+        </p>
+        <p>
+          In the combination, you must combine any sections Entitled
+          "History" in the various original documents, forming one section
+          Entitled "History"; likewise combine any sections Entitled
+          "Acknowledgements", and any sections Entitled "Dedications".
+          You must delete all sections Entitled "Endorsements".
+        </p>
+      </item>
+      <item>
+        <bullet>6.</bullet>
+        COLLECTIONS OF DOCUMENTS
+        <p>
+          You may make a collection consisting of the Document and
+          other documents released under this License, and replace the
+          individual copies of this License in the various documents
+          with a single copy that is included in the collection,
+          provided that you follow the rules of this License for verbatim
+          copying of each of the documents in all other respects.
+        </p>
+        <p>
+          You may extract a single document from such a collection,
+          and distribute it individually under this License,
+          provided you insert a copy of this License into the
+          extracted document, and follow this License in all other
+          respects regarding verbatim copying of that document.
+        </p>
+      </item>
+      <item>
+        <bullet>7.</bullet>
+        AGGREGATION WITH INDEPENDENT WORKS
+        <p>
+          A compilation of the Document or its derivatives with other
+          separate and independent documents or works, in or on a volume
+          of a storage or distribution medium, is called an "aggregate"
+          if the copyright resulting from the compilation is not used to
+          limit the legal rights of the compilation's users beyond what
+          the individual works permit. When the Document is included in an
+          aggregate, this License does not apply to the other works in the
+          aggregate which are not themselves derivative works of the Document.
+        </p>
+        <p>
+          If the Cover Text requirement of section 3 is applicable to
+          these copies of the Document, then if the Document is less
+          than one half of the entire aggregate, the Document's Cover
+          Texts may be placed on covers that bracket the Document
+          within the aggregate, or the electronic equivalent of covers
+          if the Document is in electronic form. Otherwise they must
+          appear on printed covers that bracket the whole aggregate.
+        </p>
+      </item>
+      <item>
+        <bullet>8.</bullet>
+        TRANSLATION
+        <p>
+          Translation is considered a kind of modification, so you may
+          distribute translations of the Document under the terms of section
+          4. Replacing Invariant Sections with translations requires special
+          permission from their copyright holders, but you may include
+          translations of some or all Invariant Sections in addition to the
+          original versions of these Invariant Sections. You may include a
+          translation of this License, and all the license notices in the
+          Document, and any Warranty Disclaimers, provided that you also
+          include the original English version of this License and the original
+          versions of those notices and disclaimers. In case of a disagreement
+          between the translation and the original version of this License
+          or a notice or disclaimer, the original version will prevail.
+        </p>
+        <p>
+          If a section in the Document is Entitled
+          "Acknowledgements", "Dedications", or "History", the
+          requirement (section 4) to Preserve its Title (section
+          1) will typically require changing the actual title.
+        </p>
+      </item>
+      <item>
+        <bullet>9.</bullet>
+        TERMINATION
+        <p>
+          You may not copy, modify, sublicense, or distribute the Document
+          except as expressly provided under this License. Any attempt
+          otherwise to copy, modify, sublicense, or distribute it is void,
+          and will automatically terminate your rights under this License.
+        </p>
+        <p>
+          However, if you cease all violation of this License, then your
+          license from a particular copyright holder is reinstated (a)
+          provisionally, unless and until the copyright holder explicitly
+          and finally terminates your license, and (b) permanently, if
+          the copyright holder fails to notify you of the violation by
+          some reasonable means prior to 60 days after the cessation.
+        </p>
+        <p>
+          Moreover, your license from a particular copyright holder is
+          reinstated permanently if the copyright holder notifies you
+          of the violation by some reasonable means, this is the first
+          time you have received notice of violation of this License
+          (for any work) from that copyright holder, and you cure the
+          violation prior to 30 days after your receipt of the notice.
+        </p>
+        <p>
+          Termination of your rights under this section does not terminate
+          the licenses of parties who have received copies or rights from
+          you under this License. If your rights have been terminated and
+          not permanently reinstated, receipt of a copy of some or all
+          of the same material does not give you any rights to use it.
+        </p>
+      </item>
+      <item>
+        <bullet>10.</bullet>
+        FUTURE REVISIONS OF THIS LICENSE
+        <p>
+          The Free Software Foundation may publish new, revised
+          versions of the GNU Free Documentation License from time
+          to time. Such new versions will be similar in spirit to
+          the present version, but may differ in detail to address
+          new problems or concerns. See http://www.gnu.org/copyleft/.
+        </p>
+        <p>
+          Each version of the License is given a distinguishing version number.
+          If the Document specifies that a particular numbered version of this
+          License "or any later version" applies to it, you have the option of
+          following the terms and conditions either of that specified version or
+          of any later version that has been published (not as a draft) by the
+          Free Software Foundation. If the Document does not specify a version
+          number of this License, you may choose any version ever published (not
+          as a draft) by the Free Software Foundation. If the Document specifies
+          that a proxy can decide which future versions of this License can
+          be used, that proxy's public statement of acceptance of a version
+          permanently authorizes you to choose that version for the Document.
+        </p>
+      </item>
+      <item>
+        <bullet>11.</bullet>
+        RELICENSING
+        <p>
+          "Massive Multiauthor Collaboration Site" (or "MMC Site") means any
+          World Wide Web server that publishes copyrightable works and also
+          provides prominent facilities for anybody to edit those works. A
+          public wiki that anybody can edit is an example of such a server. A
+          "Massive Multiauthor Collaboration" (or "MMC") contained in the site
+          means any set of copyrightable works thus published on the MMC site.
+        </p>
+        <p>
+          "CC-BY-SA" means the Creative Commons Attribution-Share Alike
+          3.0 license published by Creative Commons Corporation, a
+          not-for-profit corporation with a principal place of business
+          in San Francisco, California, as well as future copyleft
+          versions of that license published by that same organization.
+        </p>
+        <p>
+          "Incorporate" means to publish or republish a Document,
+          in whole or in part, as part of another Document.
+        </p>
+        <p>
+          An MMC is "eligible for relicensing" if it is licensed under this
+          License, and if all works that were first published under this License
+          somewhere other than this MMC, and subsequently incorporated in
+          whole or in part into the MMC, (1) had no cover texts or invariant
+          sections, and (2) were thus incorporated prior to November 1, 2008.
+        </p>
+        <p>
+          The operator of an MMC Site may republish an MMC contained in
+          the site under CC-BY-SA on the same site at any time before
+          August 1, 2009, provided the MMC is eligible for relicensing.
+        </p>
+      </item>
+    </list>
+    <optional>
+      <p>
+        ADDENDUM: How to use this License for your documents
+      </p>
+      <p>
+        To use this License in a document you have written, include
+        a copy of the License in the document and put the following
+        copyright and license notices just after the title page:
+      </p>
+      <p>
+        Copyright (c) YEAR YOUR NAME. Permission is granted to copy,
+        distribute and/or modify this document under the terms of the GNU
+        Free Documentation License, Version 1.3 or any later version published
+        by the Free Software Foundation; with no Invariant Sections, no
+        Front-Cover Texts, and no Back-Cover Texts. A copy of the license is
+        included in the section entitled "GNU Free Documentation License".
+      </p>
+      <p>
+        If you have Invariant Sections, Front-Cover Texts and
+        Back-Cover Texts, replace the "with...Texts." line with this:
+      </p>
+      <p>
+        with the Invariant Sections being LIST THEIR TITLES, with the
+        Front-Cover Texts being LIST, and with the Back-Cover Texts being LIST.
+      </p>
+      <p>
+        If you have Invariant Sections without Cover Texts,
+        or some other combination of the three, merge
+        those two alternatives to suit the situation.
+      </p>
+      <p>
+        If your document contains nontrivial examples of program
+        code, we recommend releasing these examples in parallel
+        under your choice of free software license, such as the GNU
+        General Public License, to permit their use in free software.
+      </p>
+    </optional>
   </license>
 </SPDXLicenseCollection>

--- a/src/GPL-1.0-only.xml
+++ b/src/GPL-1.0-only.xml
@@ -1,0 +1,367 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SPDXLicenseCollection xmlns="http://www.spdx.org/license">
+  <license licenseId="GPL-1.0" isOsiApproved="false"
+  name="GNU General Public License v1.0 only"
+  isDeprecated="true" deprecatedVersion="3.0">
+    <crossRefs>
+      <crossRef>http://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html</crossRef>
+    </crossRefs>
+    <notes>
+      DEPRECATED: Deprecated in lieu of more
+      explicit license identifier of GPL-1.0-only
+    </notes>
+    <standardLicenseHeader>
+      Copyright (C)<alt name="copyright" match=".+">19xx name of author</alt>
+      <p>
+        This program is free software; you can redistribute it and/or
+        modify it under the terms of the GNU General Public License
+        as published by the Free Software Foundation; version 1.
+      </p>
+      <p>
+        This program is distributed in the hope that it will be
+        useful, but WITHOUT ANY WARRANTY; without even the implied
+        warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+        PURPOSE. See the GNU General Public License for more details.
+      </p>
+      <p>
+        You should have received a copy of the GNU General Public License
+        along with this program; if not, write to the Free Software
+        Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+      </p>
+    </standardLicenseHeader>
+    <notes>
+      This license was released: February 1989. This license
+      has been deprecated. This refers to when this GPL
+      1.0 only is being used (as opposed to "or later).
+    </notes>
+    <titleText>
+      <p>
+        GNU GENERAL PUBLIC LICENSE<br></br>
+        Version 1, February 1989
+      </p>
+    </titleText>
+    <p>
+      Copyright (C) 1989 Free Software Foundation, Inc. 51
+      Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+    </p>
+    <p>
+      Everyone is permitted to copy and distribute verbatim copies
+      of this license document, but changing it is not allowed.
+    </p>
+    <p>
+      Preamble
+    </p>
+    <p>
+      The license agreements of most software companies try to keep
+      users at the mercy of those companies. By contrast, our General
+      Public License is intended to guarantee your freedom to share
+      and change free software--to make sure the software is free for
+      all its users. The General Public License applies to the Free
+      Software Foundation's software and to any other program whose
+      authors commit to using it. You can use it for your programs, too.
+    </p>
+    <p>
+      When we speak of free software, we are referring to freedom, not
+      price. Specifically, the General Public License is designed to
+      make sure that you have the freedom to give away or sell copies
+      of free software, that you receive source code or can get it if
+      you want it, that you can change the software or use pieces of it
+      in new free programs; and that you know you can do these things.
+    </p>
+    <p>
+      To protect your rights, we need to make restrictions that forbid
+      anyone to deny you these rights or to ask you to surrender the
+      rights. These restrictions translate to certain responsibilities for
+      you if you distribute copies of the software, or if you modify it.
+    </p>
+    <p>
+      For example, if you distribute copies of a such a program, whether
+      gratis or for a fee, you must give the recipients all the rights
+      that you have. You must make sure that they, too, receive or
+      can get the source code. And you must tell them their rights.
+    </p>
+    <p>
+      We protect your rights with two steps: (1) copyright the
+      software, and (2) offer you this license which gives you legal
+      permission to copy, distribute and/or modify the software.
+    </p>
+    <p>
+      Also, for each author's protection and ours, we want to make
+      certain that everyone understands that there is no warranty for
+      this free software. If the software is modified by someone else
+      and passed on, we want its recipients to know that what they
+      have is not the original, so that any problems introduced by
+      others will not reflect on the original authors' reputations.
+    </p>
+    <p>
+      The precise terms and conditions for copying,
+      distribution and modification follow.
+    </p>
+    <p>
+      GNU GENERAL PUBLIC LICENSE TERMS AND CONDITIONS
+      FOR COPYING, DISTRIBUTION AND MODIFICATION
+    </p>
+    <list>
+      <item>
+        <bullet>0.</bullet>
+        This License Agreement applies to any program or other work which
+        contains a notice placed by the copyright holder saying it may
+        be distributed under the terms of this General Public License.
+        The "Program", below, refers to any such program or work, and
+        a "work based on the Program" means either the Program or any
+        work containing the Program or a portion of it, either verbatim
+        or with modifications. Each licensee is addressed as "you".
+      </item>
+      <item>
+        <bullet>1.</bullet>
+        You may copy and distribute verbatim copies of the Program's
+        source code as you receive it, in any medium, provided that you
+        conspicuously and appropriately publish on each copy an appropriate
+        copyright notice and disclaimer of warranty; keep intact all the
+        notices that refer to this General Public License and to the absence
+        of any warranty; and give any other recipients of the Program a
+        copy of this General Public License along with the Program. You
+        may charge a fee for the physical act of transferring a copy.
+      </item>
+      <item>
+        <bullet>2.</bullet>
+        You may modify your copy or copies of the Program or any portion
+        of it, and copy and distribute such modifications under the terms
+        of Paragraph 1 above, provided that you also do the following:
+        <list>
+          <item>
+            <bullet>a)</bullet>
+            cause the modified files to carry prominent notices stating
+            that you changed the files and the date of any change; and
+          </item>
+          <item>
+            <bullet>b)</bullet>
+            cause the whole of any work that you distribute or publish, that
+            in whole or in part contains the Program or any part thereof,
+            either with or without modifications, to be licensed at no
+            charge to all third parties under the terms of this General
+            Public License (except that you may choose to grant warranty
+            protection to some or all third parties, at your option).
+          </item>
+          <item>
+            <bullet>c)</bullet>
+            If the modified program normally reads commands interactively
+            when run, you must cause it, when started running for such
+            interactive use in the simplest and most usual way, to
+            print or display an announcement including an appropriate
+            copyright notice and a notice that there is no warranty (or
+            else, saying that you provide a warranty) and that users may
+            redistribute the program under these conditions, and telling
+            the user how to view a copy of this General Public License.
+          </item>
+          <item>
+            <bullet>d)</bullet>
+            You may charge a fee for the physical act of
+            transferring a copy, and you may at your option
+            offer warranty protection in exchange for a fee.
+          </item>
+        </list>
+        <p>
+          Mere aggregation of another independent work with the Program (or
+          its derivative) on a volume of a storage or distribution medium
+          does not bring the other work under the scope of these terms.
+        </p>
+      </item>
+      <item>
+        <bullet>3.</bullet>
+        You may copy and distribute the Program (or a portion
+        or derivative of it, under Paragraph 2) in object code
+        or executable form under the terms of Paragraphs 1 and
+        2 above provided that you also do one of the following:
+        <list>
+          <item>
+            <bullet>a)</bullet>
+            accompany it with the complete corresponding
+            machine-readable source code, which must be distributed
+            under the terms of Paragraphs 1 and 2 above; or,
+          </item>
+          <item>
+            <bullet>b)</bullet>
+            accompany it with a written offer, valid for at least
+            three years, to give any third party free (except for a
+            nominal charge for the cost of distribution) a complete
+            machine-readable copy of the corresponding source code, to be
+            distributed under the terms of Paragraphs 1 and 2 above; or,
+          </item>
+          <item>
+            <bullet>c)</bullet>
+            accompany it with the information you received as to where the
+            corresponding source code may be obtained. (This alternative
+            is allowed only for noncommercial distribution and only if you
+            received the program in object code or executable form alone.)
+          </item>
+        </list>
+        <p>
+          Source code for a work means the preferred form of the work for
+          making modifications to it. For an executable file, complete
+          source code means all the source code for all modules it contains;
+          but, as a special exception, it need not include source code for
+          modules which are standard libraries that accompany the operating
+          system on which the executable file runs, or for standard header
+          files or definitions files that accompany that operating system.
+        </p>
+      </item>
+      <item>
+        <bullet>4.</bullet>
+        You may not copy, modify, sublicense, distribute or transfer the
+        Program except as expressly provided under this General Public
+        License. Any attempt otherwise to copy, modify, sublicense,
+        distribute or transfer the Program is void, and will automatically
+        terminate your rights to use the Program under this License. However,
+        parties who have received copies, or rights to use copies, from
+        you under this General Public License will not have their licenses
+        terminated so long as such parties remain in full compliance.
+      </item>
+      <item>
+        <bullet>5.</bullet>
+        By copying, distributing or modifying the Program (or any
+        work based on the Program) you indicate your acceptance of
+        this license to do so, and all its terms and conditions.
+      </item>
+      <item>
+        <bullet>6.</bullet>
+        Each time you redistribute the Program (or any work based on the
+        Program), the recipient automatically receives a license from the
+        original licensor to copy, distribute or modify the Program subject
+        to these terms and conditions. You may not impose any further
+        restrictions on the recipients' exercise of the rights granted herein.
+      </item>
+      <item>
+        <bullet>7.</bullet>
+        The Free Software Foundation may publish revised and/or new
+        versions of the General Public License from time to time. Such
+        new versions will be similar in spirit to the present version,
+        but may differ in detail to address new problems or concerns.
+        <p>
+          Each version is given a distinguishing version number. If the
+          Program specifies a version number of the license which applies
+          to it and "any later version", you have the option of following
+          the terms and conditions either of that version or of any later
+          version published by the Free Software Foundation. If the Program
+          does not specify a version number of the license, you may choose
+          any version ever published by the Free Software Foundation.
+        </p>
+      </item>
+      <item>
+        <bullet>8.</bullet>
+        If you wish to incorporate parts of the Program into other free
+        programs whose distribution conditions are different, write to the
+        author to ask for permission. For software which is copyrighted by the
+        Free Software Foundation, write to the Free Software Foundation; we
+        sometimes make exceptions for this. Our decision will be guided by the
+        two goals of preserving the free status of all derivatives of our free
+        software and of promoting the sharing and reuse of software generally.
+      </item>
+      <item>
+        <p>
+          NO WARRANTY
+        </p>
+        <bullet>9.</bullet>
+        <p>
+          BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+          FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT
+          WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER
+          PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND,
+          EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+          IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+          PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF
+          THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU
+          ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+        </p>
+      </item>
+      <item>
+        <bullet>10.</bullet>
+        IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+        WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+        REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR
+        DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL
+        DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM
+        (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED
+        INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF
+        THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER
+        OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+      </item>
+    </list>
+    <optional>
+      <p>
+        END OF TERMS AND CONDITIONS
+      </p>
+      <p>
+        Appendix: How to Apply These Terms to Your New Programs
+      </p>
+      <p>
+        If you develop a new program, and you want it to be
+        of the greatest possible use to humanity, the best
+        way to achieve this is to make it free software which
+        everyone can redistribute and change under these terms.
+      </p>
+      <p>
+        To do so, attach the following notices to the program. It is safest
+        to attach them to the start of each source file to most effectively
+        convey the exclusion of warranty; and each file should have at least
+        the "copyright" line and a pointer to where the full notice is found.
+      </p>
+      <p>
+        &lt;one line to give the program's name and a brief idea
+        of what it does.&gt; Copyright (C) 19yy &lt;name of author&gt;
+      </p>
+      <p>
+        This program is free software; you can redistribute it
+        and/or modify it under the terms of the GNU General Public
+        License as published by the Free Software Foundation;
+        either version 1, or (at your option) any later version.
+      </p>
+      <p>
+        This program is distributed in the hope that it will be
+        useful, but WITHOUT ANY WARRANTY; without even the implied
+        warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+        PURPOSE. See the GNU General Public License for more details.
+      </p>
+      <p>
+        You should have received a copy of the GNU General Public License
+        along with this program; if not, write to the Free Software
+        Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+      </p>
+      <p>
+        Also add information on how to contact you by electronic and paper mail.
+      </p>
+      <p>
+        If the program is interactive, make it output a short
+        notice like this when it starts in an interactive mode:
+      </p>
+      <p>
+        Gnomovision version 69, Copyright (C) 19xx name of author
+        Gnomovision comes with ABSOLUTELY NO WARRANTY; for details
+        type `show w'. This is free software, and you are welcome to
+        redistribute it under certain conditions; type `show c' for details.
+      </p>
+      <p>
+        The hypothetical commands `show w' and `show c' should show the
+        appropriate parts of the General Public License. Of course, the commands
+        you use may be called something other than `show w' and `show c'; they
+        could even be mouse-clicks or menu items--whatever suits your program.
+      </p>
+      <p>
+        You should also get your employer (if you work as a programmer)
+        or your school, if any, to sign a "copyright disclaimer" for
+        the program, if necessary. Here a sample; alter the names:
+      </p>
+      <p>
+        Yoyodyne, Inc., hereby disclaims all copyright interest in
+        the program `Gnomovision' (a program to direct compilers
+        to make passes at assemblers) written by James Hacker.
+      </p>
+      <p>
+        &lt;signature of Ty Coon&gt;, 1 April 1989 Ty Coon, President of Vice
+      </p>
+      <p>
+        That's all there is to it!
+      </p>
+    </optional>
+  </license>
+</SPDXLicenseCollection>

--- a/src/GPL-1.0-only.xml
+++ b/src/GPL-1.0-only.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-  <license licenseId="GPL-1.0" isOsiApproved="false"
-  name="GNU General Public License v1.0 only"
-  isDeprecated="true" deprecatedVersion="3.0">
+  <license licenseId="GPL-1.0-only" isOsiApproved="false"
+  name="GNU General Public License v1.0 only">
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html</crossRef>
     </crossRefs>

--- a/src/GPL-1.0-or-later.xml
+++ b/src/GPL-1.0-or-later.xml
@@ -5,16 +5,13 @@
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html</crossRef>
     </crossRefs>
-    <notes>
-      DEPRECATED: Deprecated in lieu of more
-      explicit license identifier of GPL-1.0-only
-    </notes>
     <standardLicenseHeader>
       Copyright (C)<alt name="copyright" match=".+">19xx name of author</alt>
       <p>
         This program is free software; you can redistribute it and/or
         modify it under the terms of the GNU General Public License
-        as published by the Free Software Foundation; version 1.
+	as published by the Free Software Foundation; version 1
+	or any later version.
       </p>
       <p>
         This program is distributed in the hope that it will be
@@ -30,8 +27,7 @@
     </standardLicenseHeader>
     <notes>
       This license was released: February 1989. This license
-      has been deprecated. This refers to when this GPL
-      1.0 only is being used (as opposed to "or later).
+      has been deprecated by its authors.
     </notes>
     <titleText>
       <p>

--- a/src/GPL-1.0-or-later.xml
+++ b/src/GPL-1.0-or-later.xml
@@ -1,0 +1,367 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SPDXLicenseCollection xmlns="http://www.spdx.org/license">
+  <license licenseId="GPL-1.0" isOsiApproved="false"
+  name="GNU General Public License v1.0 only"
+  isDeprecated="true" deprecatedVersion="3.0">
+    <crossRefs>
+      <crossRef>http://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html</crossRef>
+    </crossRefs>
+    <notes>
+      DEPRECATED: Deprecated in lieu of more
+      explicit license identifier of GPL-1.0-only
+    </notes>
+    <standardLicenseHeader>
+      Copyright (C)<alt name="copyright" match=".+">19xx name of author</alt>
+      <p>
+        This program is free software; you can redistribute it and/or
+        modify it under the terms of the GNU General Public License
+        as published by the Free Software Foundation; version 1.
+      </p>
+      <p>
+        This program is distributed in the hope that it will be
+        useful, but WITHOUT ANY WARRANTY; without even the implied
+        warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+        PURPOSE. See the GNU General Public License for more details.
+      </p>
+      <p>
+        You should have received a copy of the GNU General Public License
+        along with this program; if not, write to the Free Software
+        Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+      </p>
+    </standardLicenseHeader>
+    <notes>
+      This license was released: February 1989. This license
+      has been deprecated. This refers to when this GPL
+      1.0 only is being used (as opposed to "or later).
+    </notes>
+    <titleText>
+      <p>
+        GNU GENERAL PUBLIC LICENSE<br></br>
+        Version 1, February 1989
+      </p>
+    </titleText>
+    <p>
+      Copyright (C) 1989 Free Software Foundation, Inc. 51
+      Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+    </p>
+    <p>
+      Everyone is permitted to copy and distribute verbatim copies
+      of this license document, but changing it is not allowed.
+    </p>
+    <p>
+      Preamble
+    </p>
+    <p>
+      The license agreements of most software companies try to keep
+      users at the mercy of those companies. By contrast, our General
+      Public License is intended to guarantee your freedom to share
+      and change free software--to make sure the software is free for
+      all its users. The General Public License applies to the Free
+      Software Foundation's software and to any other program whose
+      authors commit to using it. You can use it for your programs, too.
+    </p>
+    <p>
+      When we speak of free software, we are referring to freedom, not
+      price. Specifically, the General Public License is designed to
+      make sure that you have the freedom to give away or sell copies
+      of free software, that you receive source code or can get it if
+      you want it, that you can change the software or use pieces of it
+      in new free programs; and that you know you can do these things.
+    </p>
+    <p>
+      To protect your rights, we need to make restrictions that forbid
+      anyone to deny you these rights or to ask you to surrender the
+      rights. These restrictions translate to certain responsibilities for
+      you if you distribute copies of the software, or if you modify it.
+    </p>
+    <p>
+      For example, if you distribute copies of a such a program, whether
+      gratis or for a fee, you must give the recipients all the rights
+      that you have. You must make sure that they, too, receive or
+      can get the source code. And you must tell them their rights.
+    </p>
+    <p>
+      We protect your rights with two steps: (1) copyright the
+      software, and (2) offer you this license which gives you legal
+      permission to copy, distribute and/or modify the software.
+    </p>
+    <p>
+      Also, for each author's protection and ours, we want to make
+      certain that everyone understands that there is no warranty for
+      this free software. If the software is modified by someone else
+      and passed on, we want its recipients to know that what they
+      have is not the original, so that any problems introduced by
+      others will not reflect on the original authors' reputations.
+    </p>
+    <p>
+      The precise terms and conditions for copying,
+      distribution and modification follow.
+    </p>
+    <p>
+      GNU GENERAL PUBLIC LICENSE TERMS AND CONDITIONS
+      FOR COPYING, DISTRIBUTION AND MODIFICATION
+    </p>
+    <list>
+      <item>
+        <bullet>0.</bullet>
+        This License Agreement applies to any program or other work which
+        contains a notice placed by the copyright holder saying it may
+        be distributed under the terms of this General Public License.
+        The "Program", below, refers to any such program or work, and
+        a "work based on the Program" means either the Program or any
+        work containing the Program or a portion of it, either verbatim
+        or with modifications. Each licensee is addressed as "you".
+      </item>
+      <item>
+        <bullet>1.</bullet>
+        You may copy and distribute verbatim copies of the Program's
+        source code as you receive it, in any medium, provided that you
+        conspicuously and appropriately publish on each copy an appropriate
+        copyright notice and disclaimer of warranty; keep intact all the
+        notices that refer to this General Public License and to the absence
+        of any warranty; and give any other recipients of the Program a
+        copy of this General Public License along with the Program. You
+        may charge a fee for the physical act of transferring a copy.
+      </item>
+      <item>
+        <bullet>2.</bullet>
+        You may modify your copy or copies of the Program or any portion
+        of it, and copy and distribute such modifications under the terms
+        of Paragraph 1 above, provided that you also do the following:
+        <list>
+          <item>
+            <bullet>a)</bullet>
+            cause the modified files to carry prominent notices stating
+            that you changed the files and the date of any change; and
+          </item>
+          <item>
+            <bullet>b)</bullet>
+            cause the whole of any work that you distribute or publish, that
+            in whole or in part contains the Program or any part thereof,
+            either with or without modifications, to be licensed at no
+            charge to all third parties under the terms of this General
+            Public License (except that you may choose to grant warranty
+            protection to some or all third parties, at your option).
+          </item>
+          <item>
+            <bullet>c)</bullet>
+            If the modified program normally reads commands interactively
+            when run, you must cause it, when started running for such
+            interactive use in the simplest and most usual way, to
+            print or display an announcement including an appropriate
+            copyright notice and a notice that there is no warranty (or
+            else, saying that you provide a warranty) and that users may
+            redistribute the program under these conditions, and telling
+            the user how to view a copy of this General Public License.
+          </item>
+          <item>
+            <bullet>d)</bullet>
+            You may charge a fee for the physical act of
+            transferring a copy, and you may at your option
+            offer warranty protection in exchange for a fee.
+          </item>
+        </list>
+        <p>
+          Mere aggregation of another independent work with the Program (or
+          its derivative) on a volume of a storage or distribution medium
+          does not bring the other work under the scope of these terms.
+        </p>
+      </item>
+      <item>
+        <bullet>3.</bullet>
+        You may copy and distribute the Program (or a portion
+        or derivative of it, under Paragraph 2) in object code
+        or executable form under the terms of Paragraphs 1 and
+        2 above provided that you also do one of the following:
+        <list>
+          <item>
+            <bullet>a)</bullet>
+            accompany it with the complete corresponding
+            machine-readable source code, which must be distributed
+            under the terms of Paragraphs 1 and 2 above; or,
+          </item>
+          <item>
+            <bullet>b)</bullet>
+            accompany it with a written offer, valid for at least
+            three years, to give any third party free (except for a
+            nominal charge for the cost of distribution) a complete
+            machine-readable copy of the corresponding source code, to be
+            distributed under the terms of Paragraphs 1 and 2 above; or,
+          </item>
+          <item>
+            <bullet>c)</bullet>
+            accompany it with the information you received as to where the
+            corresponding source code may be obtained. (This alternative
+            is allowed only for noncommercial distribution and only if you
+            received the program in object code or executable form alone.)
+          </item>
+        </list>
+        <p>
+          Source code for a work means the preferred form of the work for
+          making modifications to it. For an executable file, complete
+          source code means all the source code for all modules it contains;
+          but, as a special exception, it need not include source code for
+          modules which are standard libraries that accompany the operating
+          system on which the executable file runs, or for standard header
+          files or definitions files that accompany that operating system.
+        </p>
+      </item>
+      <item>
+        <bullet>4.</bullet>
+        You may not copy, modify, sublicense, distribute or transfer the
+        Program except as expressly provided under this General Public
+        License. Any attempt otherwise to copy, modify, sublicense,
+        distribute or transfer the Program is void, and will automatically
+        terminate your rights to use the Program under this License. However,
+        parties who have received copies, or rights to use copies, from
+        you under this General Public License will not have their licenses
+        terminated so long as such parties remain in full compliance.
+      </item>
+      <item>
+        <bullet>5.</bullet>
+        By copying, distributing or modifying the Program (or any
+        work based on the Program) you indicate your acceptance of
+        this license to do so, and all its terms and conditions.
+      </item>
+      <item>
+        <bullet>6.</bullet>
+        Each time you redistribute the Program (or any work based on the
+        Program), the recipient automatically receives a license from the
+        original licensor to copy, distribute or modify the Program subject
+        to these terms and conditions. You may not impose any further
+        restrictions on the recipients' exercise of the rights granted herein.
+      </item>
+      <item>
+        <bullet>7.</bullet>
+        The Free Software Foundation may publish revised and/or new
+        versions of the General Public License from time to time. Such
+        new versions will be similar in spirit to the present version,
+        but may differ in detail to address new problems or concerns.
+        <p>
+          Each version is given a distinguishing version number. If the
+          Program specifies a version number of the license which applies
+          to it and "any later version", you have the option of following
+          the terms and conditions either of that version or of any later
+          version published by the Free Software Foundation. If the Program
+          does not specify a version number of the license, you may choose
+          any version ever published by the Free Software Foundation.
+        </p>
+      </item>
+      <item>
+        <bullet>8.</bullet>
+        If you wish to incorporate parts of the Program into other free
+        programs whose distribution conditions are different, write to the
+        author to ask for permission. For software which is copyrighted by the
+        Free Software Foundation, write to the Free Software Foundation; we
+        sometimes make exceptions for this. Our decision will be guided by the
+        two goals of preserving the free status of all derivatives of our free
+        software and of promoting the sharing and reuse of software generally.
+      </item>
+      <item>
+        <p>
+          NO WARRANTY
+        </p>
+        <bullet>9.</bullet>
+        <p>
+          BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+          FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT
+          WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER
+          PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND,
+          EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+          IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+          PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF
+          THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU
+          ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+        </p>
+      </item>
+      <item>
+        <bullet>10.</bullet>
+        IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+        WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+        REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR
+        DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL
+        DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM
+        (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED
+        INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF
+        THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER
+        OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+      </item>
+    </list>
+    <optional>
+      <p>
+        END OF TERMS AND CONDITIONS
+      </p>
+      <p>
+        Appendix: How to Apply These Terms to Your New Programs
+      </p>
+      <p>
+        If you develop a new program, and you want it to be
+        of the greatest possible use to humanity, the best
+        way to achieve this is to make it free software which
+        everyone can redistribute and change under these terms.
+      </p>
+      <p>
+        To do so, attach the following notices to the program. It is safest
+        to attach them to the start of each source file to most effectively
+        convey the exclusion of warranty; and each file should have at least
+        the "copyright" line and a pointer to where the full notice is found.
+      </p>
+      <p>
+        &lt;one line to give the program's name and a brief idea
+        of what it does.&gt; Copyright (C) 19yy &lt;name of author&gt;
+      </p>
+      <p>
+        This program is free software; you can redistribute it
+        and/or modify it under the terms of the GNU General Public
+        License as published by the Free Software Foundation;
+        either version 1, or (at your option) any later version.
+      </p>
+      <p>
+        This program is distributed in the hope that it will be
+        useful, but WITHOUT ANY WARRANTY; without even the implied
+        warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+        PURPOSE. See the GNU General Public License for more details.
+      </p>
+      <p>
+        You should have received a copy of the GNU General Public License
+        along with this program; if not, write to the Free Software
+        Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+      </p>
+      <p>
+        Also add information on how to contact you by electronic and paper mail.
+      </p>
+      <p>
+        If the program is interactive, make it output a short
+        notice like this when it starts in an interactive mode:
+      </p>
+      <p>
+        Gnomovision version 69, Copyright (C) 19xx name of author
+        Gnomovision comes with ABSOLUTELY NO WARRANTY; for details
+        type `show w'. This is free software, and you are welcome to
+        redistribute it under certain conditions; type `show c' for details.
+      </p>
+      <p>
+        The hypothetical commands `show w' and `show c' should show the
+        appropriate parts of the General Public License. Of course, the commands
+        you use may be called something other than `show w' and `show c'; they
+        could even be mouse-clicks or menu items--whatever suits your program.
+      </p>
+      <p>
+        You should also get your employer (if you work as a programmer)
+        or your school, if any, to sign a "copyright disclaimer" for
+        the program, if necessary. Here a sample; alter the names:
+      </p>
+      <p>
+        Yoyodyne, Inc., hereby disclaims all copyright interest in
+        the program `Gnomovision' (a program to direct compilers
+        to make passes at assemblers) written by James Hacker.
+      </p>
+      <p>
+        &lt;signature of Ty Coon&gt;, 1 April 1989 Ty Coon, President of Vice
+      </p>
+      <p>
+        That's all there is to it!
+      </p>
+    </optional>
+  </license>
+</SPDXLicenseCollection>

--- a/src/GPL-1.0-or-later.xml
+++ b/src/GPL-1.0-or-later.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-  <license licenseId="GPL-1.0" isOsiApproved="false"
-  name="GNU General Public License v1.0 only"
-  isDeprecated="true" deprecatedVersion="3.0">
+  <license licenseId="GPL-1.0-or-later" isOsiApproved="false"
+  name="GNU General Public License v1.0 or later">
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html</crossRef>
     </crossRefs>

--- a/src/GPL-1.0.xml
+++ b/src/GPL-1.0.xml
@@ -1,241 +1,367 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isDeprecated="true" deprecatedVersion="3.0" isOsiApproved="false" licenseId="GPL-1.0"
-            name="GNU General Public License v1.0 only">
-      <crossRefs>
-         <crossRef>http://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html</crossRef>
-      </crossRefs>
-      <notes>DEPRECATED: Deprecated in lieu of more explicit license identifier of GPL-1.0-only</notes>
-      <standardLicenseHeader> Copyright (C) 
-    <alt match=".+" name="copyright">19xx name of author</alt> 
-         <p>This program is free software; you can redistribute it and/or modify it under the terms of the 
-    GNU General Public License as published by the Free Software Foundation; version 1.</p> 
-         <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-    without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
-    Public License for more details. </p>
-         <p>You should have received a copy of the GNU General Public License along with
-    this program; if not, write to the Free Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA. </p>
-      </standardLicenseHeader>
-      <notes>This license was released: February 1989. This license has been deprecated. This refers to when this GPL 1.0
-         only is being used (as opposed to "or later).</notes>
-      <titleText>
-         <p>GNU GENERAL PUBLIC LICENSE 
-        <br/>Version 1, February 1989 
+  <license licenseId="GPL-1.0" isOsiApproved="false"
+  name="GNU General Public License v1.0 only"
+  isDeprecated="true" deprecatedVersion="3.0">
+    <crossRefs>
+      <crossRef>http://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html</crossRef>
+    </crossRefs>
+    <notes>
+      DEPRECATED: Deprecated in lieu of more
+      explicit license identifier of GPL-1.0-only
+    </notes>
+    <standardLicenseHeader>
+      Copyright (C)<alt name="copyright" match=".+">19xx name of author</alt>
+      <p>
+        This program is free software; you can redistribute it and/or
+        modify it under the terms of the GNU General Public License
+        as published by the Free Software Foundation; version 1.
       </p>
-      </titleText>
-      <p>Copyright (C) 1989 Free Software Foundation, Inc. 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA</p>
-      <p>Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is
-       not allowed.</p>
-      <p>Preamble</p>
-      <p>The license agreements of most software companies try to keep users at the mercy of those companies. By
-       contrast, our General Public License is intended to guarantee your freedom to share and change free
-       software--to make sure the software is free for all its users. The General Public License applies to
-       the Free Software Foundation's software and to any other program whose authors commit to using
-       it. You can use it for your programs, too.</p>
-      <p>When we speak of free software, we are referring to freedom, not price. Specifically, the General Public
-       License is designed to make sure that you have the freedom to give away or sell copies of free
-       software, that you receive source code or can get it if you want it, that you can change the software
-       or use pieces of it in new free programs; and that you know you can do these things.</p>
-      <p>To protect your rights, we need to make restrictions that forbid anyone to deny you these rights or to
-       ask you to surrender the rights. These restrictions translate to certain responsibilities for you if
-       you distribute copies of the software, or if you modify it.</p>
-      <p>For example, if you distribute copies of a such a program, whether gratis or for a fee, you must give the
-       recipients all the rights that you have. You must make sure that they, too, receive or can get the
-       source code. And you must tell them their rights.</p>
-      <p>We protect your rights with two steps: (1) copyright the software, and (2) offer you this license which
-       gives you legal permission to copy, distribute and/or modify the software.</p>
-      <p>Also, for each author's protection and ours, we want to make certain that everyone understands that
-       there is no warranty for this free software. If the software is modified by someone else and passed
-       on, we want its recipients to know that what they have is not the original, so that any problems
-       introduced by others will not reflect on the original authors' reputations.</p>
-      <p>The precise terms and conditions for copying, distribution and modification follow.</p>
-      <p>GNU GENERAL PUBLIC LICENSE TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION</p>
-      <list>
-         <item>
-            <bullet>0.</bullet>
-        This License Agreement applies to any program or other work which contains a notice placed by the
-           copyright holder saying it may be distributed under the terms of this General Public License.
-           The "Program", below, refers to any such program or work, and a "work based on
-           the Program" means either the Program or any work containing the Program or a portion of
-           it, either verbatim or with modifications. Each licensee is addressed as "you".
+      <p>
+        This program is distributed in the hope that it will be
+        useful, but WITHOUT ANY WARRANTY; without even the implied
+        warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+        PURPOSE. See the GNU General Public License for more details.
+      </p>
+      <p>
+        You should have received a copy of the GNU General Public License
+        along with this program; if not, write to the Free Software
+        Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+      </p>
+    </standardLicenseHeader>
+    <notes>
+      This license was released: February 1989. This license
+      has been deprecated. This refers to when this GPL
+      1.0 only is being used (as opposed to "or later).
+    </notes>
+    <titleText>
+      <p>
+        GNU GENERAL PUBLIC LICENSE<br></br>
+        Version 1, February 1989
+      </p>
+    </titleText>
+    <p>
+      Copyright (C) 1989 Free Software Foundation, Inc. 51
+      Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+    </p>
+    <p>
+      Everyone is permitted to copy and distribute verbatim copies
+      of this license document, but changing it is not allowed.
+    </p>
+    <p>
+      Preamble
+    </p>
+    <p>
+      The license agreements of most software companies try to keep
+      users at the mercy of those companies. By contrast, our General
+      Public License is intended to guarantee your freedom to share
+      and change free software--to make sure the software is free for
+      all its users. The General Public License applies to the Free
+      Software Foundation's software and to any other program whose
+      authors commit to using it. You can use it for your programs, too.
+    </p>
+    <p>
+      When we speak of free software, we are referring to freedom, not
+      price. Specifically, the General Public License is designed to
+      make sure that you have the freedom to give away or sell copies
+      of free software, that you receive source code or can get it if
+      you want it, that you can change the software or use pieces of it
+      in new free programs; and that you know you can do these things.
+    </p>
+    <p>
+      To protect your rights, we need to make restrictions that forbid
+      anyone to deny you these rights or to ask you to surrender the
+      rights. These restrictions translate to certain responsibilities for
+      you if you distribute copies of the software, or if you modify it.
+    </p>
+    <p>
+      For example, if you distribute copies of a such a program, whether
+      gratis or for a fee, you must give the recipients all the rights
+      that you have. You must make sure that they, too, receive or
+      can get the source code. And you must tell them their rights.
+    </p>
+    <p>
+      We protect your rights with two steps: (1) copyright the
+      software, and (2) offer you this license which gives you legal
+      permission to copy, distribute and/or modify the software.
+    </p>
+    <p>
+      Also, for each author's protection and ours, we want to make
+      certain that everyone understands that there is no warranty for
+      this free software. If the software is modified by someone else
+      and passed on, we want its recipients to know that what they
+      have is not the original, so that any problems introduced by
+      others will not reflect on the original authors' reputations.
+    </p>
+    <p>
+      The precise terms and conditions for copying,
+      distribution and modification follow.
+    </p>
+    <p>
+      GNU GENERAL PUBLIC LICENSE TERMS AND CONDITIONS
+      FOR COPYING, DISTRIBUTION AND MODIFICATION
+    </p>
+    <list>
+      <item>
+        <bullet>0.</bullet>
+        This License Agreement applies to any program or other work which
+        contains a notice placed by the copyright holder saying it may
+        be distributed under the terms of this General Public License.
+        The "Program", below, refers to any such program or work, and
+        a "work based on the Program" means either the Program or any
+        work containing the Program or a portion of it, either verbatim
+        or with modifications. Each licensee is addressed as "you".
       </item>
-         <item>
-            <bullet>1.</bullet>
-        You may copy and distribute verbatim copies of the Program's source code as you receive it,
-           in any medium, provided that you conspicuously and appropriately publish on each copy an
-           appropriate copyright notice and disclaimer of warranty; keep intact all the notices that
-           refer to this General Public License and to the absence of any warranty; and give any other
-           recipients of the Program a copy of this General Public License along with the Program. You
-           may charge a fee for the physical act of transferring a copy.
+      <item>
+        <bullet>1.</bullet>
+        You may copy and distribute verbatim copies of the Program's
+        source code as you receive it, in any medium, provided that you
+        conspicuously and appropriately publish on each copy an appropriate
+        copyright notice and disclaimer of warranty; keep intact all the
+        notices that refer to this General Public License and to the absence
+        of any warranty; and give any other recipients of the Program a
+        copy of this General Public License along with the Program. You
+        may charge a fee for the physical act of transferring a copy.
       </item>
-         <item>
-            <bullet>2.</bullet>
-        You may modify your copy or copies of the Program or any portion of it, and copy and distribute
-           such modifications under the terms of Paragraph 1 above, provided that you also do the
-           following:
+      <item>
+        <bullet>2.</bullet>
+        You may modify your copy or copies of the Program or any portion
+        of it, and copy and distribute such modifications under the terms
+        of Paragraph 1 above, provided that you also do the following:
         <list>
-               <item>
-                  <bullet>a)</bullet>
-            cause the modified files to carry prominent notices stating that you changed the files and
-               the date of any change; and
+          <item>
+            <bullet>a)</bullet>
+            cause the modified files to carry prominent notices stating
+            that you changed the files and the date of any change; and
           </item>
-               <item>
-                  <bullet>b)</bullet>
-            cause the whole of any work that you distribute or publish, that in whole or in part contains
-               the Program or any part thereof, either with or without modifications, to be licensed at
-               no charge to all third parties under the terms of this General Public License (except that
-               you may choose to grant warranty protection to some or all third parties, at your
-               option).
+          <item>
+            <bullet>b)</bullet>
+            cause the whole of any work that you distribute or publish, that
+            in whole or in part contains the Program or any part thereof,
+            either with or without modifications, to be licensed at no
+            charge to all third parties under the terms of this General
+            Public License (except that you may choose to grant warranty
+            protection to some or all third parties, at your option).
           </item>
-               <item>
-                  <bullet>c)</bullet>
-            If the modified program normally reads commands interactively when run, you must cause it,
-               when started running for such interactive use in the simplest and most usual way, to print
-               or display an announcement including an appropriate copyright notice and a notice that
-               there is no warranty (or else, saying that you provide a warranty) and that users may
-               redistribute the program under these conditions, and telling the user how to view a copy
-               of this General Public License.
+          <item>
+            <bullet>c)</bullet>
+            If the modified program normally reads commands interactively
+            when run, you must cause it, when started running for such
+            interactive use in the simplest and most usual way, to
+            print or display an announcement including an appropriate
+            copyright notice and a notice that there is no warranty (or
+            else, saying that you provide a warranty) and that users may
+            redistribute the program under these conditions, and telling
+            the user how to view a copy of this General Public License.
           </item>
-               <item>
-                  <bullet>d)</bullet>
-            You may charge a fee for the physical act of transferring a copy, and you may at your option
-               offer warranty protection in exchange for a fee.
+          <item>
+            <bullet>d)</bullet>
+            You may charge a fee for the physical act of
+            transferring a copy, and you may at your option
+            offer warranty protection in exchange for a fee.
           </item>
-            </list>
-            <p>Mere aggregation of another independent work with the Program (or its derivative) on a volume
-           of a storage or distribution medium does not bring the other work under the scope of these
-           terms.</p>
-         </item>
-         <item>
-            <bullet>3.</bullet>
-        You may copy and distribute the Program (or a portion or derivative of it, under Paragraph 2) in
-           object code or executable form under the terms of Paragraphs 1 and 2 above provided that you
-           also do one of the following:
+        </list>
+        <p>
+          Mere aggregation of another independent work with the Program (or
+          its derivative) on a volume of a storage or distribution medium
+          does not bring the other work under the scope of these terms.
+        </p>
+      </item>
+      <item>
+        <bullet>3.</bullet>
+        You may copy and distribute the Program (or a portion
+        or derivative of it, under Paragraph 2) in object code
+        or executable form under the terms of Paragraphs 1 and
+        2 above provided that you also do one of the following:
         <list>
-               <item>
-                  <bullet>a)</bullet>
-            accompany it with the complete corresponding machine-readable source code, which must be
-               distributed under the terms of Paragraphs 1 and 2 above; or,
+          <item>
+            <bullet>a)</bullet>
+            accompany it with the complete corresponding
+            machine-readable source code, which must be distributed
+            under the terms of Paragraphs 1 and 2 above; or,
           </item>
-               <item>
-                  <bullet>b)</bullet>
-            accompany it with a written offer, valid for at least three years, to give any third party
-               free (except for a nominal charge for the cost of distribution) a complete
-               machine-readable copy of the corresponding source code, to be distributed under the terms
-               of Paragraphs 1 and 2 above; or,
+          <item>
+            <bullet>b)</bullet>
+            accompany it with a written offer, valid for at least
+            three years, to give any third party free (except for a
+            nominal charge for the cost of distribution) a complete
+            machine-readable copy of the corresponding source code, to be
+            distributed under the terms of Paragraphs 1 and 2 above; or,
           </item>
-               <item>
-                  <bullet>c)</bullet>
-            accompany it with the information you received as to where the corresponding source code may
-               be obtained. (This alternative is allowed only for noncommercial distribution and only if
-               you received the program in object code or executable form alone.)
+          <item>
+            <bullet>c)</bullet>
+            accompany it with the information you received as to where the
+            corresponding source code may be obtained. (This alternative
+            is allowed only for noncommercial distribution and only if you
+            received the program in object code or executable form alone.)
           </item>
-            </list>
-            <p>Source code for a work means the preferred form of the work for making modifications to it.
-           For an executable file, complete source code means all the source code for all modules it
-           contains; but, as a special exception, it need not include source code for modules which
-           are standard libraries that accompany the operating system on which the executable file
-           runs, or for standard header files or definitions files that accompany that operating
-           system.</p>
-         </item>
-         <item>
-            <bullet>4.</bullet>
-        You may not copy, modify, sublicense, distribute or transfer the Program except as expressly
-           provided under this General Public License. Any attempt otherwise to copy, modify, sublicense,
-           distribute or transfer the Program is void, and will automatically terminate your rights to
-           use the Program under this License. However, parties who have received copies, or rights to
-           use copies, from you under this General Public License will not have their licenses terminated
-           so long as such parties remain in full compliance.
+        </list>
+        <p>
+          Source code for a work means the preferred form of the work for
+          making modifications to it. For an executable file, complete
+          source code means all the source code for all modules it contains;
+          but, as a special exception, it need not include source code for
+          modules which are standard libraries that accompany the operating
+          system on which the executable file runs, or for standard header
+          files or definitions files that accompany that operating system.
+        </p>
       </item>
-         <item>
-            <bullet>5.</bullet>
-        By copying, distributing or modifying the Program (or any work based on the Program) you indicate
-           your acceptance of this license to do so, and all its terms and conditions.
+      <item>
+        <bullet>4.</bullet>
+        You may not copy, modify, sublicense, distribute or transfer the
+        Program except as expressly provided under this General Public
+        License. Any attempt otherwise to copy, modify, sublicense,
+        distribute or transfer the Program is void, and will automatically
+        terminate your rights to use the Program under this License. However,
+        parties who have received copies, or rights to use copies, from
+        you under this General Public License will not have their licenses
+        terminated so long as such parties remain in full compliance.
       </item>
-         <item>
-            <bullet>6.</bullet>
-        Each time you redistribute the Program (or any work based on the Program), the recipient
-           automatically receives a license from the original licensor to copy, distribute or modify the
-           Program subject to these terms and conditions. You may not impose any further restrictions on
-           the recipients' exercise of the rights granted herein.
+      <item>
+        <bullet>5.</bullet>
+        By copying, distributing or modifying the Program (or any
+        work based on the Program) you indicate your acceptance of
+        this license to do so, and all its terms and conditions.
       </item>
-         <item>
-            <bullet>7.</bullet>
-        The Free Software Foundation may publish revised and/or new versions of the General Public
-           License from time to time. Such new versions will be similar in spirit to the present version,
-           but may differ in detail to address new problems or concerns.
-        <p>Each version is given a distinguishing version number. If the Program specifies a version number
-           of the license which applies to it and "any later version", you have the option of
-           following the terms and conditions either of that version or of any later version published by
-           the Free Software Foundation. If the Program does not specify a version number of the license,
-           you may choose any version ever published by the Free Software Foundation.</p>
-         </item>
-        <item>
-            <bullet>8.</bullet>
-          If you wish to incorporate parts of the Program into other free programs whose distribution
-             conditions are different, write to the author to ask for permission. For software which is
-             copyrighted by the Free Software Foundation, write to the Free Software Foundation; we
-             sometimes make exceptions for this. Our decision will be guided by the two goals of preserving
-             the free status of all derivatives of our free software and of promoting the sharing and reuse
-             of software generally.
-        </item>
-        <item>
-            <p>NO WARRANTY</p>
-            <bullet>9.</bullet>
-            <p>BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY FOR THE PROGRAM, TO THE
-             EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
-             HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY
-             KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-             MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND
-             PERFORMANCE OF THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE
-             COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.</p>
-        </item>
-        <item>
-            <bullet>10.</bullet>
-          IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY COPYRIGHT HOLDER,
-             OR ANY OTHER PARTY WHO MAY MODIFY AND/OR REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE
-             LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES
-             ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
-             DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
-             FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY
-             HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
-        </item>
-      </list>
-      <optional>
-         <p>END OF TERMS AND CONDITIONS</p>
-         <p>Appendix: How to Apply These Terms to Your New Programs</p>
-         <p>If you develop a new program, and you want it to be of the greatest possible use to humanity, the best
-         way to achieve this is to make it free software which everyone can redistribute and change under these
-         terms.</p>
-         <p>To do so, attach the following notices to the program. It is safest to attach them to the start of each
-         source file to most effectively convey the exclusion of warranty; and each file should have at least
-         the "copyright" line and a pointer to where the full notice is found.</p>
-         <p>&lt;one line to give the program's name and a brief idea of what it does.&gt; Copyright (C) 19yy
-         &lt;name of author&gt;</p>
-         <p>This program is free software; you can redistribute it and/or modify it under the terms of the GNU
-         General Public License as published by the Free Software Foundation; either version 1, or (at your
-         option) any later version.</p>
-         <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
-         the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
-         Public License for more details.</p>
-         <p>You should have received a copy of the GNU General Public License along with this program; if not, write
-         to the Free Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.</p>
-         <p>Also add information on how to contact you by electronic and paper mail.</p>
-         <p>If the program is interactive, make it output a short notice like this when it starts in an interactive
-         mode:</p>
-         <p>Gnomovision version 69, Copyright (C) 19xx name of author Gnomovision comes with ABSOLUTELY NO WARRANTY;
-         for details type `show w'. This is free software, and you are welcome to redistribute it under
-         certain conditions; type `show c' for details.</p>
-         <p>The hypothetical commands `show w' and `show c' should show the appropriate parts of the
-         General Public License. Of course, the commands you use may be called something other than `show
-         w' and `show c'; they could even be mouse-clicks or menu items--whatever suits your
-         program.</p>
-         <p>You should also get your employer (if you work as a programmer) or your school, if any, to sign a
-         "copyright disclaimer" for the program, if necessary. Here a sample; alter the names:</p>
-         <p>Yoyodyne, Inc., hereby disclaims all copyright interest in the program `Gnomovision' (a program to
-         direct compilers to make passes at assemblers) written by James Hacker.</p>
-         <p>&lt;signature of Ty Coon&gt;, 1 April 1989 Ty Coon, President of Vice</p>
-         <p>That's all there is to it!</p>
-      </optional>
+      <item>
+        <bullet>6.</bullet>
+        Each time you redistribute the Program (or any work based on the
+        Program), the recipient automatically receives a license from the
+        original licensor to copy, distribute or modify the Program subject
+        to these terms and conditions. You may not impose any further
+        restrictions on the recipients' exercise of the rights granted herein.
+      </item>
+      <item>
+        <bullet>7.</bullet>
+        The Free Software Foundation may publish revised and/or new
+        versions of the General Public License from time to time. Such
+        new versions will be similar in spirit to the present version,
+        but may differ in detail to address new problems or concerns.
+        <p>
+          Each version is given a distinguishing version number. If the
+          Program specifies a version number of the license which applies
+          to it and "any later version", you have the option of following
+          the terms and conditions either of that version or of any later
+          version published by the Free Software Foundation. If the Program
+          does not specify a version number of the license, you may choose
+          any version ever published by the Free Software Foundation.
+        </p>
+      </item>
+      <item>
+        <bullet>8.</bullet>
+        If you wish to incorporate parts of the Program into other free
+        programs whose distribution conditions are different, write to the
+        author to ask for permission. For software which is copyrighted by the
+        Free Software Foundation, write to the Free Software Foundation; we
+        sometimes make exceptions for this. Our decision will be guided by the
+        two goals of preserving the free status of all derivatives of our free
+        software and of promoting the sharing and reuse of software generally.
+      </item>
+      <item>
+        <p>
+          NO WARRANTY
+        </p>
+        <bullet>9.</bullet>
+        <p>
+          BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+          FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT
+          WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER
+          PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND,
+          EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+          IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+          PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF
+          THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU
+          ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+        </p>
+      </item>
+      <item>
+        <bullet>10.</bullet>
+        IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+        WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+        REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR
+        DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL
+        DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM
+        (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED
+        INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF
+        THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER
+        OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+      </item>
+    </list>
+    <optional>
+      <p>
+        END OF TERMS AND CONDITIONS
+      </p>
+      <p>
+        Appendix: How to Apply These Terms to Your New Programs
+      </p>
+      <p>
+        If you develop a new program, and you want it to be
+        of the greatest possible use to humanity, the best
+        way to achieve this is to make it free software which
+        everyone can redistribute and change under these terms.
+      </p>
+      <p>
+        To do so, attach the following notices to the program. It is safest
+        to attach them to the start of each source file to most effectively
+        convey the exclusion of warranty; and each file should have at least
+        the "copyright" line and a pointer to where the full notice is found.
+      </p>
+      <p>
+        &lt;one line to give the program's name and a brief idea
+        of what it does.&gt; Copyright (C) 19yy &lt;name of author&gt;
+      </p>
+      <p>
+        This program is free software; you can redistribute it
+        and/or modify it under the terms of the GNU General Public
+        License as published by the Free Software Foundation;
+        either version 1, or (at your option) any later version.
+      </p>
+      <p>
+        This program is distributed in the hope that it will be
+        useful, but WITHOUT ANY WARRANTY; without even the implied
+        warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+        PURPOSE. See the GNU General Public License for more details.
+      </p>
+      <p>
+        You should have received a copy of the GNU General Public License
+        along with this program; if not, write to the Free Software
+        Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+      </p>
+      <p>
+        Also add information on how to contact you by electronic and paper mail.
+      </p>
+      <p>
+        If the program is interactive, make it output a short
+        notice like this when it starts in an interactive mode:
+      </p>
+      <p>
+        Gnomovision version 69, Copyright (C) 19xx name of author
+        Gnomovision comes with ABSOLUTELY NO WARRANTY; for details
+        type `show w'. This is free software, and you are welcome to
+        redistribute it under certain conditions; type `show c' for details.
+      </p>
+      <p>
+        The hypothetical commands `show w' and `show c' should show the
+        appropriate parts of the General Public License. Of course, the commands
+        you use may be called something other than `show w' and `show c'; they
+        could even be mouse-clicks or menu items--whatever suits your program.
+      </p>
+      <p>
+        You should also get your employer (if you work as a programmer)
+        or your school, if any, to sign a "copyright disclaimer" for
+        the program, if necessary. Here a sample; alter the names:
+      </p>
+      <p>
+        Yoyodyne, Inc., hereby disclaims all copyright interest in
+        the program `Gnomovision' (a program to direct compilers
+        to make passes at assemblers) written by James Hacker.
+      </p>
+      <p>
+        &lt;signature of Ty Coon&gt;, 1 April 1989 Ty Coon, President of Vice
+      </p>
+      <p>
+        That's all there is to it!
+      </p>
+    </optional>
   </license>
 </SPDXLicenseCollection>

--- a/src/GPL-2.0-only.xml
+++ b/src/GPL-2.0-only.xml
@@ -1,0 +1,469 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SPDXLicenseCollection xmlns="http://www.spdx.org/license">
+  <license licenseId="GPL-2.0" isOsiApproved="true"
+  name="GNU General Public License v2.0 only">
+    <crossRefs>
+      <crossRef>http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html</crossRef>
+      <crossRef>http://www.opensource.org/licenses/GPL-2.0</crossRef>
+    </crossRefs>
+    <standardLicenseHeader>
+      Copyright (C)<alt name="copyright" match=".+">yyyy name of author</alt>
+      <p>
+        This program is free software; you can redistribute it and/or
+        modify it under the terms of the GNU General Public License
+        as published by the Free Software Foundation; version 2.
+      </p>
+      <p>
+        This program is distributed in the hope that it will be
+        useful, but WITHOUT ANY WARRANTY; without even the implied
+        warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+        PURPOSE. See the GNU General Public License for more details.
+      </p>
+      <p>
+        You should have received a copy of the GNU General Public License
+        along with this program; if not, write to the Free Software Foundation,
+        Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301
+        <optional>,</optional>
+        USA.
+      </p>
+    </standardLicenseHeader>
+    <notes>
+      This license was released: June 1991 This refers to when this
+      GPL 2.0 only is being used (as opposed to GPLv2 or later).
+    </notes>
+    <titleText>
+      <p>
+        GNU GENERAL PUBLIC LICENSE<br></br>
+        Version 2, June 1991
+      </p>
+    </titleText>
+    <p>
+      Copyright (C) 1989, 1991 Free Software Foundation, Inc.<br></br>
+      51 Franklin Street, Fifth Floor, Boston, MA 02110-1301
+      <optional>,</optional>
+      USA
+    </p>
+    <p>
+      Everyone is permitted to copy and distribute verbatim copies
+      of this license document, but changing it is not allowed.
+    </p>
+    <p>
+      Preamble
+    </p>
+    <p>
+      The licenses for most software are designed to take away your freedom
+      to share and change it. By contrast, the GNU General Public License is
+      intended to guarantee your freedom to share and change free software--to
+      make sure the software is free for all its users. This General Public
+      License applies to most of the Free Software Foundation's software
+      and to any other program whose authors commit to using it. (Some other
+      Free Software Foundation software is covered by the GNU Lesser General
+      Public License instead.) You can apply it to your programs, too.
+    </p>
+    <p>
+      When we speak of free software, we are referring to freedom, not price.
+      Our General Public Licenses are designed to make sure that you have
+      the freedom to distribute copies of free software (and charge for
+      this service if you wish), that you receive source code or can get
+      it if you want it, that you can change the software or use pieces of
+      it in new free programs; and that you know you can do these things.
+    </p>
+    <p>
+      To protect your rights, we need to make restrictions that forbid
+      anyone to deny you these rights or to ask you to surrender the
+      rights. These restrictions translate to certain responsibilities for
+      you if you distribute copies of the software, or if you modify it.
+    </p>
+    <p>
+      For example, if you distribute copies of such a program, whether gratis
+      or for a fee, you must give the recipients all the rights that you
+      have. You must make sure that they, too, receive or can get the source
+      code. And you must show them these terms so they know their rights.
+    </p>
+    <p>
+      We protect your rights with two steps: (1) copyright the
+      software, and (2) offer you this license which gives you legal
+      permission to copy, distribute and/or modify the software.
+    </p>
+    <p>
+      Also, for each author's protection and ours, we want to make
+      certain that everyone understands that there is no warranty for
+      this free software. If the software is modified by someone else
+      and passed on, we want its recipients to know that what they
+      have is not the original, so that any problems introduced by
+      others will not reflect on the original authors' reputations.
+    </p>
+    <p>
+      Finally, any free program is threatened constantly by software patents.
+      We wish to avoid the danger that redistributors of a free program
+      will individually obtain patent licenses, in effect making the program
+      proprietary. To prevent this, we have made it clear that any patent
+      must be licensed for everyone's free use or not licensed at all.
+    </p>
+    <p>
+      The precise terms and conditions for copying,
+      distribution and modification follow.
+    </p>
+    <p>
+      TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+    </p>
+    <list>
+      <item>
+        <bullet>0.</bullet>
+        This License applies to any program or other work which contains a
+        notice placed by the copyright holder saying it may be distributed
+        under the terms of this General Public License. The "Program", below,
+        refers to any such program or work, and a "work based on the Program"
+        means either the Program or any derivative work under copyright law:
+        that is to say, a work containing the Program or a portion of it,
+        either verbatim or with modifications and/or translated into another
+        language. (Hereinafter, translation is included without limitation
+        in the term "modification".) Each licensee is addressed as "you".
+        <p>
+          Activities other than copying, distribution and modification are
+          not covered by this License; they are outside its scope. The act
+          of running the Program is not restricted, and the output from the
+          Program is covered only if its contents constitute a work based
+          on the Program (independent of having been made by running the
+          Program). Whether that is true depends on what the Program does.
+        </p>
+      </item>
+      <item>
+        <bullet>1.</bullet>
+        You may copy and distribute verbatim copies of the Program's source
+        code as you receive it, in any medium, provided that you conspicuously
+        and appropriately publish on each copy an appropriate copyright notice
+        and disclaimer of warranty; keep intact all the notices that refer to
+        this License and to the absence of any warranty; and give any other
+        recipients of the Program a copy of this License along with the Program.
+        <p>
+          You may charge a fee for the physical act of
+          transferring a copy, and you may at your option
+          offer warranty protection in exchange for a fee.
+        </p>
+      </item>
+      <item>
+        <bullet>2.</bullet>
+        You may modify your copy or copies of the Program or any portion
+        of it, thus forming a work based on the Program, and copy and
+        distribute such modifications or work under the terms of Section
+        1 above, provided that you also meet all of these conditions:
+        <list>
+          <item>
+            <bullet>a)</bullet>
+            You must cause the modified files to carry prominent notices
+            stating that you changed the files and the date of any change.
+          </item>
+          <item>
+            <bullet>b)</bullet>
+            You must cause any work that you distribute or publish,
+            that in whole or in part contains or is derived from the
+            Program or any part thereof, to be licensed as a whole at no
+            charge to all third parties under the terms of this License.
+          </item>
+          <item>
+            <bullet>c)</bullet>
+            If the modified program normally reads commands interactively
+            when run, you must cause it, when started running for such
+            interactive use in the most ordinary way, to print or display
+            an announcement including an appropriate copyright notice and
+            a notice that there is no warranty (or else, saying that you
+            provide a warranty) and that users may redistribute the program
+            under these conditions, and telling the user how to view a copy
+            of this License. (Exception: if the Program itself is interactive
+            but does not normally print such an announcement, your work
+            based on the Program is not required to print an announcement.)
+          </item>
+        </list>
+        <p>
+          These requirements apply to the modified work as a whole. If
+          identifiable sections of that work are not derived from the
+          Program, and can be reasonably considered independent and separate
+          works in themselves, then this License, and its terms, do not
+          apply to those sections when you distribute them as separate
+          works. But when you distribute the same sections as part of a
+          whole which is a work based on the Program, the distribution
+          of the whole must be on the terms of this License, whose
+          permissions for other licensees extend to the entire whole,
+          and thus to each and every part regardless of who wrote it.
+        </p>
+        <p>
+          Thus, it is not the intent of this section to claim rights or
+          contest your rights to work written entirely by you; rather,
+          the intent is to exercise the right to control the distribution
+          of derivative or collective works based on the Program.
+        </p>
+        <p>
+          In addition, mere aggregation of another work not based on
+          the Program with the Program (or with a work based on the
+          Program) on a volume of a storage or distribution medium does
+          not bring the other work under the scope of this License.
+        </p>
+      </item>
+      <item>
+        <bullet>3.</bullet>
+        You may copy and distribute the Program (or a work based on it,
+        under Section 2) in object code or executable form under the terms of
+        Sections 1 and 2 above provided that you also do one of the following:
+        <list>
+          <item>
+            <bullet>a)</bullet>
+            Accompany it with the complete corresponding machine-readable source
+            code, which must be distributed under the terms of Sections 1 and
+            2 above on a medium customarily used for software interchange; or,
+          </item>
+          <item>
+            <bullet>b)</bullet>
+            Accompany it with a written offer, valid for at least three
+            years, to give any third party, for a charge no more than your
+            cost of physically performing source distribution, a complete
+            machine-readable copy of the corresponding source code, to
+            be distributed under the terms of Sections 1 and 2 above
+            on a medium customarily used for software interchange; or,
+          </item>
+          <item>
+            <bullet>c)</bullet>
+            Accompany it with the information you received as to the offer
+            to distribute corresponding source code. (This alternative
+            is allowed only for noncommercial distribution and only if
+            you received the program in object code or executable form
+            with such an offer, in accord with Subsection b above.)
+          </item>
+        </list>
+        <p>
+          The source code for a work means the preferred form of the work
+          for making modifications to it. For an executable work, complete
+          source code means all the source code for all modules it contains,
+          plus any associated interface definition files, plus the scripts
+          used to control compilation and installation of the executable.
+          However, as a special exception, the source code distributed
+          need not include anything that is normally distributed (in either
+          source or binary form) with the major components (compiler,
+          kernel, and so on) of the operating system on which the executable
+          runs, unless that component itself accompanies the executable.
+        </p>
+        <p>
+          If distribution of executable or object code is made by offering
+          access to copy from a designated place, then offering equivalent
+          access to copy the source code from the same place counts as
+          distribution of the source code, even though third parties are
+          not compelled to copy the source along with the object code.
+        </p>
+      </item>
+      <item>
+        <bullet>4.</bullet>
+        You may not copy, modify, sublicense, or distribute the Program
+        except as expressly provided under this License. Any attempt
+        otherwise to copy, modify, sublicense or distribute the Program
+        is void, and will automatically terminate your rights under
+        this License. However, parties who have received copies, or
+        rights, from you under this License will not have their licenses
+        terminated so long as such parties remain in full compliance.
+      </item>
+      <item>
+        <bullet>5.</bullet>
+        You are not required to accept this License, since you have
+        not signed it. However, nothing else grants you permission to
+        modify or distribute the Program or its derivative works. These
+        actions are prohibited by law if you do not accept this License.
+        Therefore, by modifying or distributing the Program (or any
+        work based on the Program), you indicate your acceptance of this
+        License to do so, and all its terms and conditions for copying,
+        distributing or modifying the Program or works based on it.
+      </item>
+      <item>
+        <bullet>6.</bullet>
+        Each time you redistribute the Program (or any work based on the
+        Program), the recipient automatically receives a license from the
+        original licensor to copy, distribute or modify the Program subject to
+        these terms and conditions. You may not impose any further restrictions
+        on the recipients' exercise of the rights granted herein. You are not
+        responsible for enforcing compliance by third parties to this License.
+      </item>
+      <item>
+        <bullet>7.</bullet>
+        If, as a consequence of a court judgment or allegation of patent
+        infringement or for any other reason (not limited to patent issues),
+        conditions are imposed on you (whether by court order, agreement
+        or otherwise) that contradict the conditions of this License,
+        they do not excuse you from the conditions of this License. If you
+        cannot distribute so as to satisfy simultaneously your obligations
+        under this License and any other pertinent obligations, then as a
+        consequence you may not distribute the Program at all. For example,
+        if a patent license would not permit royalty-free redistribution of
+        the Program by all those who receive copies directly or indirectly
+        through you, then the only way you could satisfy both it and this
+        License would be to refrain entirely from distribution of the Program.
+        <p>
+          If any portion of this section is held invalid or
+          unenforceable under any particular circumstance, the
+          balance of the section is intended to apply and the section
+          as a whole is intended to apply in other circumstances.
+        </p>
+        <p>
+          It is not the purpose of this section to induce you to infringe
+          any patents or other property right claims or to contest
+          validity of any such claims; this section has the sole purpose
+          of protecting the integrity of the free software distribution
+          system, which is implemented by public license practices. Many
+          people have made generous contributions to the wide range of
+          software distributed through that system in reliance on consistent
+          application of that system; it is up to the author/donor to
+          decide if he or she is willing to distribute software through
+          any other system and a licensee cannot impose that choice.
+        </p>
+        <p>
+          This section is intended to make thoroughly clear what is
+          believed to be a consequence of the rest of this License.
+        </p>
+      </item>
+      <item>
+        <bullet>8.</bullet>
+        If the distribution and/or use of the Program is restricted in
+        certain countries either by patents or by copyrighted interfaces,
+        the original copyright holder who places the Program under this
+        License may add an explicit geographical distribution limitation
+        excluding those countries, so that distribution is permitted only
+        in or among countries not thus excluded. In such case, this License
+        incorporates the limitation as if written in the body of this License.
+      </item>
+      <item>
+        <bullet>9.</bullet>
+        The Free Software Foundation may publish revised and/or new
+        versions of the General Public License from time to time. Such
+        new versions will be similar in spirit to the present version,
+        but may differ in detail to address new problems or concerns.
+        <p>
+          Each version is given a distinguishing version number. If the
+          Program specifies a version number of this License which applies
+          to it and "any later version", you have the option of following
+          the terms and conditions either of that version or of any later
+          version published by the Free Software Foundation. If the Program
+          does not specify a version number of this License, you may choose
+          any version ever published by the Free Software Foundation.
+        </p>
+      </item>
+      <item>
+        <bullet>10.</bullet>
+        If you wish to incorporate parts of the Program into other free
+        programs whose distribution conditions are different, write to the
+        author to ask for permission. For software which is copyrighted by the
+        Free Software Foundation, write to the Free Software Foundation; we
+        sometimes make exceptions for this. Our decision will be guided by the
+        two goals of preserving the free status of all derivatives of our free
+        software and of promoting the sharing and reuse of software generally.
+        <p>
+          NO WARRANTY
+        </p>
+      </item>
+      <item>
+        <bullet>11.</bullet>
+        BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+        FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT
+        WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER
+        PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND,
+        EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+        IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+        PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF
+        THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU
+        ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+      </item>
+      <item>
+        <bullet>12.</bullet>
+        IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+        WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+        REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR
+        DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL
+        DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM
+        (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED
+        INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF
+        THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER
+        OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+      </item>
+    </list>
+    <optional>
+      <p>
+        END OF TERMS AND CONDITIONS
+      </p>
+      <p>
+        How to Apply These Terms to Your New Programs
+      </p>
+      <p>
+        If you develop a new program, and you want it to be
+        of the greatest possible use to the public, the best
+        way to achieve this is to make it free software which
+        everyone can redistribute and change under these terms.
+      </p>
+      <p>
+        To do so, attach the following notices to the program. It is safest
+        to attach them to the start of each source file to most effectively
+        convey the exclusion of warranty; and each file should have at least
+        the "copyright" line and a pointer to where the full notice is found.
+      </p>
+      <p>
+        <optional>&lt;</optional>
+        one line to give the program's name and an idea of what it does.
+        <optional>&gt;</optional>
+        <br></br>
+        Copyright (C)
+        <optional>&lt;</optional>
+        yyyy
+        <optional>&gt;</optional>
+        <optional>&lt;</optional>
+        name of author
+        <optional>&gt;</optional>
+      </p>
+      <p>
+        This program is free software; you can redistribute it and/or
+        modify it under the terms of the GNU General Public License
+        as published by the Free Software Foundation; either version
+        2 of the License, or (at your option) any later version.
+      </p>
+      <p>
+        This program is distributed in the hope that it will be
+        useful, but WITHOUT ANY WARRANTY; without even the implied
+        warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+        PURPOSE. See the GNU General Public License for more details.
+      </p>
+      <p>
+        You should have received a copy of the GNU General Public License
+        along with this program; if not, write to the Free Software Foundation,
+        Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301
+        <optional>
+          ,
+        </optional>
+        USA. Also add information on how to
+        contact you by electronic and paper mail.
+      </p>
+      <p>
+        If the program is interactive, make it output a short
+        notice like this when it starts in an interactive mode:
+      </p>
+      <p>
+        Gnomovision version 69, Copyright (C) year name of author
+        Gnomovision comes with ABSOLUTELY NO WARRANTY; for details
+        type `show w'. This is free software, and you are welcome to
+        redistribute it under certain conditions; type `show c' for details.
+      </p>
+      <p>
+        The hypothetical commands `show w' and `show c' should show the
+        appropriate parts of the General Public License. Of course, the commands
+        you use may be called something other than `show w' and `show c'; they
+        could even be mouse-clicks or menu items--whatever suits your program.
+      </p>
+      <p>
+        You should also get your employer (if you work as a programmer)
+        or your school, if any, to sign a "copyright disclaimer" for
+        the program, if necessary. Here is a sample; alter the names:
+      </p>
+      <p>
+        Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+        `Gnomovision' (which makes passes at compilers) written by James Hacker.
+      </p>
+      <p>
+	<optional>&lt;</optional>signature of Ty Coon<optional>&gt;</optional>,
+	1 April 1989 Ty Coon, President of Vice
+      </p>
+    </optional>
+  </license>
+</SPDXLicenseCollection>

--- a/src/GPL-2.0-only.xml
+++ b/src/GPL-2.0-only.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-  <license licenseId="GPL-2.0" isOsiApproved="true"
+  <license licenseId="GPL-2.0-only" isOsiApproved="true"
   name="GNU General Public License v2.0 only">
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html</crossRef>

--- a/src/GPL-2.0-or-later.xml
+++ b/src/GPL-2.0-or-later.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-  <license licenseId="GPL-2.0" isOsiApproved="true"
-  name="GNU General Public License v2.0 only">
+  <license licenseId="GPL-2.0-or-later" isOsiApproved="true"
+  name="GNU General Public License v2.0 or later">
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html</crossRef>
       <crossRef>http://www.opensource.org/licenses/GPL-2.0</crossRef>

--- a/src/GPL-2.0-or-later.xml
+++ b/src/GPL-2.0-or-later.xml
@@ -1,0 +1,469 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SPDXLicenseCollection xmlns="http://www.spdx.org/license">
+  <license licenseId="GPL-2.0" isOsiApproved="true"
+  name="GNU General Public License v2.0 only">
+    <crossRefs>
+      <crossRef>http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html</crossRef>
+      <crossRef>http://www.opensource.org/licenses/GPL-2.0</crossRef>
+    </crossRefs>
+    <standardLicenseHeader>
+      Copyright (C)<alt name="copyright" match=".+">yyyy name of author</alt>
+      <p>
+        This program is free software; you can redistribute it and/or
+        modify it under the terms of the GNU General Public License
+        as published by the Free Software Foundation; version 2.
+      </p>
+      <p>
+        This program is distributed in the hope that it will be
+        useful, but WITHOUT ANY WARRANTY; without even the implied
+        warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+        PURPOSE. See the GNU General Public License for more details.
+      </p>
+      <p>
+        You should have received a copy of the GNU General Public License
+        along with this program; if not, write to the Free Software Foundation,
+        Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301
+        <optional>,</optional>
+        USA.
+      </p>
+    </standardLicenseHeader>
+    <notes>
+      This license was released: June 1991 This refers to when this
+      GPL 2.0 only is being used (as opposed to GPLv2 or later).
+    </notes>
+    <titleText>
+      <p>
+        GNU GENERAL PUBLIC LICENSE<br></br>
+        Version 2, June 1991
+      </p>
+    </titleText>
+    <p>
+      Copyright (C) 1989, 1991 Free Software Foundation, Inc.<br></br>
+      51 Franklin Street, Fifth Floor, Boston, MA 02110-1301
+      <optional>,</optional>
+      USA
+    </p>
+    <p>
+      Everyone is permitted to copy and distribute verbatim copies
+      of this license document, but changing it is not allowed.
+    </p>
+    <p>
+      Preamble
+    </p>
+    <p>
+      The licenses for most software are designed to take away your freedom
+      to share and change it. By contrast, the GNU General Public License is
+      intended to guarantee your freedom to share and change free software--to
+      make sure the software is free for all its users. This General Public
+      License applies to most of the Free Software Foundation's software
+      and to any other program whose authors commit to using it. (Some other
+      Free Software Foundation software is covered by the GNU Lesser General
+      Public License instead.) You can apply it to your programs, too.
+    </p>
+    <p>
+      When we speak of free software, we are referring to freedom, not price.
+      Our General Public Licenses are designed to make sure that you have
+      the freedom to distribute copies of free software (and charge for
+      this service if you wish), that you receive source code or can get
+      it if you want it, that you can change the software or use pieces of
+      it in new free programs; and that you know you can do these things.
+    </p>
+    <p>
+      To protect your rights, we need to make restrictions that forbid
+      anyone to deny you these rights or to ask you to surrender the
+      rights. These restrictions translate to certain responsibilities for
+      you if you distribute copies of the software, or if you modify it.
+    </p>
+    <p>
+      For example, if you distribute copies of such a program, whether gratis
+      or for a fee, you must give the recipients all the rights that you
+      have. You must make sure that they, too, receive or can get the source
+      code. And you must show them these terms so they know their rights.
+    </p>
+    <p>
+      We protect your rights with two steps: (1) copyright the
+      software, and (2) offer you this license which gives you legal
+      permission to copy, distribute and/or modify the software.
+    </p>
+    <p>
+      Also, for each author's protection and ours, we want to make
+      certain that everyone understands that there is no warranty for
+      this free software. If the software is modified by someone else
+      and passed on, we want its recipients to know that what they
+      have is not the original, so that any problems introduced by
+      others will not reflect on the original authors' reputations.
+    </p>
+    <p>
+      Finally, any free program is threatened constantly by software patents.
+      We wish to avoid the danger that redistributors of a free program
+      will individually obtain patent licenses, in effect making the program
+      proprietary. To prevent this, we have made it clear that any patent
+      must be licensed for everyone's free use or not licensed at all.
+    </p>
+    <p>
+      The precise terms and conditions for copying,
+      distribution and modification follow.
+    </p>
+    <p>
+      TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+    </p>
+    <list>
+      <item>
+        <bullet>0.</bullet>
+        This License applies to any program or other work which contains a
+        notice placed by the copyright holder saying it may be distributed
+        under the terms of this General Public License. The "Program", below,
+        refers to any such program or work, and a "work based on the Program"
+        means either the Program or any derivative work under copyright law:
+        that is to say, a work containing the Program or a portion of it,
+        either verbatim or with modifications and/or translated into another
+        language. (Hereinafter, translation is included without limitation
+        in the term "modification".) Each licensee is addressed as "you".
+        <p>
+          Activities other than copying, distribution and modification are
+          not covered by this License; they are outside its scope. The act
+          of running the Program is not restricted, and the output from the
+          Program is covered only if its contents constitute a work based
+          on the Program (independent of having been made by running the
+          Program). Whether that is true depends on what the Program does.
+        </p>
+      </item>
+      <item>
+        <bullet>1.</bullet>
+        You may copy and distribute verbatim copies of the Program's source
+        code as you receive it, in any medium, provided that you conspicuously
+        and appropriately publish on each copy an appropriate copyright notice
+        and disclaimer of warranty; keep intact all the notices that refer to
+        this License and to the absence of any warranty; and give any other
+        recipients of the Program a copy of this License along with the Program.
+        <p>
+          You may charge a fee for the physical act of
+          transferring a copy, and you may at your option
+          offer warranty protection in exchange for a fee.
+        </p>
+      </item>
+      <item>
+        <bullet>2.</bullet>
+        You may modify your copy or copies of the Program or any portion
+        of it, thus forming a work based on the Program, and copy and
+        distribute such modifications or work under the terms of Section
+        1 above, provided that you also meet all of these conditions:
+        <list>
+          <item>
+            <bullet>a)</bullet>
+            You must cause the modified files to carry prominent notices
+            stating that you changed the files and the date of any change.
+          </item>
+          <item>
+            <bullet>b)</bullet>
+            You must cause any work that you distribute or publish,
+            that in whole or in part contains or is derived from the
+            Program or any part thereof, to be licensed as a whole at no
+            charge to all third parties under the terms of this License.
+          </item>
+          <item>
+            <bullet>c)</bullet>
+            If the modified program normally reads commands interactively
+            when run, you must cause it, when started running for such
+            interactive use in the most ordinary way, to print or display
+            an announcement including an appropriate copyright notice and
+            a notice that there is no warranty (or else, saying that you
+            provide a warranty) and that users may redistribute the program
+            under these conditions, and telling the user how to view a copy
+            of this License. (Exception: if the Program itself is interactive
+            but does not normally print such an announcement, your work
+            based on the Program is not required to print an announcement.)
+          </item>
+        </list>
+        <p>
+          These requirements apply to the modified work as a whole. If
+          identifiable sections of that work are not derived from the
+          Program, and can be reasonably considered independent and separate
+          works in themselves, then this License, and its terms, do not
+          apply to those sections when you distribute them as separate
+          works. But when you distribute the same sections as part of a
+          whole which is a work based on the Program, the distribution
+          of the whole must be on the terms of this License, whose
+          permissions for other licensees extend to the entire whole,
+          and thus to each and every part regardless of who wrote it.
+        </p>
+        <p>
+          Thus, it is not the intent of this section to claim rights or
+          contest your rights to work written entirely by you; rather,
+          the intent is to exercise the right to control the distribution
+          of derivative or collective works based on the Program.
+        </p>
+        <p>
+          In addition, mere aggregation of another work not based on
+          the Program with the Program (or with a work based on the
+          Program) on a volume of a storage or distribution medium does
+          not bring the other work under the scope of this License.
+        </p>
+      </item>
+      <item>
+        <bullet>3.</bullet>
+        You may copy and distribute the Program (or a work based on it,
+        under Section 2) in object code or executable form under the terms of
+        Sections 1 and 2 above provided that you also do one of the following:
+        <list>
+          <item>
+            <bullet>a)</bullet>
+            Accompany it with the complete corresponding machine-readable source
+            code, which must be distributed under the terms of Sections 1 and
+            2 above on a medium customarily used for software interchange; or,
+          </item>
+          <item>
+            <bullet>b)</bullet>
+            Accompany it with a written offer, valid for at least three
+            years, to give any third party, for a charge no more than your
+            cost of physically performing source distribution, a complete
+            machine-readable copy of the corresponding source code, to
+            be distributed under the terms of Sections 1 and 2 above
+            on a medium customarily used for software interchange; or,
+          </item>
+          <item>
+            <bullet>c)</bullet>
+            Accompany it with the information you received as to the offer
+            to distribute corresponding source code. (This alternative
+            is allowed only for noncommercial distribution and only if
+            you received the program in object code or executable form
+            with such an offer, in accord with Subsection b above.)
+          </item>
+        </list>
+        <p>
+          The source code for a work means the preferred form of the work
+          for making modifications to it. For an executable work, complete
+          source code means all the source code for all modules it contains,
+          plus any associated interface definition files, plus the scripts
+          used to control compilation and installation of the executable.
+          However, as a special exception, the source code distributed
+          need not include anything that is normally distributed (in either
+          source or binary form) with the major components (compiler,
+          kernel, and so on) of the operating system on which the executable
+          runs, unless that component itself accompanies the executable.
+        </p>
+        <p>
+          If distribution of executable or object code is made by offering
+          access to copy from a designated place, then offering equivalent
+          access to copy the source code from the same place counts as
+          distribution of the source code, even though third parties are
+          not compelled to copy the source along with the object code.
+        </p>
+      </item>
+      <item>
+        <bullet>4.</bullet>
+        You may not copy, modify, sublicense, or distribute the Program
+        except as expressly provided under this License. Any attempt
+        otherwise to copy, modify, sublicense or distribute the Program
+        is void, and will automatically terminate your rights under
+        this License. However, parties who have received copies, or
+        rights, from you under this License will not have their licenses
+        terminated so long as such parties remain in full compliance.
+      </item>
+      <item>
+        <bullet>5.</bullet>
+        You are not required to accept this License, since you have
+        not signed it. However, nothing else grants you permission to
+        modify or distribute the Program or its derivative works. These
+        actions are prohibited by law if you do not accept this License.
+        Therefore, by modifying or distributing the Program (or any
+        work based on the Program), you indicate your acceptance of this
+        License to do so, and all its terms and conditions for copying,
+        distributing or modifying the Program or works based on it.
+      </item>
+      <item>
+        <bullet>6.</bullet>
+        Each time you redistribute the Program (or any work based on the
+        Program), the recipient automatically receives a license from the
+        original licensor to copy, distribute or modify the Program subject to
+        these terms and conditions. You may not impose any further restrictions
+        on the recipients' exercise of the rights granted herein. You are not
+        responsible for enforcing compliance by third parties to this License.
+      </item>
+      <item>
+        <bullet>7.</bullet>
+        If, as a consequence of a court judgment or allegation of patent
+        infringement or for any other reason (not limited to patent issues),
+        conditions are imposed on you (whether by court order, agreement
+        or otherwise) that contradict the conditions of this License,
+        they do not excuse you from the conditions of this License. If you
+        cannot distribute so as to satisfy simultaneously your obligations
+        under this License and any other pertinent obligations, then as a
+        consequence you may not distribute the Program at all. For example,
+        if a patent license would not permit royalty-free redistribution of
+        the Program by all those who receive copies directly or indirectly
+        through you, then the only way you could satisfy both it and this
+        License would be to refrain entirely from distribution of the Program.
+        <p>
+          If any portion of this section is held invalid or
+          unenforceable under any particular circumstance, the
+          balance of the section is intended to apply and the section
+          as a whole is intended to apply in other circumstances.
+        </p>
+        <p>
+          It is not the purpose of this section to induce you to infringe
+          any patents or other property right claims or to contest
+          validity of any such claims; this section has the sole purpose
+          of protecting the integrity of the free software distribution
+          system, which is implemented by public license practices. Many
+          people have made generous contributions to the wide range of
+          software distributed through that system in reliance on consistent
+          application of that system; it is up to the author/donor to
+          decide if he or she is willing to distribute software through
+          any other system and a licensee cannot impose that choice.
+        </p>
+        <p>
+          This section is intended to make thoroughly clear what is
+          believed to be a consequence of the rest of this License.
+        </p>
+      </item>
+      <item>
+        <bullet>8.</bullet>
+        If the distribution and/or use of the Program is restricted in
+        certain countries either by patents or by copyrighted interfaces,
+        the original copyright holder who places the Program under this
+        License may add an explicit geographical distribution limitation
+        excluding those countries, so that distribution is permitted only
+        in or among countries not thus excluded. In such case, this License
+        incorporates the limitation as if written in the body of this License.
+      </item>
+      <item>
+        <bullet>9.</bullet>
+        The Free Software Foundation may publish revised and/or new
+        versions of the General Public License from time to time. Such
+        new versions will be similar in spirit to the present version,
+        but may differ in detail to address new problems or concerns.
+        <p>
+          Each version is given a distinguishing version number. If the
+          Program specifies a version number of this License which applies
+          to it and "any later version", you have the option of following
+          the terms and conditions either of that version or of any later
+          version published by the Free Software Foundation. If the Program
+          does not specify a version number of this License, you may choose
+          any version ever published by the Free Software Foundation.
+        </p>
+      </item>
+      <item>
+        <bullet>10.</bullet>
+        If you wish to incorporate parts of the Program into other free
+        programs whose distribution conditions are different, write to the
+        author to ask for permission. For software which is copyrighted by the
+        Free Software Foundation, write to the Free Software Foundation; we
+        sometimes make exceptions for this. Our decision will be guided by the
+        two goals of preserving the free status of all derivatives of our free
+        software and of promoting the sharing and reuse of software generally.
+        <p>
+          NO WARRANTY
+        </p>
+      </item>
+      <item>
+        <bullet>11.</bullet>
+        BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+        FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT
+        WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER
+        PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND,
+        EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+        IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+        PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF
+        THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU
+        ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+      </item>
+      <item>
+        <bullet>12.</bullet>
+        IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+        WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+        REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR
+        DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL
+        DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM
+        (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED
+        INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF
+        THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER
+        OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+      </item>
+    </list>
+    <optional>
+      <p>
+        END OF TERMS AND CONDITIONS
+      </p>
+      <p>
+        How to Apply These Terms to Your New Programs
+      </p>
+      <p>
+        If you develop a new program, and you want it to be
+        of the greatest possible use to the public, the best
+        way to achieve this is to make it free software which
+        everyone can redistribute and change under these terms.
+      </p>
+      <p>
+        To do so, attach the following notices to the program. It is safest
+        to attach them to the start of each source file to most effectively
+        convey the exclusion of warranty; and each file should have at least
+        the "copyright" line and a pointer to where the full notice is found.
+      </p>
+      <p>
+        <optional>&lt;</optional>
+        one line to give the program's name and an idea of what it does.
+        <optional>&gt;</optional>
+        <br></br>
+        Copyright (C)
+        <optional>&lt;</optional>
+        yyyy
+        <optional>&gt;</optional>
+        <optional>&lt;</optional>
+        name of author
+        <optional>&gt;</optional>
+      </p>
+      <p>
+        This program is free software; you can redistribute it and/or
+        modify it under the terms of the GNU General Public License
+        as published by the Free Software Foundation; either version
+        2 of the License, or (at your option) any later version.
+      </p>
+      <p>
+        This program is distributed in the hope that it will be
+        useful, but WITHOUT ANY WARRANTY; without even the implied
+        warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+        PURPOSE. See the GNU General Public License for more details.
+      </p>
+      <p>
+        You should have received a copy of the GNU General Public License
+        along with this program; if not, write to the Free Software Foundation,
+        Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301
+        <optional>
+          ,
+        </optional>
+        USA. Also add information on how to
+        contact you by electronic and paper mail.
+      </p>
+      <p>
+        If the program is interactive, make it output a short
+        notice like this when it starts in an interactive mode:
+      </p>
+      <p>
+        Gnomovision version 69, Copyright (C) year name of author
+        Gnomovision comes with ABSOLUTELY NO WARRANTY; for details
+        type `show w'. This is free software, and you are welcome to
+        redistribute it under certain conditions; type `show c' for details.
+      </p>
+      <p>
+        The hypothetical commands `show w' and `show c' should show the
+        appropriate parts of the General Public License. Of course, the commands
+        you use may be called something other than `show w' and `show c'; they
+        could even be mouse-clicks or menu items--whatever suits your program.
+      </p>
+      <p>
+        You should also get your employer (if you work as a programmer)
+        or your school, if any, to sign a "copyright disclaimer" for
+        the program, if necessary. Here is a sample; alter the names:
+      </p>
+      <p>
+        Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+        `Gnomovision' (which makes passes at compilers) written by James Hacker.
+      </p>
+      <p>
+	<optional>&lt;</optional>signature of Ty Coon<optional>&gt;</optional>,
+	1 April 1989 Ty Coon, President of Vice
+      </p>
+    </optional>
+  </license>
+</SPDXLicenseCollection>

--- a/src/GPL-2.0-or-later.xml
+++ b/src/GPL-2.0-or-later.xml
@@ -11,7 +11,8 @@
       <p>
         This program is free software; you can redistribute it and/or
         modify it under the terms of the GNU General Public License
-        as published by the Free Software Foundation; version 2.
+	as published by the Free Software Foundation; version 2
+	or any later version.
       </p>
       <p>
         This program is distributed in the hope that it will be
@@ -28,8 +29,7 @@
       </p>
     </standardLicenseHeader>
     <notes>
-      This license was released: June 1991 This refers to when this
-      GPL 2.0 only is being used (as opposed to GPLv2 or later).
+      This license was released: June 1991
     </notes>
     <titleText>
       <p>

--- a/src/GPL-2.0.xml
+++ b/src/GPL-2.0.xml
@@ -1,11 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
   <license licenseId="GPL-2.0" isOsiApproved="true"
-  name="GNU General Public License v2.0 only">
+  name="GNU General Public License v2.0 only"
+  isDeprecated="true" deprecatedVersion="3.0">
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html</crossRef>
       <crossRef>http://www.opensource.org/licenses/GPL-2.0</crossRef>
     </crossRefs>
+    <notes>
+      DEPRECATED: Deprecated in lieu of more
+      explicit license identifier of GPL-2.0-only
+    </notes>
     <standardLicenseHeader>
       Copyright (C)<alt name="copyright" match=".+">yyyy name of author</alt>
       <p>

--- a/src/GPL-2.0.xml
+++ b/src/GPL-2.0.xml
@@ -1,310 +1,469 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isOsiApproved="true" licenseId="GPL-2.0"
-            name="GNU General Public License v2.0 only">
-      <crossRefs>
-         <crossRef>http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html</crossRef>
-         <crossRef>http://www.opensource.org/licenses/GPL-2.0</crossRef>
-      </crossRefs>
-      <standardLicenseHeader> Copyright (C)
-    <alt match=".+" name="copyright">yyyy name of author</alt>
-         <p>This program is free software; you can redistribute
-    it and/or modify it under the terms of the GNU General Public License as published by the Free Software
-    Foundation; version 2. </p>
-         <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-    without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
-    Public License for more details. </p>
-         <p>You should have received a copy of the GNU General Public License along with
-    this program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
-    02110-1301<optional>,</optional> USA.</p>
-      </standardLicenseHeader>
-      <notes>This license was released: June 1991 This refers to when this GPL 2.0 only is being used (as opposed to GPLv2
-         or later).</notes>
-      <titleText>
-         <p>GNU GENERAL PUBLIC LICENSE
-        <br/>Version 2, June 1991
+  <license licenseId="GPL-2.0" isOsiApproved="true"
+  name="GNU General Public License v2.0 only">
+    <crossRefs>
+      <crossRef>http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html</crossRef>
+      <crossRef>http://www.opensource.org/licenses/GPL-2.0</crossRef>
+    </crossRefs>
+    <standardLicenseHeader>
+      Copyright (C)<alt name="copyright" match=".+">yyyy name of author</alt>
+      <p>
+        This program is free software; you can redistribute it and/or
+        modify it under the terms of the GNU General Public License
+        as published by the Free Software Foundation; version 2.
       </p>
-      </titleText>
-      <p>Copyright (C) 1989, 1991 Free Software Foundation, Inc.
-        <br/>51 Franklin Street, Fifth Floor, Boston, MA 02110-1301<optional>,</optional> USA
+      <p>
+        This program is distributed in the hope that it will be
+        useful, but WITHOUT ANY WARRANTY; without even the implied
+        warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+        PURPOSE. See the GNU General Public License for more details.
       </p>
-      <p>Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is
-         not allowed.</p>
-      <p>Preamble</p>
-      <p>The licenses for most software are designed to take away your freedom to share and change it. By
-         contrast, the GNU General Public License is intended to guarantee your freedom to share and change
-         free software--to make sure the software is free for all its users. This General Public License
-         applies to most of the Free Software Foundation's software and to any other program whose authors
-         commit to using it. (Some other Free Software Foundation software is covered by the GNU Lesser General
-         Public License instead.) You can apply it to your programs, too.</p>
-      <p>When we speak of free software, we are referring to freedom, not price. Our General Public Licenses are
-         designed to make sure that you have the freedom to distribute copies of free software (and charge for
-         this service if you wish), that you receive source code or can get it if you want it, that you can
-         change the software or use pieces of it in new free programs; and that you know you can do these
-         things.</p>
-      <p>To protect your rights, we need to make restrictions that forbid anyone to deny you these rights or to
-         ask you to surrender the rights. These restrictions translate to certain responsibilities for you if
-         you distribute copies of the software, or if you modify it.</p>
-      <p>For example, if you distribute copies of such a program, whether gratis or for a fee, you must give the
-         recipients all the rights that you have. You must make sure that they, too, receive or can get the
-         source code. And you must show them these terms so they know their rights.</p>
-      <p>We protect your rights with two steps: (1) copyright the software, and (2) offer you this license which
-         gives you legal permission to copy, distribute and/or modify the software.</p>
-      <p>Also, for each author's protection and ours, we want to make certain that everyone understands that
-         there is no warranty for this free software. If the software is modified by someone else and passed
-         on, we want its recipients to know that what they have is not the original, so that any problems
-         introduced by others will not reflect on the original authors' reputations.</p>
-      <p>Finally, any free program is threatened constantly by software patents. We wish to avoid the danger that
-         redistributors of a free program will individually obtain patent licenses, in effect making the
-         program proprietary. To prevent this, we have made it clear that any patent must be licensed for
-         everyone's free use or not licensed at all.</p>
-      <p>The precise terms and conditions for copying, distribution and modification follow.</p>
-      <p>TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION</p>
-      <list>
-        <item>
-            <bullet>0.</bullet>
-          This License applies to any program or other work which contains a notice placed by the copyright
-             holder saying it may be distributed under the terms of this General Public License. The
-             "Program", below, refers to any such program or work, and a "work based on the
-             Program" means either the Program or any derivative work under copyright law: that is to
-             say, a work containing the Program or a portion of it, either verbatim or with modifications
-             and/or translated into another language. (Hereinafter, translation is included without
-             limitation in the term "modification".) Each licensee is addressed as
-             "you".
-          <p>Activities other than copying, distribution and modification are not covered by this License;
-             they are outside its scope. The act of running the Program is not restricted, and the output
-             from the Program is covered only if its contents constitute a work based on the Program
-             (independent of having been made by running the Program). Whether that is true depends on what
-             the Program does.</p>
-        </item>
-        <item>
-            <bullet>1.</bullet>
-          You may copy and distribute verbatim copies of the Program's source code as you receive it,
-             in any medium, provided that you conspicuously and appropriately publish on each copy an
-             appropriate copyright notice and disclaimer of warranty; keep intact all the notices that
-             refer to this License and to the absence of any warranty; and give any other recipients of the
-             Program a copy of this License along with the Program.
-          <p>You may charge a fee for the physical act of transferring a copy, and you may at your option
-             offer warranty protection in exchange for a fee.</p>
-        </item>
-        <item>
-            <bullet>2.</bullet>
-          You may modify your copy or copies of the Program or any portion of it, thus forming a work based
-             on the Program, and copy and distribute such modifications or work under the terms of Section
-             1 above, provided that you also meet all of these conditions:
+      <p>
+        You should have received a copy of the GNU General Public License
+        along with this program; if not, write to the Free Software Foundation,
+        Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301
+        <optional>,</optional>
+        USA.
+      </p>
+    </standardLicenseHeader>
+    <notes>
+      This license was released: June 1991 This refers to when this
+      GPL 2.0 only is being used (as opposed to GPLv2 or later).
+    </notes>
+    <titleText>
+      <p>
+        GNU GENERAL PUBLIC LICENSE<br></br>
+        Version 2, June 1991
+      </p>
+    </titleText>
+    <p>
+      Copyright (C) 1989, 1991 Free Software Foundation, Inc.<br></br>
+      51 Franklin Street, Fifth Floor, Boston, MA 02110-1301
+      <optional>,</optional>
+      USA
+    </p>
+    <p>
+      Everyone is permitted to copy and distribute verbatim copies
+      of this license document, but changing it is not allowed.
+    </p>
+    <p>
+      Preamble
+    </p>
+    <p>
+      The licenses for most software are designed to take away your freedom
+      to share and change it. By contrast, the GNU General Public License is
+      intended to guarantee your freedom to share and change free software--to
+      make sure the software is free for all its users. This General Public
+      License applies to most of the Free Software Foundation's software
+      and to any other program whose authors commit to using it. (Some other
+      Free Software Foundation software is covered by the GNU Lesser General
+      Public License instead.) You can apply it to your programs, too.
+    </p>
+    <p>
+      When we speak of free software, we are referring to freedom, not price.
+      Our General Public Licenses are designed to make sure that you have
+      the freedom to distribute copies of free software (and charge for
+      this service if you wish), that you receive source code or can get
+      it if you want it, that you can change the software or use pieces of
+      it in new free programs; and that you know you can do these things.
+    </p>
+    <p>
+      To protect your rights, we need to make restrictions that forbid
+      anyone to deny you these rights or to ask you to surrender the
+      rights. These restrictions translate to certain responsibilities for
+      you if you distribute copies of the software, or if you modify it.
+    </p>
+    <p>
+      For example, if you distribute copies of such a program, whether gratis
+      or for a fee, you must give the recipients all the rights that you
+      have. You must make sure that they, too, receive or can get the source
+      code. And you must show them these terms so they know their rights.
+    </p>
+    <p>
+      We protect your rights with two steps: (1) copyright the
+      software, and (2) offer you this license which gives you legal
+      permission to copy, distribute and/or modify the software.
+    </p>
+    <p>
+      Also, for each author's protection and ours, we want to make
+      certain that everyone understands that there is no warranty for
+      this free software. If the software is modified by someone else
+      and passed on, we want its recipients to know that what they
+      have is not the original, so that any problems introduced by
+      others will not reflect on the original authors' reputations.
+    </p>
+    <p>
+      Finally, any free program is threatened constantly by software patents.
+      We wish to avoid the danger that redistributors of a free program
+      will individually obtain patent licenses, in effect making the program
+      proprietary. To prevent this, we have made it clear that any patent
+      must be licensed for everyone's free use or not licensed at all.
+    </p>
+    <p>
+      The precise terms and conditions for copying,
+      distribution and modification follow.
+    </p>
+    <p>
+      TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+    </p>
+    <list>
+      <item>
+        <bullet>0.</bullet>
+        This License applies to any program or other work which contains a
+        notice placed by the copyright holder saying it may be distributed
+        under the terms of this General Public License. The "Program", below,
+        refers to any such program or work, and a "work based on the Program"
+        means either the Program or any derivative work under copyright law:
+        that is to say, a work containing the Program or a portion of it,
+        either verbatim or with modifications and/or translated into another
+        language. (Hereinafter, translation is included without limitation
+        in the term "modification".) Each licensee is addressed as "you".
+        <p>
+          Activities other than copying, distribution and modification are
+          not covered by this License; they are outside its scope. The act
+          of running the Program is not restricted, and the output from the
+          Program is covered only if its contents constitute a work based
+          on the Program (independent of having been made by running the
+          Program). Whether that is true depends on what the Program does.
+        </p>
+      </item>
+      <item>
+        <bullet>1.</bullet>
+        You may copy and distribute verbatim copies of the Program's source
+        code as you receive it, in any medium, provided that you conspicuously
+        and appropriately publish on each copy an appropriate copyright notice
+        and disclaimer of warranty; keep intact all the notices that refer to
+        this License and to the absence of any warranty; and give any other
+        recipients of the Program a copy of this License along with the Program.
+        <p>
+          You may charge a fee for the physical act of
+          transferring a copy, and you may at your option
+          offer warranty protection in exchange for a fee.
+        </p>
+      </item>
+      <item>
+        <bullet>2.</bullet>
+        You may modify your copy or copies of the Program or any portion
+        of it, thus forming a work based on the Program, and copy and
+        distribute such modifications or work under the terms of Section
+        1 above, provided that you also meet all of these conditions:
         <list>
-               <item>
-                  <bullet>a)</bullet>
-            You must cause the modified files to carry prominent notices stating that you changed the
-               files and the date of any change.
+          <item>
+            <bullet>a)</bullet>
+            You must cause the modified files to carry prominent notices
+            stating that you changed the files and the date of any change.
           </item>
-               <item>
-                  <bullet>b)</bullet>
-            You must cause any work that you distribute or publish, that in whole or in part contains or
-               is derived from the Program or any part thereof, to be licensed as a whole at no charge to
-               all third parties under the terms of this License.
+          <item>
+            <bullet>b)</bullet>
+            You must cause any work that you distribute or publish,
+            that in whole or in part contains or is derived from the
+            Program or any part thereof, to be licensed as a whole at no
+            charge to all third parties under the terms of this License.
           </item>
-               <item>
-                  <bullet>c)</bullet>
-            If the modified program normally reads commands interactively when run, you must cause it,
-               when started running for such interactive use in the most ordinary way, to print or
-               display an announcement including an appropriate copyright notice and a notice that there
-               is no warranty (or else, saying that you provide a warranty) and that users may
-               redistribute the program under these conditions, and telling the user how to view a copy
-               of this License. (Exception: if the Program itself is interactive but does not normally
-               print such an announcement, your work based on the Program is not required to print an
-               announcement.)
+          <item>
+            <bullet>c)</bullet>
+            If the modified program normally reads commands interactively
+            when run, you must cause it, when started running for such
+            interactive use in the most ordinary way, to print or display
+            an announcement including an appropriate copyright notice and
+            a notice that there is no warranty (or else, saying that you
+            provide a warranty) and that users may redistribute the program
+            under these conditions, and telling the user how to view a copy
+            of this License. (Exception: if the Program itself is interactive
+            but does not normally print such an announcement, your work
+            based on the Program is not required to print an announcement.)
           </item>
-            </list>
-            <p>These requirements apply to the modified work as a whole. If identifiable sections of that
-               work are not derived from the Program, and can be reasonably considered independent and
-               separate works in themselves, then this License, and its terms, do not apply to those
-               sections when you distribute them as separate works. But when you distribute the same
-               sections as part of a whole which is a work based on the Program, the distribution of the
-               whole must be on the terms of this License, whose permissions for other licensees extend
-               to the entire whole, and thus to each and every part regardless of who wrote it.</p>
-            <p>Thus, it is not the intent of this section to claim rights or contest your rights to work
-               written entirely by you; rather, the intent is to exercise the right to control the
-               distribution of derivative or collective works based on the Program.</p>
-            <p>In addition, mere aggregation of another work not based on the Program with the Program (or
-               with a work based on the Program) on a volume of a storage or distribution medium does not
-               bring the other work under the scope of this License.</p>
-        </item>
-        <item>
-            <bullet>3.</bullet>
-          You may copy and distribute the Program (or a work based on it, under Section 2) in object code
-             or executable form under the terms of Sections 1 and 2 above provided that you also do one of
-             the following:
+        </list>
+        <p>
+          These requirements apply to the modified work as a whole. If
+          identifiable sections of that work are not derived from the
+          Program, and can be reasonably considered independent and separate
+          works in themselves, then this License, and its terms, do not
+          apply to those sections when you distribute them as separate
+          works. But when you distribute the same sections as part of a
+          whole which is a work based on the Program, the distribution
+          of the whole must be on the terms of this License, whose
+          permissions for other licensees extend to the entire whole,
+          and thus to each and every part regardless of who wrote it.
+        </p>
+        <p>
+          Thus, it is not the intent of this section to claim rights or
+          contest your rights to work written entirely by you; rather,
+          the intent is to exercise the right to control the distribution
+          of derivative or collective works based on the Program.
+        </p>
+        <p>
+          In addition, mere aggregation of another work not based on
+          the Program with the Program (or with a work based on the
+          Program) on a volume of a storage or distribution medium does
+          not bring the other work under the scope of this License.
+        </p>
+      </item>
+      <item>
+        <bullet>3.</bullet>
+        You may copy and distribute the Program (or a work based on it,
+        under Section 2) in object code or executable form under the terms of
+        Sections 1 and 2 above provided that you also do one of the following:
         <list>
-               <item>
-                  <bullet>a)</bullet>
-            Accompany it with the complete corresponding machine-readable source code, which must be
-               distributed under the terms of Sections 1 and 2 above on a medium customarily used for
-               software interchange; or,
+          <item>
+            <bullet>a)</bullet>
+            Accompany it with the complete corresponding machine-readable source
+            code, which must be distributed under the terms of Sections 1 and
+            2 above on a medium customarily used for software interchange; or,
           </item>
-               <item>
-                  <bullet>b)</bullet>
-            Accompany it with a written offer, valid for at least three years, to give any third party,
-               for a charge no more than your cost of physically performing source distribution, a
-               complete machine-readable copy of the corresponding source code, to be distributed under
-               the terms of Sections 1 and 2 above on a medium customarily used for software interchange;
-               or,
+          <item>
+            <bullet>b)</bullet>
+            Accompany it with a written offer, valid for at least three
+            years, to give any third party, for a charge no more than your
+            cost of physically performing source distribution, a complete
+            machine-readable copy of the corresponding source code, to
+            be distributed under the terms of Sections 1 and 2 above
+            on a medium customarily used for software interchange; or,
           </item>
-               <item>
-                  <bullet>c)</bullet>
-            Accompany it with the information you received as to the offer to distribute corresponding
-               source code. (This alternative is allowed only for noncommercial distribution and only if
-               you received the program in object code or executable form with such an offer, in accord
-               with Subsection b above.)
+          <item>
+            <bullet>c)</bullet>
+            Accompany it with the information you received as to the offer
+            to distribute corresponding source code. (This alternative
+            is allowed only for noncommercial distribution and only if
+            you received the program in object code or executable form
+            with such an offer, in accord with Subsection b above.)
           </item>
-            </list>
-            <p>The source code for a work means the preferred form of the work for making modifications to
-               it. For an executable work, complete source code means all the source code for all modules
-               it contains, plus any associated interface definition files, plus the scripts used to
-               control compilation and installation of the executable. However, as a special exception,
-               the source code distributed need not include anything that is normally distributed (in
-               either source or binary form) with the major components (compiler, kernel, and so on) of
-               the operating system on which the executable runs, unless that component itself
-               accompanies the executable.</p>
-            <p>If distribution of executable or object code is made by offering access to copy from a
-               designated place, then offering equivalent access to copy the source code from the same
-               place counts as distribution of the source code, even though third parties are not
-               compelled to copy the source along with the object code.</p>
-        </item>
-        <item>
-            <bullet>4.</bullet>
-          You may not copy, modify, sublicense, or distribute the Program except as expressly provided
-             under this License. Any attempt otherwise to copy, modify, sublicense or distribute the
-             Program is void, and will automatically terminate your rights under this License. However,
-             parties who have received copies, or rights, from you under this License will not have their
-             licenses terminated so long as such parties remain in full compliance.
-        </item>
-        <item>
-            <bullet>5.</bullet>
-          You are not required to accept this License, since you have not signed it. However, nothing else
-             grants you permission to modify or distribute the Program or its derivative works. These
-             actions are prohibited by law if you do not accept this License. Therefore, by modifying or
-             distributing the Program (or any work based on the Program), you indicate your acceptance of
-             this License to do so, and all its terms and conditions for copying, distributing or modifying
-             the Program or works based on it.
-        </item>
-        <item>
-            <bullet>6.</bullet>
-          Each time you redistribute the Program (or any work based on the Program), the recipient
-             automatically receives a license from the original licensor to copy, distribute or modify the
-             Program subject to these terms and conditions. You may not impose any further restrictions on
-             the recipients' exercise of the rights granted herein. You are not responsible for
-             enforcing compliance by third parties to this License.
-        </item>
-        <item>
-            <bullet>7.</bullet>
-          If, as a consequence of a court judgment or allegation of patent infringement or for any other
-             reason (not limited to patent issues), conditions are imposed on you (whether by court order,
-             agreement or otherwise) that contradict the conditions of this License, they do not excuse you
-             from the conditions of this License. If you cannot distribute so as to satisfy simultaneously
-             your obligations under this License and any other pertinent obligations, then as a consequence
-             you may not distribute the Program at all. For example, if a patent license would not permit
-             royalty-free redistribution of the Program by all those who receive copies directly or
-             indirectly through you, then the only way you could satisfy both it and this License would be
-             to refrain entirely from distribution of the Program.
-          <p>If any portion of this section is held invalid or unenforceable under any particular
-             circumstance, the balance of the section is intended to apply and the section as a whole is
-             intended to apply in other circumstances.</p>
-            <p>It is not the purpose of this section to induce you to infringe any patents or other property
-             right claims or to contest validity of any such claims; this section has the sole purpose of
-             protecting the integrity of the free software distribution system, which is implemented by
-             public license practices. Many people have made generous contributions to the wide range of
-             software distributed through that system in reliance on consistent application of that system;
-             it is up to the author/donor to decide if he or she is willing to distribute software through
-             any other system and a licensee cannot impose that choice.</p>
-            <p>This section is intended to make thoroughly clear what is believed to be a consequence of the
-             rest of this License.</p>
-        </item>
-        <item>
-            <bullet>8.</bullet>
-          If the distribution and/or use of the Program is restricted in certain countries either by
-             patents or by copyrighted interfaces, the original copyright holder who places the Program
-             under this License may add an explicit geographical distribution limitation excluding those
-             countries, so that distribution is permitted only in or among countries not thus excluded. In
-             such case, this License incorporates the limitation as if written in the body of this
-             License.
-        </item>
-        <item>
-            <bullet>9.</bullet>
-          The Free Software Foundation may publish revised and/or new versions of the General Public
-             License from time to time. Such new versions will be similar in spirit to the present version,
-             but may differ in detail to address new problems or concerns.
-          <p>Each version is given a distinguishing version number. If the Program specifies a version number
-             of this License which applies to it and "any later version", you have the option of
-             following the terms and conditions either of that version or of any later version published by
-             the Free Software Foundation. If the Program does not specify a version number of this
-             License, you may choose any version ever published by the Free Software Foundation.</p>
-        </item>
-        <item>
-            <bullet>10.</bullet>
-          If you wish to incorporate parts of the Program into other free programs whose distribution
-             conditions are different, write to the author to ask for permission. For software which is
-             copyrighted by the Free Software Foundation, write to the Free Software Foundation; we
-             sometimes make exceptions for this. Our decision will be guided by the two goals of preserving
-             the free status of all derivatives of our free software and of promoting the sharing and reuse
-             of software generally.
-          <p>NO WARRANTY</p>
-        </item>
-        <item>
-            <bullet>11.</bullet>
-          BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY FOR THE PROGRAM, TO THE
-             EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
-             HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY
-             KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-             MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND
-             PERFORMANCE OF THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE
-             COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
-        </item>
-        <item>
-            <bullet>12.</bullet>
-          IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY COPYRIGHT HOLDER,
-             OR ANY OTHER PARTY WHO MAY MODIFY AND/OR REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE
-             LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES
-             ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
-             DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
-             FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY
-             HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
-        </item>
-      </list>
-      <optional>
-         <p>END OF TERMS AND CONDITIONS</p>
-         <p>How to Apply These Terms to Your New Programs</p>
-         <p>If you develop a new program, and you want it to be of the greatest possible use to the public, the best
-         way to achieve this is to make it free software which everyone can redistribute and change under these
-         terms.</p>
-         <p>To do so, attach the following notices to the program. It is safest to attach them to the start of each
-         source file to most effectively convey the exclusion of warranty; and each file should have at least
-         the "copyright" line and a pointer to where the full notice is found.</p>
-         <p><optional>&lt;</optional>one line to give the program's name and an idea of what it does.<optional>&gt;</optional>
-         <br/>Copyright (C) <optional>&lt;</optional>yyyy<optional>&gt;</optional> <optional>&lt;</optional>name of author<optional>&gt;</optional></p>
-         <p>This program is free software; you can redistribute it and/or modify it under the terms of the GNU
-         General Public License as published by the Free Software Foundation; either version 2 of the License,
-         or (at your option) any later version.</p>
-         <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
-         the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
-         Public License for more details.</p>
-         <p>You should have received a copy of the GNU General Public License along with this program; if not, write
-         to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301<optional>,</optional> USA.
-         Also add information on how to contact you by electronic and paper mail.</p>
-         <p>If the program is interactive, make it output a short notice like this when it starts in an interactive
-         mode:</p>
-         <p>Gnomovision version 69, Copyright (C) year name of author Gnomovision comes with ABSOLUTELY NO WARRANTY;
-         for details type `show w'. This is free software, and you are welcome to redistribute it under
-         certain conditions; type `show c' for details.</p>
-         <p>The hypothetical commands `show w' and `show c' should show the appropriate parts of the
-         General Public License. Of course, the commands you use may be called something other than `show
-         w' and `show c'; they could even be mouse-clicks or menu items--whatever suits your
-         program.</p>
-         <p>You should also get your employer (if you work as a programmer) or your school, if any, to sign a
-         "copyright disclaimer" for the program, if necessary. Here is a sample; alter the names:</p>
-         <p>Yoyodyne, Inc., hereby disclaims all copyright interest in the program `Gnomovision' (which makes
-         passes at compilers) written by James Hacker.</p>
-         <p><optional>&lt;</optional>signature of Ty Coon<optional>&gt;</optional>, 1 April 1989 Ty Coon, President of Vice</p>
-      </optional>
+        </list>
+        <p>
+          The source code for a work means the preferred form of the work
+          for making modifications to it. For an executable work, complete
+          source code means all the source code for all modules it contains,
+          plus any associated interface definition files, plus the scripts
+          used to control compilation and installation of the executable.
+          However, as a special exception, the source code distributed
+          need not include anything that is normally distributed (in either
+          source or binary form) with the major components (compiler,
+          kernel, and so on) of the operating system on which the executable
+          runs, unless that component itself accompanies the executable.
+        </p>
+        <p>
+          If distribution of executable or object code is made by offering
+          access to copy from a designated place, then offering equivalent
+          access to copy the source code from the same place counts as
+          distribution of the source code, even though third parties are
+          not compelled to copy the source along with the object code.
+        </p>
+      </item>
+      <item>
+        <bullet>4.</bullet>
+        You may not copy, modify, sublicense, or distribute the Program
+        except as expressly provided under this License. Any attempt
+        otherwise to copy, modify, sublicense or distribute the Program
+        is void, and will automatically terminate your rights under
+        this License. However, parties who have received copies, or
+        rights, from you under this License will not have their licenses
+        terminated so long as such parties remain in full compliance.
+      </item>
+      <item>
+        <bullet>5.</bullet>
+        You are not required to accept this License, since you have
+        not signed it. However, nothing else grants you permission to
+        modify or distribute the Program or its derivative works. These
+        actions are prohibited by law if you do not accept this License.
+        Therefore, by modifying or distributing the Program (or any
+        work based on the Program), you indicate your acceptance of this
+        License to do so, and all its terms and conditions for copying,
+        distributing or modifying the Program or works based on it.
+      </item>
+      <item>
+        <bullet>6.</bullet>
+        Each time you redistribute the Program (or any work based on the
+        Program), the recipient automatically receives a license from the
+        original licensor to copy, distribute or modify the Program subject to
+        these terms and conditions. You may not impose any further restrictions
+        on the recipients' exercise of the rights granted herein. You are not
+        responsible for enforcing compliance by third parties to this License.
+      </item>
+      <item>
+        <bullet>7.</bullet>
+        If, as a consequence of a court judgment or allegation of patent
+        infringement or for any other reason (not limited to patent issues),
+        conditions are imposed on you (whether by court order, agreement
+        or otherwise) that contradict the conditions of this License,
+        they do not excuse you from the conditions of this License. If you
+        cannot distribute so as to satisfy simultaneously your obligations
+        under this License and any other pertinent obligations, then as a
+        consequence you may not distribute the Program at all. For example,
+        if a patent license would not permit royalty-free redistribution of
+        the Program by all those who receive copies directly or indirectly
+        through you, then the only way you could satisfy both it and this
+        License would be to refrain entirely from distribution of the Program.
+        <p>
+          If any portion of this section is held invalid or
+          unenforceable under any particular circumstance, the
+          balance of the section is intended to apply and the section
+          as a whole is intended to apply in other circumstances.
+        </p>
+        <p>
+          It is not the purpose of this section to induce you to infringe
+          any patents or other property right claims or to contest
+          validity of any such claims; this section has the sole purpose
+          of protecting the integrity of the free software distribution
+          system, which is implemented by public license practices. Many
+          people have made generous contributions to the wide range of
+          software distributed through that system in reliance on consistent
+          application of that system; it is up to the author/donor to
+          decide if he or she is willing to distribute software through
+          any other system and a licensee cannot impose that choice.
+        </p>
+        <p>
+          This section is intended to make thoroughly clear what is
+          believed to be a consequence of the rest of this License.
+        </p>
+      </item>
+      <item>
+        <bullet>8.</bullet>
+        If the distribution and/or use of the Program is restricted in
+        certain countries either by patents or by copyrighted interfaces,
+        the original copyright holder who places the Program under this
+        License may add an explicit geographical distribution limitation
+        excluding those countries, so that distribution is permitted only
+        in or among countries not thus excluded. In such case, this License
+        incorporates the limitation as if written in the body of this License.
+      </item>
+      <item>
+        <bullet>9.</bullet>
+        The Free Software Foundation may publish revised and/or new
+        versions of the General Public License from time to time. Such
+        new versions will be similar in spirit to the present version,
+        but may differ in detail to address new problems or concerns.
+        <p>
+          Each version is given a distinguishing version number. If the
+          Program specifies a version number of this License which applies
+          to it and "any later version", you have the option of following
+          the terms and conditions either of that version or of any later
+          version published by the Free Software Foundation. If the Program
+          does not specify a version number of this License, you may choose
+          any version ever published by the Free Software Foundation.
+        </p>
+      </item>
+      <item>
+        <bullet>10.</bullet>
+        If you wish to incorporate parts of the Program into other free
+        programs whose distribution conditions are different, write to the
+        author to ask for permission. For software which is copyrighted by the
+        Free Software Foundation, write to the Free Software Foundation; we
+        sometimes make exceptions for this. Our decision will be guided by the
+        two goals of preserving the free status of all derivatives of our free
+        software and of promoting the sharing and reuse of software generally.
+        <p>
+          NO WARRANTY
+        </p>
+      </item>
+      <item>
+        <bullet>11.</bullet>
+        BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+        FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT
+        WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER
+        PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND,
+        EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+        IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+        PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF
+        THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU
+        ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+      </item>
+      <item>
+        <bullet>12.</bullet>
+        IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+        WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+        REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR
+        DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL
+        DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM
+        (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED
+        INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF
+        THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER
+        OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+      </item>
+    </list>
+    <optional>
+      <p>
+        END OF TERMS AND CONDITIONS
+      </p>
+      <p>
+        How to Apply These Terms to Your New Programs
+      </p>
+      <p>
+        If you develop a new program, and you want it to be
+        of the greatest possible use to the public, the best
+        way to achieve this is to make it free software which
+        everyone can redistribute and change under these terms.
+      </p>
+      <p>
+        To do so, attach the following notices to the program. It is safest
+        to attach them to the start of each source file to most effectively
+        convey the exclusion of warranty; and each file should have at least
+        the "copyright" line and a pointer to where the full notice is found.
+      </p>
+      <p>
+        <optional>&lt;</optional>
+        one line to give the program's name and an idea of what it does.
+        <optional>&gt;</optional>
+        <br></br>
+        Copyright (C)
+        <optional>&lt;</optional>
+        yyyy
+        <optional>&gt;</optional>
+        <optional>&lt;</optional>
+        name of author
+        <optional>&gt;</optional>
+      </p>
+      <p>
+        This program is free software; you can redistribute it and/or
+        modify it under the terms of the GNU General Public License
+        as published by the Free Software Foundation; either version
+        2 of the License, or (at your option) any later version.
+      </p>
+      <p>
+        This program is distributed in the hope that it will be
+        useful, but WITHOUT ANY WARRANTY; without even the implied
+        warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+        PURPOSE. See the GNU General Public License for more details.
+      </p>
+      <p>
+        You should have received a copy of the GNU General Public License
+        along with this program; if not, write to the Free Software Foundation,
+        Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301
+        <optional>
+          ,
+        </optional>
+        USA. Also add information on how to
+        contact you by electronic and paper mail.
+      </p>
+      <p>
+        If the program is interactive, make it output a short
+        notice like this when it starts in an interactive mode:
+      </p>
+      <p>
+        Gnomovision version 69, Copyright (C) year name of author
+        Gnomovision comes with ABSOLUTELY NO WARRANTY; for details
+        type `show w'. This is free software, and you are welcome to
+        redistribute it under certain conditions; type `show c' for details.
+      </p>
+      <p>
+        The hypothetical commands `show w' and `show c' should show the
+        appropriate parts of the General Public License. Of course, the commands
+        you use may be called something other than `show w' and `show c'; they
+        could even be mouse-clicks or menu items--whatever suits your program.
+      </p>
+      <p>
+        You should also get your employer (if you work as a programmer)
+        or your school, if any, to sign a "copyright disclaimer" for
+        the program, if necessary. Here is a sample; alter the names:
+      </p>
+      <p>
+        Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+        `Gnomovision' (which makes passes at compilers) written by James Hacker.
+      </p>
+      <p>
+	<optional>&lt;</optional>signature of Ty Coon<optional>&gt;</optional>,
+	1 April 1989 Ty Coon, President of Vice
+      </p>
+    </optional>
   </license>
 </SPDXLicenseCollection>

--- a/src/GPL-3.0-only.xml
+++ b/src/GPL-3.0-only.xml
@@ -11,7 +11,7 @@
       match=".+">&lt;year&gt; &lt;name of author&gt;</alt>
       [year] This program is free software: you can redistribute it and/or
       modify it under the terms of the GNU General Public License as
-      published by the Free Software Foundation, version. This program is
+      published by the Free Software Foundation, version 3. This program is
       distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
       without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
       PARTICULAR PURPOSE. See the GNU General Public License for more details.

--- a/src/GPL-3.0-only.xml
+++ b/src/GPL-3.0-only.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-  <license licenseId="GPL-3.0" isOsiApproved="true"
+  <license licenseId="GPL-3.0-only" isOsiApproved="true"
   name="GNU General Public License v3.0 only">
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/gpl-3.0-standalone.html</crossRef>

--- a/src/GPL-3.0-only.xml
+++ b/src/GPL-3.0-only.xml
@@ -1,0 +1,847 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SPDXLicenseCollection xmlns="http://www.spdx.org/license">
+  <license licenseId="GPL-3.0" isOsiApproved="true"
+  name="GNU General Public License v3.0 only">
+    <crossRefs>
+      <crossRef>http://www.gnu.org/licenses/gpl-3.0-standalone.html</crossRef>
+      <crossRef>http://www.opensource.org/licenses/GPL-3.0</crossRef>
+    </crossRefs>
+    <standardLicenseHeader>
+      Copyright (C)<alt name="copyright"
+      match=".+">&lt;year&gt; &lt;name of author&gt;</alt>
+      [year] This program is free software: you can redistribute it and/or
+      modify it under the terms of the GNU General Public License as
+      published by the Free Software Foundation, version. This program is
+      distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+      without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+      PARTICULAR PURPOSE. See the GNU General Public License for more details.
+      You should have received a copy of the GNU General Public License
+      along with this program. If not, see http://www.gnu.org/licenses/
+    </standardLicenseHeader>
+    <notes>
+      This license was released: 29 June 2007 This refers to when
+      this GPL 3.0 only is being used (as opposed to "or later).
+    </notes>
+    <titleText>
+      <p>
+        GNU GENERAL PUBLIC LICENSE<br></br>
+        Version 3, 29 June 2007
+      </p>
+    </titleText>
+    <p>
+      Copyright © 2007 Free Software Foundation, Inc.
+      &lt;http<optional>s</optional>://fsf.org/&gt;
+    </p>
+    <p>
+      Everyone is permitted to copy and distribute verbatim copies
+      of this license document, but changing it is not allowed.
+    </p>
+    <p>
+      Preamble
+    </p>
+    <p>
+      The GNU General Public License is a free, copyleft
+      license for software and other kinds of works.
+    </p>
+    <p>
+      The licenses for most software and other practical works are designed to
+      take away your freedom to share and change the works. By contrast, the GNU
+      General Public License is intended to guarantee your freedom to share and
+      change all versions of a program--to make sure it remains free software
+      for all its users. We, the Free Software Foundation, use the GNU General
+      Public License for most of our software; it applies also to any other work
+      released this way by its authors. You can apply it to your programs, too.
+    </p>
+    <p>
+      When we speak of free software, we are referring to freedom, not
+      price. Our General Public Licenses are designed to make sure that you
+      have the freedom to distribute copies of free software (and charge
+      for them if you wish), that you receive source code or can get it
+      if you want it, that you can change the software or use pieces of
+      it in new free programs, and that you know you can do these things.
+    </p>
+    <p>
+      To protect your rights, we need to prevent others from denying you
+      these rights or asking you to surrender the rights. Therefore, you have
+      certain responsibilities if you distribute copies of the software, or
+      if you modify it: responsibilities to respect the freedom of others.
+    </p>
+    <p>
+      For example, if you distribute copies of such a program, whether gratis
+      or for a fee, you must pass on to the recipients the same freedoms that
+      you received. You must make sure that they, too, receive or can get the
+      source code. And you must show them these terms so they know their rights.
+    </p>
+    <p>
+      Developers that use the GNU GPL protect your rights with two steps:
+      (1) assert copyright on the software, and (2) offer you this License
+      giving you legal permission to copy, distribute and/or modify it.
+    </p>
+    <p>
+      For the developers' and authors' protection, the GPL clearly
+      explains that there is no warranty for this free software. For
+      both users' and authors' sake, the GPL requires that modified
+      versions be marked as changed, so that their problems will
+      not be attributed erroneously to authors of previous versions.
+    </p>
+    <p>
+      Some devices are designed to deny users access to install or run modified
+      versions of the software inside them, although the manufacturer can
+      do so. This is fundamentally incompatible with the aim of protecting
+      users' freedom to change the software. The systematic pattern of
+      such abuse occurs in the area of products for individuals to use,
+      which is precisely where it is most unacceptable. Therefore, we have
+      designed this version of the GPL to prohibit the practice for those
+      products. If such problems arise substantially in other domains,
+      we stand ready to extend this provision to those domains in future
+      versions of the GPL, as needed to protect the freedom of users.
+    </p>
+    <p>
+      Finally, every program is threatened constantly by software patents.
+      States should not allow patents to restrict development and use of
+      software on general-purpose computers, but in those that do, we wish
+      to avoid the special danger that patents applied to a free program
+      could make it effectively proprietary. To prevent this, the GPL
+      assures that patents cannot be used to render the program non-free.
+    </p>
+    <p>
+      The precise terms and conditions for copying,
+      distribution and modification follow.
+    </p>
+    <p>
+      TERMS AND CONDITIONS
+    </p>
+    <list>
+      <item>
+        <bullet>0.</bullet>
+        Definitions.
+        <p>
+          “This License” refers to version 3 of the GNU General Public License.
+        </p>
+        <p>
+          “Copyright” also means copyright-like laws that apply
+          to other kinds of works, such as semiconductor masks.
+        </p>
+        <p>
+          “The Program” refers to any copyrightable work licensed under
+          this License. Each licensee is addressed as “you”. “Licensees”
+          and “recipients” may be individuals or organizations.
+        </p>
+        <p>
+          To “modify” a work means to copy from or adapt all or part of the
+          work in a fashion requiring copyright permission, other than the
+          making of an exact copy. The resulting work is called a “modified
+          version” of the earlier work or a work “based on” the earlier work.
+        </p>
+        <p>
+          A “covered work” means either the unmodified
+          Program or a work based on the Program.
+        </p>
+        <p>
+          To “propagate” a work means to do anything with it that, without
+          permission, would make you directly or secondarily liable for
+          infringement under applicable copyright law, except executing it
+          on a computer or modifying a private copy. Propagation includes
+          copying, distribution (with or without modification), making available
+          to the public, and in some countries other activities as well.
+        </p>
+        <p>
+          To “convey” a work means any kind of propagation
+          that enables other parties to make or receive copies.
+          Mere interaction with a user through a computer
+          network, with no transfer of a copy, is not conveying.
+        </p>
+        <p>
+          An interactive user interface displays “Appropriate Legal Notices”
+          to the extent that it includes a convenient and prominently visible
+          feature that (1) displays an appropriate copyright notice, and (2)
+          tells the user that there is no warranty for the work (except to
+          the extent that warranties are provided), that licensees may convey
+          the work under this License, and how to view a copy of this License.
+          If the interface presents a list of user commands or options,
+          such as a menu, a prominent item in the list meets this criterion.
+        </p>
+      </item>
+      <item>
+        <bullet>1.</bullet>
+        Source Code.<br></br>
+        The “source code” for a work means the preferred
+        form of the work for making modifications to it.
+        “Object code” means any non-source form of a work.
+        <p>
+          A “Standard Interface” means an interface that either is an official
+          standard defined by a recognized standards body, or, in the case
+          of interfaces specified for a particular programming language,
+          one that is widely used among developers working in that language.
+        </p>
+        <p>
+          The “System Libraries” of an executable work include anything, other
+          than the work as a whole, that (a) is included in the normal form
+          of packaging a Major Component, but which is not part of that Major
+          Component, and (b) serves only to enable use of the work with that
+          Major Component, or to implement a Standard Interface for which an
+          implementation is available to the public in source code form. A
+          “Major Component”, in this context, means a major essential component
+          (kernel, window system, and so on) of the specific operating system
+          (if any) on which the executable work runs, or a compiler used to
+          produce the work, or an object code interpreter used to run it.
+        </p>
+        <p>
+          The “Corresponding Source” for a work in object code form means all
+          the source code needed to generate, install, and (for an executable
+          work) run the object code and to modify the work, including scripts
+          to control those activities. However, it does not include the work's
+          System Libraries, or general-purpose tools or generally available
+          free programs which are used unmodified in performing those activities
+          but which are not part of the work. For example, Corresponding
+          Source includes interface definition files associated with source
+          files for the work, and the source code for shared libraries
+          and dynamically linked subprograms that the work is specifically
+          designed to require, such as by intimate data communication or
+          control flow between those subprograms and other parts of the work.
+        </p>
+        <p>
+          The Corresponding Source need not include anything that users can
+          regenerate automatically from other parts of the Corresponding Source.
+        </p>
+        <p>
+          The Corresponding Source for a work
+          in source code form is that same work.
+        </p>
+      </item>
+      <item>
+        <bullet>2.</bullet>
+        Basic Permissions.<br></br>
+        All rights granted under this License are granted for the term of
+        copyright on the Program, and are irrevocable provided the stated
+        conditions are met. This License explicitly affirms your unlimited
+        permission to run the unmodified Program. The output from running a
+        covered work is covered by this License only if the output, given its
+        content, constitutes a covered work. This License acknowledges your
+        rights of fair use or other equivalent, as provided by copyright law.
+        <p>
+          You may make, run and propagate covered works that you do not convey,
+          without conditions so long as your license otherwise remains in force.
+          You may convey covered works to others for the sole purpose of having
+          them make modifications exclusively for you, or provide you with
+          facilities for running those works, provided that you comply with
+          the terms of this License in conveying all material for which you do
+          not control copyright. Those thus making or running the covered works
+          for you must do so exclusively on your behalf, under your direction
+          and control, on terms that prohibit them from making any copies
+          of your copyrighted material outside their relationship with you.
+        </p>
+        <p>
+          Conveying under any other circumstances is permitted
+          solely under the conditions stated below. Sublicensing
+          is not allowed; section 10 makes it unnecessary.
+        </p>
+      </item>
+      <item>
+        <bullet>3.</bullet>
+        Protecting Users' Legal Rights From Anti-Circumvention Law.<br></br>
+        No covered work shall be deemed part of an effective technological
+        measure under any applicable law fulfilling obligations under article
+        11 of the WIPO copyright treaty adopted on 20 December 1996, or
+        similar laws prohibiting or restricting circumvention of such measures.
+        <p>
+          When you convey a covered work, you waive any legal power to
+          forbid circumvention of technological measures to the extent
+          such circumvention is effected by exercising rights under this
+          License with respect to the covered work, and you disclaim any
+          intention to limit operation or modification of the work as a means
+          of enforcing, against the work's users, your or third parties'
+          legal rights to forbid circumvention of technological measures.
+        </p>
+      </item>
+      <item>
+        <bullet>4.</bullet>
+        Conveying Verbatim Copies.<br></br>
+        You may convey verbatim copies of the Program's source code as
+        you receive it, in any medium, provided that you conspicuously
+        and appropriately publish on each copy an appropriate copyright
+        notice; keep intact all notices stating that this License and any
+        non-permissive terms added in accord with section 7 apply to the
+        code; keep intact all notices of the absence of any warranty; and
+        give all recipients a copy of this License along with the Program.
+        <p>
+          You may charge any price or no price for each copy that you
+          convey, and you may offer support or warranty protection for a fee.
+        </p>
+      </item>
+      <item>
+        <bullet>5.</bullet>
+        Conveying Modified Source Versions.<br></br>
+        You may convey a work based on the Program, or the modifications to
+        produce it from the Program, in the form of source code under the terms
+        of section 4, provided that you also meet all of these conditions:
+        <list>
+          <item>
+            <bullet>a)</bullet>
+            The work must carry prominent notices stating
+            that you modified it, and giving a relevant date.
+          </item>
+          <item>
+            <bullet>b)</bullet>
+            The work must carry prominent notices stating that
+            it is released under this License and any conditions
+            added under section 7. This requirement modifies the
+            requirement in section 4 to “keep intact all notices”.
+          </item>
+          <item>
+            <bullet>c)</bullet>
+            You must license the entire work, as a whole, under this License
+            to anyone who comes into possession of a copy. This License
+            will therefore apply, along with any applicable section 7
+            additional terms, to the whole of the work, and all its parts,
+            regardless of how they are packaged. This License gives no
+            permission to license the work in any other way, but it does not
+            invalidate such permission if you have separately received it.
+          </item>
+          <item>
+            <bullet>d)</bullet>
+            If the work has interactive user interfaces, each must
+            display Appropriate Legal Notices; however, if the Program
+            has interactive interfaces that do not display Appropriate
+            Legal Notices, your work need not make them do so.
+          </item>
+        </list>
+        <p>
+          A compilation of a covered work with other separate and independent
+          works, which are not by their nature extensions of the covered
+          work, and which are not combined with it such as to form a larger
+          program, in or on a volume of a storage or distribution medium,
+          is called an “aggregate” if the compilation and its resulting
+          copyright are not used to limit the access or legal rights
+          of the compilation's users beyond what the individual works
+          permit. Inclusion of a covered work in an aggregate does not
+          cause this License to apply to the other parts of the aggregate.
+        </p>
+      </item>
+      <item>
+        <bullet>6.</bullet>
+        Conveying Non-Source Forms.<br></br>
+        You may convey a covered work in object code form
+        under the terms of sections 4 and 5, provided that you
+        also convey the machine-readable Corresponding Source
+        under the terms of this License, in one of these ways:
+        <list>
+          <item>
+            <bullet>a)</bullet>
+            Convey the object code in, or embodied in, a physical
+            product (including a physical distribution medium),
+            accompanied by the Corresponding Source fixed on a durable
+            physical medium customarily used for software interchange.
+          </item>
+          <item>
+            <bullet>b)</bullet>
+            Convey the object code in, or embodied in, a physical product
+            (including a physical distribution medium), accompanied by a
+            written offer, valid for at least three years and valid for
+            as long as you offer spare parts or customer support for that
+            product model, to give anyone who possesses the object code
+            either (1) a copy of the Corresponding Source for all the software
+            in the product that is covered by this License, on a durable
+            physical medium customarily used for software interchange,
+            for a price no more than your reasonable cost of physically
+            performing this conveying of source, or (2) access to copy
+            the Corresponding Source from a network server at no charge.
+          </item>
+          <item>
+            <bullet>c)</bullet>
+            Convey individual copies of the object code with a
+            copy of the written offer to provide the Corresponding
+            Source. This alternative is allowed only occasionally
+            and noncommercially, and only if you received the object
+            code with such an offer, in accord with subsection 6b.
+          </item>
+          <item>
+            <bullet>d)</bullet>
+            Convey the object code by offering access from a designated place
+            (gratis or for a charge), and offer equivalent access to the
+            Corresponding Source in the same way through the same place at
+            no further charge. You need not require recipients to copy the
+            Corresponding Source along with the object code. If the place
+            to copy the object code is a network server, the Corresponding
+            Source may be on a different server (operated by you or a third
+            party) that supports equivalent copying facilities, provided you
+            maintain clear directions next to the object code saying where
+            to find the Corresponding Source. Regardless of what server hosts
+            the Corresponding Source, you remain obligated to ensure that it
+            is available for as long as needed to satisfy these requirements.
+          </item>
+          <item>
+            <bullet>e)</bullet>
+            Convey the object code using peer-to-peer transmission,
+            provided you inform other peers where the object code
+            and Corresponding Source of the work are being offered
+            to the general public at no charge under subsection 6d.
+          </item>
+        </list>
+        <p>
+          A separable portion of the object code, whose source code is
+          excluded from the Corresponding Source as a System Library,
+          need not be included in conveying the object code work.
+        </p>
+        <p>
+          A “User Product” is either (1) a “consumer product”, which means
+          any tangible personal property which is normally used for personal,
+          family, or household purposes, or (2) anything designed or sold
+          for incorporation into a dwelling. In determining whether a product
+          is a consumer product, doubtful cases shall be resolved in favor
+          of coverage. For a particular product received by a particular
+          user, “normally used” refers to a typical or common use of that
+          class of product, regardless of the status of the particular
+          user or of the way in which the particular user actually uses,
+          or expects or is expected to use, the product. A product is a
+          consumer product regardless of whether the product has substantial
+          commercial, industrial or non-consumer uses, unless such uses
+          represent the only significant mode of use of the product.
+        </p>
+        <p>
+          “Installation Information” for a User Product means any methods,
+          procedures, authorization keys, or other information required
+          to install and execute modified versions of a covered work in
+          that User Product from a modified version of its Corresponding
+          Source. The information must suffice to ensure that the continued
+          functioning of the modified object code is in no case prevented
+          or interfered with solely because modification has been made.
+        </p>
+        <p>
+          If you convey an object code work under this section in, or with,
+          or specifically for use in, a User Product, and the conveying
+          occurs as part of a transaction in which the right of possession
+          and use of the User Product is transferred to the recipient in
+          perpetuity or for a fixed term (regardless of how the transaction
+          is characterized), the Corresponding Source conveyed under this
+          section must be accompanied by the Installation Information.
+          But this requirement does not apply if neither you nor any third
+          party retains the ability to install modified object code on the
+          User Product (for example, the work has been installed in ROM).
+        </p>
+        <p>
+          The requirement to provide Installation Information does not
+          include a requirement to continue to provide support service,
+          warranty, or updates for a work that has been modified
+          or installed by the recipient, or for the User Product in
+          which it has been modified or installed. Access to a network
+          may be denied when the modification itself materially and
+          adversely affects the operation of the network or violates
+          the rules and protocols for communication across the network.
+        </p>
+        <p>
+          Corresponding Source conveyed, and Installation Information
+          provided, in accord with this section must be in a format that
+          is publicly documented (and with an implementation available
+          to the public in source code form), and must require no
+          special password or key for unpacking, reading or copying.
+        </p>
+      </item>
+      <item>
+        <bullet>7.</bullet>
+        Additional Terms.<br></br>
+        “Additional permissions” are terms that supplement the terms of this
+        License by making exceptions from one or more of its conditions.
+        Additional permissions that are applicable to the entire Program
+        shall be treated as though they were included in this License, to
+        the extent that they are valid under applicable law. If additional
+        permissions apply only to part of the Program, that part may be used
+        separately under those permissions, but the entire Program remains
+        governed by this License without regard to the additional permissions.
+        <p>
+          When you convey a copy of a covered work, you may at your option
+          remove any additional permissions from that copy, or from any part
+          of it. (Additional permissions may be written to require their own
+          removal in certain cases when you modify the work.) You may place
+          additional permissions on material, added by you to a covered work,
+          for which you have or can give appropriate copyright permission.
+        </p>
+        <p>
+          Notwithstanding any other provision of this License, for material you
+          add to a covered work, you may (if authorized by the copyright holders
+          of that material) supplement the terms of this License with terms:
+        </p>
+        <list>
+          <item>
+            <bullet>a)</bullet>
+            Disclaiming warranty or limiting liability differently
+            from the terms of sections 15 and 16 of this License; or
+          </item>
+          <item>
+            <bullet>b)</bullet>
+            Requiring preservation of specified reasonable legal
+            notices or author attributions in that material or in the
+            Appropriate Legal Notices displayed by works containing it; or
+          </item>
+          <item>
+            <bullet>c)</bullet>
+            Prohibiting misrepresentation of the origin of that material,
+            or requiring that modified versions of such material be marked
+            in reasonable ways as different from the original version; or
+          </item>
+          <item>
+            <bullet>d)</bullet>
+            Limiting the use for publicity purposes of names
+            of licensors or authors of the material; or
+          </item>
+          <item>
+            <bullet>e)</bullet>
+            Declining to grant rights under trademark law for use
+            of some trade names, trademarks, or service marks; or
+          </item>
+          <item>
+            <bullet>f)</bullet>
+            Requiring indemnification of licensors and authors of that
+            material by anyone who conveys the material (or modified
+            versions of it) with contractual assumptions of liability
+            to the recipient, for any liability that these contractual
+            assumptions directly impose on those licensors and authors.
+          </item>
+        </list>
+        <p>
+          All other non-permissive additional terms are considered “further
+          restrictions” within the meaning of section 10. If the Program
+          as you received it, or any part of it, contains a notice stating
+          that it is governed by this License along with a term that is
+          a further restriction, you may remove that term. If a license
+          document contains a further restriction but permits relicensing or
+          conveying under this License, you may add to a covered work material
+          governed by the terms of that license document, provided that the
+          further restriction does not survive such relicensing or conveying.
+        </p>
+        <p>
+          If you add terms to a covered work in accord with this
+          section, you must place, in the relevant source files, a
+          statement of the additional terms that apply to those files,
+          or a notice indicating where to find the applicable terms.
+        </p>
+        <p>
+          Additional terms, permissive or non-permissive, may be
+          stated in the form of a separately written license, or stated
+          as exceptions; the above requirements apply either way.
+        </p>
+      </item>
+      <item>
+        <bullet>8.</bullet>
+        Termination.<br></br>
+        You may not propagate or modify a covered work except as
+        expressly provided under this License. Any attempt otherwise
+        to propagate or modify it is void, and will automatically
+        terminate your rights under this License (including any patent
+        licenses granted under the third paragraph of section 11).
+        <p>
+          However, if you cease all violation of this License, then your
+          license from a particular copyright holder is reinstated (a)
+          provisionally, unless and until the copyright holder explicitly
+          and finally terminates your license, and (b) permanently, if
+          the copyright holder fails to notify you of the violation by
+          some reasonable means prior to 60 days after the cessation.
+        </p>
+        <p>
+          Moreover, your license from a particular copyright holder is
+          reinstated permanently if the copyright holder notifies you
+          of the violation by some reasonable means, this is the first
+          time you have received notice of violation of this License
+          (for any work) from that copyright holder, and you cure the
+          violation prior to 30 days after your receipt of the notice.
+        </p>
+        <p>
+          Termination of your rights under this section does not
+          terminate the licenses of parties who have received copies or
+          rights from you under this License. If your rights have been
+          terminated and not permanently reinstated, you do not qualify
+          to receive new licenses for the same material under section 10.
+        </p>
+      </item>
+      <item>
+        <bullet>9.</bullet>
+        Acceptance Not Required for Having Copies.<br></br>
+        You are not required to accept this License in order to receive or
+        run a copy of the Program. Ancillary propagation of a covered work
+        occurring solely as a consequence of using peer-to-peer transmission
+        to receive a copy likewise does not require acceptance. However,
+        nothing other than this License grants you permission to propagate
+        or modify any covered work. These actions infringe copyright if you
+        do not accept this License. Therefore, by modifying or propagating a
+        covered work, you indicate your acceptance of this License to do so.
+      </item>
+      <item>
+        <bullet>10.</bullet>
+        Automatic Licensing of Downstream Recipients.<br></br>
+        Each time you convey a covered work, the recipient automatically
+        receives a license from the original licensors, to run, modify and
+        propagate that work, subject to this License. You are not responsible
+        for enforcing compliance by third parties with this License.
+        <p>
+          An “entity transaction” is a transaction transferring control of
+          an organization, or substantially all assets of one, or subdividing
+          an organization, or merging organizations. If propagation of a
+          covered work results from an entity transaction, each party to that
+          transaction who receives a copy of the work also receives whatever
+          licenses to the work the party's predecessor in interest had or could
+          give under the previous paragraph, plus a right to possession of the
+          Corresponding Source of the work from the predecessor in interest,
+          if the predecessor has it or can get it with reasonable efforts.
+        </p>
+        <p>
+          You may not impose any further restrictions on the exercise of the
+          rights granted or affirmed under this License. For example, you
+          may not impose a license fee, royalty, or other charge for exercise
+          of rights granted under this License, and you may not initiate
+          litigation (including a cross-claim or counterclaim in a lawsuit)
+          alleging that any patent claim is infringed by making, using, selling,
+          offering for sale, or importing the Program or any portion of it.
+        </p>
+      </item>
+      <item>
+        <bullet>11.</bullet>
+        Patents.<br></br>
+        A “contributor” is a copyright holder who authorizes use under this
+        License of the Program or a work on which the Program is based. The
+        work thus licensed is called the contributor's “contributor version”.
+        <p>
+          A contributor's “essential patent claims” are all patent
+          claims owned or controlled by the contributor, whether already
+          acquired or hereafter acquired, that would be infringed by some
+          manner, permitted by this License, of making, using, or selling
+          its contributor version, but do not include claims that would
+          be infringed only as a consequence of further modification
+          of the contributor version. For purposes of this definition,
+          “control” includes the right to grant patent sublicenses in
+          a manner consistent with the requirements of this License.
+        </p>
+        <p>
+          Each contributor grants you a non-exclusive, worldwide, royalty-free
+          patent license under the contributor's essential patent claims,
+          to make, use, sell, offer for sale, import and otherwise run,
+          modify and propagate the contents of its contributor version.
+        </p>
+        <p>
+          In the following three paragraphs, a “patent license” is any
+          express agreement or commitment, however denominated, not to
+          enforce a patent (such as an express permission to practice
+          a patent or covenant not to sue for patent infringement). To
+          “grant” such a patent license to a party means to make such an
+          agreement or commitment not to enforce a patent against the party.
+        </p>
+        <p>
+          If you convey a covered work, knowingly relying on a patent license,
+          and the Corresponding Source of the work is not available for anyone
+          to copy, free of charge and under the terms of this License, through
+          a publicly available network server or other readily accessible
+          means, then you must either (1) cause the Corresponding Source to
+          be so available, or (2) arrange to deprive yourself of the benefit
+          of the patent license for this particular work, or (3) arrange, in
+          a manner consistent with the requirements of this License, to extend
+          the patent license to downstream recipients. “Knowingly relying”
+          means you have actual knowledge that, but for the patent license, your
+          conveying the covered work in a country, or your recipient's use of
+          the covered work in a country, would infringe one or more identifiable
+          patents in that country that you have reason to believe are valid.
+        </p>
+        <p>
+          If, pursuant to or in connection with a single transaction or
+          arrangement, you convey, or propagate by procuring conveyance
+          of, a covered work, and grant a patent license to some of the
+          parties receiving the covered work authorizing them to use,
+          propagate, modify or convey a specific copy of the covered work,
+          then the patent license you grant is automatically extended
+          to all recipients of the covered work and works based on it.
+        </p>
+        <p>
+          A patent license is “discriminatory” if it does not include within the
+          scope of its coverage, prohibits the exercise of, or is conditioned
+          on the non-exercise of one or more of the rights that are specifically
+          granted under this License. You may not convey a covered work if
+          you are a party to an arrangement with a third party that is in the
+          business of distributing software, under which you make payment to
+          the third party based on the extent of your activity of conveying
+          the work, and under which the third party grants, to any of the
+          parties who would receive the covered work from you, a discriminatory
+          patent license (a) in connection with copies of the covered work
+          conveyed by you (or copies made from those copies), or (b) primarily
+          for and in connection with specific products or compilations that
+          contain the covered work, unless you entered into that arrangement,
+          or that patent license was granted, prior to 28 March 2007.
+        </p>
+        <p>
+          Nothing in this License shall be construed as excluding or
+          limiting any implied license or other defenses to infringement
+          that may otherwise be available to you under applicable patent law.
+        </p>
+      </item>
+      <item>
+        <bullet>12.</bullet>
+        No Surrender of Others' Freedom.<br></br>
+        If conditions are imposed on you (whether by court order, agreement
+        or otherwise) that contradict the conditions of this License,
+        they do not excuse you from the conditions of this License. If
+        you cannot convey a covered work so as to satisfy simultaneously
+        your obligations under this License and any other pertinent
+        obligations, then as a consequence you may not convey it at all.
+        For example, if you agree to terms that obligate you to collect
+        a royalty for further conveying from those to whom you convey the
+        Program, the only way you could satisfy both those terms and this
+        License would be to refrain entirely from conveying the Program.
+      </item>
+      <item>
+        <bullet>13.</bullet>
+        Use with the GNU Affero General Public License.<br></br>
+        Notwithstanding any other provision of this License, you have
+        permission to link or combine any covered work with a work licensed
+        under version 3 of the GNU Affero General Public License into
+        a single combined work, and to convey the resulting work. The
+        terms of this License will continue to apply to the part which
+        is the covered work, but the special requirements of the GNU
+        Affero General Public License, section 13, concerning interaction
+        through a network will apply to the combination as such.
+      </item>
+      <item>
+        <bullet>14.</bullet>
+        Revised Versions of this License.<br></br>
+        The Free Software Foundation may publish revised and/or new
+        versions of the GNU General Public License from time to time. Such
+        new versions will be similar in spirit to the present version,
+        but may differ in detail to address new problems or concerns.
+        <p>
+          Each version is given a distinguishing version number. If the
+          Program specifies that a certain numbered version of the GNU
+          General Public License “or any later version” applies to it,
+          you have the option of following the terms and conditions either
+          of that numbered version or of any later version published by
+          the Free Software Foundation. If the Program does not specify a
+          version number of the GNU General Public License, you may choose
+          any version ever published by the Free Software Foundation.
+        </p>
+        <p>
+          If the Program specifies that a proxy can decide which future
+          versions of the GNU General Public License can be used, that
+          proxy's public statement of acceptance of a version permanently
+          authorizes you to choose that version for the Program.
+        </p>
+        <p>
+          Later license versions may give you additional or
+          different permissions. However, no additional obligations
+          are imposed on any author or copyright holder as a
+          result of your choosing to follow a later version.
+        </p>
+      </item>
+      <item>
+        <bullet>15.</bullet>
+        Disclaimer of Warranty.<br></br>
+        THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+        APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+        HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM “AS IS” WITHOUT
+        WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT
+        LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+        A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE
+        OF THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU
+        ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+      </item>
+      <item>
+        <bullet>16.</bullet>
+        Limitation of Liability.<br></br>
+        IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+        WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR
+        CONVEYS THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+        INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES
+        ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING
+        BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE
+        OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE
+        PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER
+        OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+      </item>
+      <item>
+        <bullet>17.</bullet>
+        Interpretation of Sections 15 and 16.
+      </item>
+    </list>
+    <p>
+      If the disclaimer of warranty and limitation of liability
+      provided above cannot be given local legal effect according to
+      their terms, reviewing courts shall apply local law that most
+      closely approximates an absolute waiver of all civil liability in
+      connection with the Program, unless a warranty or assumption of
+      liability accompanies a copy of the Program in return for a fee.
+    </p>
+    <optional>
+      <p>
+        END OF TERMS AND CONDITIONS
+      </p>
+      <p>
+        How to Apply These Terms to Your New Programs
+      </p>
+      <p>
+        If you develop a new program, and you want it to be
+        of the greatest possible use to the public, the best
+        way to achieve this is to make it free software which
+        everyone can redistribute and change under these terms.
+      </p>
+      <p>
+        To do so, attach the following notices to the program. It is safest
+        to attach them to the start of each source file to most effectively
+        state the exclusion of warranty; and each file should have at least
+        the “copyright” line and a pointer to where the full notice is found.
+      </p>
+      <p>
+        &lt;one line to give the program's name and
+        a brief idea of what it does.&gt;<br></br>
+        Copyright (C) &lt;year&gt; &lt;name of author&gt;
+      </p>
+      <p>
+        This program is free software: you can redistribute it and/or
+        modify it under the terms of the GNU General Public License
+        as published by the Free Software Foundation, either version
+        3 of the License, or (at your option) any later version.
+      </p>
+      <p>
+        This program is distributed in the hope that it will be
+        useful, but WITHOUT ANY WARRANTY; without even the implied
+        warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+        PURPOSE. See the GNU General Public License for more details.
+      </p>
+      <p>
+        You should have received a copy of the GNU General
+	Public License along with this program. If not, see
+	&lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.
+      </p>
+      <p>
+        Also add information on how to contact you by electronic and paper mail.
+      </p>
+      <p>
+        If the program does terminal interaction, make it output a
+        short notice like this when it starts in an interactive mode:
+      </p>
+      <p>
+	&lt;program&gt; Copyright (C) &lt;year&gt;
+	&lt;name of author&gt;<br></br>
+        This program comes with ABSOLUTELY NO
+        WARRANTY; for details type `show w'.<br></br>
+        This is free software, and you are welcome to redistribute
+        it under certain conditions; type `show c' for details.
+      </p>
+      <p>
+        The hypothetical commands `show w' and `show c' should
+        show the appropriate parts of the General Public License.
+        Of course, your program's commands might be different;
+        for a GUI interface, you would use an “about box”.
+      </p>
+      <p>
+        You should also get your employer (if you work as a
+        programmer) or school, if any, to sign a “copyright disclaimer”
+        for the program, if necessary. For more information on
+	this, and how to apply and follow the GNU GPL, see
+	&lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.
+      </p>
+      <p>
+        The GNU General Public License does not permit incorporating
+        your program into proprietary programs. If your program is a
+        subroutine library, you may consider it more useful to permit
+        linking proprietary applications with the library. If this
+        is what you want to do, use the GNU Lesser General Public
+	License instead of this License. But first, please read
+	&lt;http<optional>s</optional>://www.gnu.org/philosophy/why-not-lgpl.html&gt;.
+      </p>
+    </optional>
+  </license>
+</SPDXLicenseCollection>

--- a/src/GPL-3.0-or-later.xml
+++ b/src/GPL-3.0-or-later.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-  <license licenseId="GPL-3.0" isOsiApproved="true"
-  name="GNU General Public License v3.0 only">
+  <license licenseId="GPL-3.0-or-later" isOsiApproved="true"
+  name="GNU General Public License v3.0 or later">
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/gpl-3.0-standalone.html</crossRef>
       <crossRef>http://www.opensource.org/licenses/GPL-3.0</crossRef>

--- a/src/GPL-3.0-or-later.xml
+++ b/src/GPL-3.0-or-later.xml
@@ -1,0 +1,847 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SPDXLicenseCollection xmlns="http://www.spdx.org/license">
+  <license licenseId="GPL-3.0" isOsiApproved="true"
+  name="GNU General Public License v3.0 only">
+    <crossRefs>
+      <crossRef>http://www.gnu.org/licenses/gpl-3.0-standalone.html</crossRef>
+      <crossRef>http://www.opensource.org/licenses/GPL-3.0</crossRef>
+    </crossRefs>
+    <standardLicenseHeader>
+      Copyright (C)<alt name="copyright"
+      match=".+">&lt;year&gt; &lt;name of author&gt;</alt>
+      [year] This program is free software: you can redistribute it and/or
+      modify it under the terms of the GNU General Public License as
+      published by the Free Software Foundation, version. This program is
+      distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+      without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+      PARTICULAR PURPOSE. See the GNU General Public License for more details.
+      You should have received a copy of the GNU General Public License
+      along with this program. If not, see http://www.gnu.org/licenses/
+    </standardLicenseHeader>
+    <notes>
+      This license was released: 29 June 2007 This refers to when
+      this GPL 3.0 only is being used (as opposed to "or later).
+    </notes>
+    <titleText>
+      <p>
+        GNU GENERAL PUBLIC LICENSE<br></br>
+        Version 3, 29 June 2007
+      </p>
+    </titleText>
+    <p>
+      Copyright © 2007 Free Software Foundation, Inc.
+      &lt;http<optional>s</optional>://fsf.org/&gt;
+    </p>
+    <p>
+      Everyone is permitted to copy and distribute verbatim copies
+      of this license document, but changing it is not allowed.
+    </p>
+    <p>
+      Preamble
+    </p>
+    <p>
+      The GNU General Public License is a free, copyleft
+      license for software and other kinds of works.
+    </p>
+    <p>
+      The licenses for most software and other practical works are designed to
+      take away your freedom to share and change the works. By contrast, the GNU
+      General Public License is intended to guarantee your freedom to share and
+      change all versions of a program--to make sure it remains free software
+      for all its users. We, the Free Software Foundation, use the GNU General
+      Public License for most of our software; it applies also to any other work
+      released this way by its authors. You can apply it to your programs, too.
+    </p>
+    <p>
+      When we speak of free software, we are referring to freedom, not
+      price. Our General Public Licenses are designed to make sure that you
+      have the freedom to distribute copies of free software (and charge
+      for them if you wish), that you receive source code or can get it
+      if you want it, that you can change the software or use pieces of
+      it in new free programs, and that you know you can do these things.
+    </p>
+    <p>
+      To protect your rights, we need to prevent others from denying you
+      these rights or asking you to surrender the rights. Therefore, you have
+      certain responsibilities if you distribute copies of the software, or
+      if you modify it: responsibilities to respect the freedom of others.
+    </p>
+    <p>
+      For example, if you distribute copies of such a program, whether gratis
+      or for a fee, you must pass on to the recipients the same freedoms that
+      you received. You must make sure that they, too, receive or can get the
+      source code. And you must show them these terms so they know their rights.
+    </p>
+    <p>
+      Developers that use the GNU GPL protect your rights with two steps:
+      (1) assert copyright on the software, and (2) offer you this License
+      giving you legal permission to copy, distribute and/or modify it.
+    </p>
+    <p>
+      For the developers' and authors' protection, the GPL clearly
+      explains that there is no warranty for this free software. For
+      both users' and authors' sake, the GPL requires that modified
+      versions be marked as changed, so that their problems will
+      not be attributed erroneously to authors of previous versions.
+    </p>
+    <p>
+      Some devices are designed to deny users access to install or run modified
+      versions of the software inside them, although the manufacturer can
+      do so. This is fundamentally incompatible with the aim of protecting
+      users' freedom to change the software. The systematic pattern of
+      such abuse occurs in the area of products for individuals to use,
+      which is precisely where it is most unacceptable. Therefore, we have
+      designed this version of the GPL to prohibit the practice for those
+      products. If such problems arise substantially in other domains,
+      we stand ready to extend this provision to those domains in future
+      versions of the GPL, as needed to protect the freedom of users.
+    </p>
+    <p>
+      Finally, every program is threatened constantly by software patents.
+      States should not allow patents to restrict development and use of
+      software on general-purpose computers, but in those that do, we wish
+      to avoid the special danger that patents applied to a free program
+      could make it effectively proprietary. To prevent this, the GPL
+      assures that patents cannot be used to render the program non-free.
+    </p>
+    <p>
+      The precise terms and conditions for copying,
+      distribution and modification follow.
+    </p>
+    <p>
+      TERMS AND CONDITIONS
+    </p>
+    <list>
+      <item>
+        <bullet>0.</bullet>
+        Definitions.
+        <p>
+          “This License” refers to version 3 of the GNU General Public License.
+        </p>
+        <p>
+          “Copyright” also means copyright-like laws that apply
+          to other kinds of works, such as semiconductor masks.
+        </p>
+        <p>
+          “The Program” refers to any copyrightable work licensed under
+          this License. Each licensee is addressed as “you”. “Licensees”
+          and “recipients” may be individuals or organizations.
+        </p>
+        <p>
+          To “modify” a work means to copy from or adapt all or part of the
+          work in a fashion requiring copyright permission, other than the
+          making of an exact copy. The resulting work is called a “modified
+          version” of the earlier work or a work “based on” the earlier work.
+        </p>
+        <p>
+          A “covered work” means either the unmodified
+          Program or a work based on the Program.
+        </p>
+        <p>
+          To “propagate” a work means to do anything with it that, without
+          permission, would make you directly or secondarily liable for
+          infringement under applicable copyright law, except executing it
+          on a computer or modifying a private copy. Propagation includes
+          copying, distribution (with or without modification), making available
+          to the public, and in some countries other activities as well.
+        </p>
+        <p>
+          To “convey” a work means any kind of propagation
+          that enables other parties to make or receive copies.
+          Mere interaction with a user through a computer
+          network, with no transfer of a copy, is not conveying.
+        </p>
+        <p>
+          An interactive user interface displays “Appropriate Legal Notices”
+          to the extent that it includes a convenient and prominently visible
+          feature that (1) displays an appropriate copyright notice, and (2)
+          tells the user that there is no warranty for the work (except to
+          the extent that warranties are provided), that licensees may convey
+          the work under this License, and how to view a copy of this License.
+          If the interface presents a list of user commands or options,
+          such as a menu, a prominent item in the list meets this criterion.
+        </p>
+      </item>
+      <item>
+        <bullet>1.</bullet>
+        Source Code.<br></br>
+        The “source code” for a work means the preferred
+        form of the work for making modifications to it.
+        “Object code” means any non-source form of a work.
+        <p>
+          A “Standard Interface” means an interface that either is an official
+          standard defined by a recognized standards body, or, in the case
+          of interfaces specified for a particular programming language,
+          one that is widely used among developers working in that language.
+        </p>
+        <p>
+          The “System Libraries” of an executable work include anything, other
+          than the work as a whole, that (a) is included in the normal form
+          of packaging a Major Component, but which is not part of that Major
+          Component, and (b) serves only to enable use of the work with that
+          Major Component, or to implement a Standard Interface for which an
+          implementation is available to the public in source code form. A
+          “Major Component”, in this context, means a major essential component
+          (kernel, window system, and so on) of the specific operating system
+          (if any) on which the executable work runs, or a compiler used to
+          produce the work, or an object code interpreter used to run it.
+        </p>
+        <p>
+          The “Corresponding Source” for a work in object code form means all
+          the source code needed to generate, install, and (for an executable
+          work) run the object code and to modify the work, including scripts
+          to control those activities. However, it does not include the work's
+          System Libraries, or general-purpose tools or generally available
+          free programs which are used unmodified in performing those activities
+          but which are not part of the work. For example, Corresponding
+          Source includes interface definition files associated with source
+          files for the work, and the source code for shared libraries
+          and dynamically linked subprograms that the work is specifically
+          designed to require, such as by intimate data communication or
+          control flow between those subprograms and other parts of the work.
+        </p>
+        <p>
+          The Corresponding Source need not include anything that users can
+          regenerate automatically from other parts of the Corresponding Source.
+        </p>
+        <p>
+          The Corresponding Source for a work
+          in source code form is that same work.
+        </p>
+      </item>
+      <item>
+        <bullet>2.</bullet>
+        Basic Permissions.<br></br>
+        All rights granted under this License are granted for the term of
+        copyright on the Program, and are irrevocable provided the stated
+        conditions are met. This License explicitly affirms your unlimited
+        permission to run the unmodified Program. The output from running a
+        covered work is covered by this License only if the output, given its
+        content, constitutes a covered work. This License acknowledges your
+        rights of fair use or other equivalent, as provided by copyright law.
+        <p>
+          You may make, run and propagate covered works that you do not convey,
+          without conditions so long as your license otherwise remains in force.
+          You may convey covered works to others for the sole purpose of having
+          them make modifications exclusively for you, or provide you with
+          facilities for running those works, provided that you comply with
+          the terms of this License in conveying all material for which you do
+          not control copyright. Those thus making or running the covered works
+          for you must do so exclusively on your behalf, under your direction
+          and control, on terms that prohibit them from making any copies
+          of your copyrighted material outside their relationship with you.
+        </p>
+        <p>
+          Conveying under any other circumstances is permitted
+          solely under the conditions stated below. Sublicensing
+          is not allowed; section 10 makes it unnecessary.
+        </p>
+      </item>
+      <item>
+        <bullet>3.</bullet>
+        Protecting Users' Legal Rights From Anti-Circumvention Law.<br></br>
+        No covered work shall be deemed part of an effective technological
+        measure under any applicable law fulfilling obligations under article
+        11 of the WIPO copyright treaty adopted on 20 December 1996, or
+        similar laws prohibiting or restricting circumvention of such measures.
+        <p>
+          When you convey a covered work, you waive any legal power to
+          forbid circumvention of technological measures to the extent
+          such circumvention is effected by exercising rights under this
+          License with respect to the covered work, and you disclaim any
+          intention to limit operation or modification of the work as a means
+          of enforcing, against the work's users, your or third parties'
+          legal rights to forbid circumvention of technological measures.
+        </p>
+      </item>
+      <item>
+        <bullet>4.</bullet>
+        Conveying Verbatim Copies.<br></br>
+        You may convey verbatim copies of the Program's source code as
+        you receive it, in any medium, provided that you conspicuously
+        and appropriately publish on each copy an appropriate copyright
+        notice; keep intact all notices stating that this License and any
+        non-permissive terms added in accord with section 7 apply to the
+        code; keep intact all notices of the absence of any warranty; and
+        give all recipients a copy of this License along with the Program.
+        <p>
+          You may charge any price or no price for each copy that you
+          convey, and you may offer support or warranty protection for a fee.
+        </p>
+      </item>
+      <item>
+        <bullet>5.</bullet>
+        Conveying Modified Source Versions.<br></br>
+        You may convey a work based on the Program, or the modifications to
+        produce it from the Program, in the form of source code under the terms
+        of section 4, provided that you also meet all of these conditions:
+        <list>
+          <item>
+            <bullet>a)</bullet>
+            The work must carry prominent notices stating
+            that you modified it, and giving a relevant date.
+          </item>
+          <item>
+            <bullet>b)</bullet>
+            The work must carry prominent notices stating that
+            it is released under this License and any conditions
+            added under section 7. This requirement modifies the
+            requirement in section 4 to “keep intact all notices”.
+          </item>
+          <item>
+            <bullet>c)</bullet>
+            You must license the entire work, as a whole, under this License
+            to anyone who comes into possession of a copy. This License
+            will therefore apply, along with any applicable section 7
+            additional terms, to the whole of the work, and all its parts,
+            regardless of how they are packaged. This License gives no
+            permission to license the work in any other way, but it does not
+            invalidate such permission if you have separately received it.
+          </item>
+          <item>
+            <bullet>d)</bullet>
+            If the work has interactive user interfaces, each must
+            display Appropriate Legal Notices; however, if the Program
+            has interactive interfaces that do not display Appropriate
+            Legal Notices, your work need not make them do so.
+          </item>
+        </list>
+        <p>
+          A compilation of a covered work with other separate and independent
+          works, which are not by their nature extensions of the covered
+          work, and which are not combined with it such as to form a larger
+          program, in or on a volume of a storage or distribution medium,
+          is called an “aggregate” if the compilation and its resulting
+          copyright are not used to limit the access or legal rights
+          of the compilation's users beyond what the individual works
+          permit. Inclusion of a covered work in an aggregate does not
+          cause this License to apply to the other parts of the aggregate.
+        </p>
+      </item>
+      <item>
+        <bullet>6.</bullet>
+        Conveying Non-Source Forms.<br></br>
+        You may convey a covered work in object code form
+        under the terms of sections 4 and 5, provided that you
+        also convey the machine-readable Corresponding Source
+        under the terms of this License, in one of these ways:
+        <list>
+          <item>
+            <bullet>a)</bullet>
+            Convey the object code in, or embodied in, a physical
+            product (including a physical distribution medium),
+            accompanied by the Corresponding Source fixed on a durable
+            physical medium customarily used for software interchange.
+          </item>
+          <item>
+            <bullet>b)</bullet>
+            Convey the object code in, or embodied in, a physical product
+            (including a physical distribution medium), accompanied by a
+            written offer, valid for at least three years and valid for
+            as long as you offer spare parts or customer support for that
+            product model, to give anyone who possesses the object code
+            either (1) a copy of the Corresponding Source for all the software
+            in the product that is covered by this License, on a durable
+            physical medium customarily used for software interchange,
+            for a price no more than your reasonable cost of physically
+            performing this conveying of source, or (2) access to copy
+            the Corresponding Source from a network server at no charge.
+          </item>
+          <item>
+            <bullet>c)</bullet>
+            Convey individual copies of the object code with a
+            copy of the written offer to provide the Corresponding
+            Source. This alternative is allowed only occasionally
+            and noncommercially, and only if you received the object
+            code with such an offer, in accord with subsection 6b.
+          </item>
+          <item>
+            <bullet>d)</bullet>
+            Convey the object code by offering access from a designated place
+            (gratis or for a charge), and offer equivalent access to the
+            Corresponding Source in the same way through the same place at
+            no further charge. You need not require recipients to copy the
+            Corresponding Source along with the object code. If the place
+            to copy the object code is a network server, the Corresponding
+            Source may be on a different server (operated by you or a third
+            party) that supports equivalent copying facilities, provided you
+            maintain clear directions next to the object code saying where
+            to find the Corresponding Source. Regardless of what server hosts
+            the Corresponding Source, you remain obligated to ensure that it
+            is available for as long as needed to satisfy these requirements.
+          </item>
+          <item>
+            <bullet>e)</bullet>
+            Convey the object code using peer-to-peer transmission,
+            provided you inform other peers where the object code
+            and Corresponding Source of the work are being offered
+            to the general public at no charge under subsection 6d.
+          </item>
+        </list>
+        <p>
+          A separable portion of the object code, whose source code is
+          excluded from the Corresponding Source as a System Library,
+          need not be included in conveying the object code work.
+        </p>
+        <p>
+          A “User Product” is either (1) a “consumer product”, which means
+          any tangible personal property which is normally used for personal,
+          family, or household purposes, or (2) anything designed or sold
+          for incorporation into a dwelling. In determining whether a product
+          is a consumer product, doubtful cases shall be resolved in favor
+          of coverage. For a particular product received by a particular
+          user, “normally used” refers to a typical or common use of that
+          class of product, regardless of the status of the particular
+          user or of the way in which the particular user actually uses,
+          or expects or is expected to use, the product. A product is a
+          consumer product regardless of whether the product has substantial
+          commercial, industrial or non-consumer uses, unless such uses
+          represent the only significant mode of use of the product.
+        </p>
+        <p>
+          “Installation Information” for a User Product means any methods,
+          procedures, authorization keys, or other information required
+          to install and execute modified versions of a covered work in
+          that User Product from a modified version of its Corresponding
+          Source. The information must suffice to ensure that the continued
+          functioning of the modified object code is in no case prevented
+          or interfered with solely because modification has been made.
+        </p>
+        <p>
+          If you convey an object code work under this section in, or with,
+          or specifically for use in, a User Product, and the conveying
+          occurs as part of a transaction in which the right of possession
+          and use of the User Product is transferred to the recipient in
+          perpetuity or for a fixed term (regardless of how the transaction
+          is characterized), the Corresponding Source conveyed under this
+          section must be accompanied by the Installation Information.
+          But this requirement does not apply if neither you nor any third
+          party retains the ability to install modified object code on the
+          User Product (for example, the work has been installed in ROM).
+        </p>
+        <p>
+          The requirement to provide Installation Information does not
+          include a requirement to continue to provide support service,
+          warranty, or updates for a work that has been modified
+          or installed by the recipient, or for the User Product in
+          which it has been modified or installed. Access to a network
+          may be denied when the modification itself materially and
+          adversely affects the operation of the network or violates
+          the rules and protocols for communication across the network.
+        </p>
+        <p>
+          Corresponding Source conveyed, and Installation Information
+          provided, in accord with this section must be in a format that
+          is publicly documented (and with an implementation available
+          to the public in source code form), and must require no
+          special password or key for unpacking, reading or copying.
+        </p>
+      </item>
+      <item>
+        <bullet>7.</bullet>
+        Additional Terms.<br></br>
+        “Additional permissions” are terms that supplement the terms of this
+        License by making exceptions from one or more of its conditions.
+        Additional permissions that are applicable to the entire Program
+        shall be treated as though they were included in this License, to
+        the extent that they are valid under applicable law. If additional
+        permissions apply only to part of the Program, that part may be used
+        separately under those permissions, but the entire Program remains
+        governed by this License without regard to the additional permissions.
+        <p>
+          When you convey a copy of a covered work, you may at your option
+          remove any additional permissions from that copy, or from any part
+          of it. (Additional permissions may be written to require their own
+          removal in certain cases when you modify the work.) You may place
+          additional permissions on material, added by you to a covered work,
+          for which you have or can give appropriate copyright permission.
+        </p>
+        <p>
+          Notwithstanding any other provision of this License, for material you
+          add to a covered work, you may (if authorized by the copyright holders
+          of that material) supplement the terms of this License with terms:
+        </p>
+        <list>
+          <item>
+            <bullet>a)</bullet>
+            Disclaiming warranty or limiting liability differently
+            from the terms of sections 15 and 16 of this License; or
+          </item>
+          <item>
+            <bullet>b)</bullet>
+            Requiring preservation of specified reasonable legal
+            notices or author attributions in that material or in the
+            Appropriate Legal Notices displayed by works containing it; or
+          </item>
+          <item>
+            <bullet>c)</bullet>
+            Prohibiting misrepresentation of the origin of that material,
+            or requiring that modified versions of such material be marked
+            in reasonable ways as different from the original version; or
+          </item>
+          <item>
+            <bullet>d)</bullet>
+            Limiting the use for publicity purposes of names
+            of licensors or authors of the material; or
+          </item>
+          <item>
+            <bullet>e)</bullet>
+            Declining to grant rights under trademark law for use
+            of some trade names, trademarks, or service marks; or
+          </item>
+          <item>
+            <bullet>f)</bullet>
+            Requiring indemnification of licensors and authors of that
+            material by anyone who conveys the material (or modified
+            versions of it) with contractual assumptions of liability
+            to the recipient, for any liability that these contractual
+            assumptions directly impose on those licensors and authors.
+          </item>
+        </list>
+        <p>
+          All other non-permissive additional terms are considered “further
+          restrictions” within the meaning of section 10. If the Program
+          as you received it, or any part of it, contains a notice stating
+          that it is governed by this License along with a term that is
+          a further restriction, you may remove that term. If a license
+          document contains a further restriction but permits relicensing or
+          conveying under this License, you may add to a covered work material
+          governed by the terms of that license document, provided that the
+          further restriction does not survive such relicensing or conveying.
+        </p>
+        <p>
+          If you add terms to a covered work in accord with this
+          section, you must place, in the relevant source files, a
+          statement of the additional terms that apply to those files,
+          or a notice indicating where to find the applicable terms.
+        </p>
+        <p>
+          Additional terms, permissive or non-permissive, may be
+          stated in the form of a separately written license, or stated
+          as exceptions; the above requirements apply either way.
+        </p>
+      </item>
+      <item>
+        <bullet>8.</bullet>
+        Termination.<br></br>
+        You may not propagate or modify a covered work except as
+        expressly provided under this License. Any attempt otherwise
+        to propagate or modify it is void, and will automatically
+        terminate your rights under this License (including any patent
+        licenses granted under the third paragraph of section 11).
+        <p>
+          However, if you cease all violation of this License, then your
+          license from a particular copyright holder is reinstated (a)
+          provisionally, unless and until the copyright holder explicitly
+          and finally terminates your license, and (b) permanently, if
+          the copyright holder fails to notify you of the violation by
+          some reasonable means prior to 60 days after the cessation.
+        </p>
+        <p>
+          Moreover, your license from a particular copyright holder is
+          reinstated permanently if the copyright holder notifies you
+          of the violation by some reasonable means, this is the first
+          time you have received notice of violation of this License
+          (for any work) from that copyright holder, and you cure the
+          violation prior to 30 days after your receipt of the notice.
+        </p>
+        <p>
+          Termination of your rights under this section does not
+          terminate the licenses of parties who have received copies or
+          rights from you under this License. If your rights have been
+          terminated and not permanently reinstated, you do not qualify
+          to receive new licenses for the same material under section 10.
+        </p>
+      </item>
+      <item>
+        <bullet>9.</bullet>
+        Acceptance Not Required for Having Copies.<br></br>
+        You are not required to accept this License in order to receive or
+        run a copy of the Program. Ancillary propagation of a covered work
+        occurring solely as a consequence of using peer-to-peer transmission
+        to receive a copy likewise does not require acceptance. However,
+        nothing other than this License grants you permission to propagate
+        or modify any covered work. These actions infringe copyright if you
+        do not accept this License. Therefore, by modifying or propagating a
+        covered work, you indicate your acceptance of this License to do so.
+      </item>
+      <item>
+        <bullet>10.</bullet>
+        Automatic Licensing of Downstream Recipients.<br></br>
+        Each time you convey a covered work, the recipient automatically
+        receives a license from the original licensors, to run, modify and
+        propagate that work, subject to this License. You are not responsible
+        for enforcing compliance by third parties with this License.
+        <p>
+          An “entity transaction” is a transaction transferring control of
+          an organization, or substantially all assets of one, or subdividing
+          an organization, or merging organizations. If propagation of a
+          covered work results from an entity transaction, each party to that
+          transaction who receives a copy of the work also receives whatever
+          licenses to the work the party's predecessor in interest had or could
+          give under the previous paragraph, plus a right to possession of the
+          Corresponding Source of the work from the predecessor in interest,
+          if the predecessor has it or can get it with reasonable efforts.
+        </p>
+        <p>
+          You may not impose any further restrictions on the exercise of the
+          rights granted or affirmed under this License. For example, you
+          may not impose a license fee, royalty, or other charge for exercise
+          of rights granted under this License, and you may not initiate
+          litigation (including a cross-claim or counterclaim in a lawsuit)
+          alleging that any patent claim is infringed by making, using, selling,
+          offering for sale, or importing the Program or any portion of it.
+        </p>
+      </item>
+      <item>
+        <bullet>11.</bullet>
+        Patents.<br></br>
+        A “contributor” is a copyright holder who authorizes use under this
+        License of the Program or a work on which the Program is based. The
+        work thus licensed is called the contributor's “contributor version”.
+        <p>
+          A contributor's “essential patent claims” are all patent
+          claims owned or controlled by the contributor, whether already
+          acquired or hereafter acquired, that would be infringed by some
+          manner, permitted by this License, of making, using, or selling
+          its contributor version, but do not include claims that would
+          be infringed only as a consequence of further modification
+          of the contributor version. For purposes of this definition,
+          “control” includes the right to grant patent sublicenses in
+          a manner consistent with the requirements of this License.
+        </p>
+        <p>
+          Each contributor grants you a non-exclusive, worldwide, royalty-free
+          patent license under the contributor's essential patent claims,
+          to make, use, sell, offer for sale, import and otherwise run,
+          modify and propagate the contents of its contributor version.
+        </p>
+        <p>
+          In the following three paragraphs, a “patent license” is any
+          express agreement or commitment, however denominated, not to
+          enforce a patent (such as an express permission to practice
+          a patent or covenant not to sue for patent infringement). To
+          “grant” such a patent license to a party means to make such an
+          agreement or commitment not to enforce a patent against the party.
+        </p>
+        <p>
+          If you convey a covered work, knowingly relying on a patent license,
+          and the Corresponding Source of the work is not available for anyone
+          to copy, free of charge and under the terms of this License, through
+          a publicly available network server or other readily accessible
+          means, then you must either (1) cause the Corresponding Source to
+          be so available, or (2) arrange to deprive yourself of the benefit
+          of the patent license for this particular work, or (3) arrange, in
+          a manner consistent with the requirements of this License, to extend
+          the patent license to downstream recipients. “Knowingly relying”
+          means you have actual knowledge that, but for the patent license, your
+          conveying the covered work in a country, or your recipient's use of
+          the covered work in a country, would infringe one or more identifiable
+          patents in that country that you have reason to believe are valid.
+        </p>
+        <p>
+          If, pursuant to or in connection with a single transaction or
+          arrangement, you convey, or propagate by procuring conveyance
+          of, a covered work, and grant a patent license to some of the
+          parties receiving the covered work authorizing them to use,
+          propagate, modify or convey a specific copy of the covered work,
+          then the patent license you grant is automatically extended
+          to all recipients of the covered work and works based on it.
+        </p>
+        <p>
+          A patent license is “discriminatory” if it does not include within the
+          scope of its coverage, prohibits the exercise of, or is conditioned
+          on the non-exercise of one or more of the rights that are specifically
+          granted under this License. You may not convey a covered work if
+          you are a party to an arrangement with a third party that is in the
+          business of distributing software, under which you make payment to
+          the third party based on the extent of your activity of conveying
+          the work, and under which the third party grants, to any of the
+          parties who would receive the covered work from you, a discriminatory
+          patent license (a) in connection with copies of the covered work
+          conveyed by you (or copies made from those copies), or (b) primarily
+          for and in connection with specific products or compilations that
+          contain the covered work, unless you entered into that arrangement,
+          or that patent license was granted, prior to 28 March 2007.
+        </p>
+        <p>
+          Nothing in this License shall be construed as excluding or
+          limiting any implied license or other defenses to infringement
+          that may otherwise be available to you under applicable patent law.
+        </p>
+      </item>
+      <item>
+        <bullet>12.</bullet>
+        No Surrender of Others' Freedom.<br></br>
+        If conditions are imposed on you (whether by court order, agreement
+        or otherwise) that contradict the conditions of this License,
+        they do not excuse you from the conditions of this License. If
+        you cannot convey a covered work so as to satisfy simultaneously
+        your obligations under this License and any other pertinent
+        obligations, then as a consequence you may not convey it at all.
+        For example, if you agree to terms that obligate you to collect
+        a royalty for further conveying from those to whom you convey the
+        Program, the only way you could satisfy both those terms and this
+        License would be to refrain entirely from conveying the Program.
+      </item>
+      <item>
+        <bullet>13.</bullet>
+        Use with the GNU Affero General Public License.<br></br>
+        Notwithstanding any other provision of this License, you have
+        permission to link or combine any covered work with a work licensed
+        under version 3 of the GNU Affero General Public License into
+        a single combined work, and to convey the resulting work. The
+        terms of this License will continue to apply to the part which
+        is the covered work, but the special requirements of the GNU
+        Affero General Public License, section 13, concerning interaction
+        through a network will apply to the combination as such.
+      </item>
+      <item>
+        <bullet>14.</bullet>
+        Revised Versions of this License.<br></br>
+        The Free Software Foundation may publish revised and/or new
+        versions of the GNU General Public License from time to time. Such
+        new versions will be similar in spirit to the present version,
+        but may differ in detail to address new problems or concerns.
+        <p>
+          Each version is given a distinguishing version number. If the
+          Program specifies that a certain numbered version of the GNU
+          General Public License “or any later version” applies to it,
+          you have the option of following the terms and conditions either
+          of that numbered version or of any later version published by
+          the Free Software Foundation. If the Program does not specify a
+          version number of the GNU General Public License, you may choose
+          any version ever published by the Free Software Foundation.
+        </p>
+        <p>
+          If the Program specifies that a proxy can decide which future
+          versions of the GNU General Public License can be used, that
+          proxy's public statement of acceptance of a version permanently
+          authorizes you to choose that version for the Program.
+        </p>
+        <p>
+          Later license versions may give you additional or
+          different permissions. However, no additional obligations
+          are imposed on any author or copyright holder as a
+          result of your choosing to follow a later version.
+        </p>
+      </item>
+      <item>
+        <bullet>15.</bullet>
+        Disclaimer of Warranty.<br></br>
+        THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+        APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+        HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM “AS IS” WITHOUT
+        WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT
+        LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+        A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE
+        OF THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU
+        ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+      </item>
+      <item>
+        <bullet>16.</bullet>
+        Limitation of Liability.<br></br>
+        IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+        WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR
+        CONVEYS THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+        INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES
+        ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING
+        BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE
+        OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE
+        PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER
+        OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+      </item>
+      <item>
+        <bullet>17.</bullet>
+        Interpretation of Sections 15 and 16.
+      </item>
+    </list>
+    <p>
+      If the disclaimer of warranty and limitation of liability
+      provided above cannot be given local legal effect according to
+      their terms, reviewing courts shall apply local law that most
+      closely approximates an absolute waiver of all civil liability in
+      connection with the Program, unless a warranty or assumption of
+      liability accompanies a copy of the Program in return for a fee.
+    </p>
+    <optional>
+      <p>
+        END OF TERMS AND CONDITIONS
+      </p>
+      <p>
+        How to Apply These Terms to Your New Programs
+      </p>
+      <p>
+        If you develop a new program, and you want it to be
+        of the greatest possible use to the public, the best
+        way to achieve this is to make it free software which
+        everyone can redistribute and change under these terms.
+      </p>
+      <p>
+        To do so, attach the following notices to the program. It is safest
+        to attach them to the start of each source file to most effectively
+        state the exclusion of warranty; and each file should have at least
+        the “copyright” line and a pointer to where the full notice is found.
+      </p>
+      <p>
+        &lt;one line to give the program's name and
+        a brief idea of what it does.&gt;<br></br>
+        Copyright (C) &lt;year&gt; &lt;name of author&gt;
+      </p>
+      <p>
+        This program is free software: you can redistribute it and/or
+        modify it under the terms of the GNU General Public License
+        as published by the Free Software Foundation, either version
+        3 of the License, or (at your option) any later version.
+      </p>
+      <p>
+        This program is distributed in the hope that it will be
+        useful, but WITHOUT ANY WARRANTY; without even the implied
+        warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+        PURPOSE. See the GNU General Public License for more details.
+      </p>
+      <p>
+        You should have received a copy of the GNU General
+	Public License along with this program. If not, see
+	&lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.
+      </p>
+      <p>
+        Also add information on how to contact you by electronic and paper mail.
+      </p>
+      <p>
+        If the program does terminal interaction, make it output a
+        short notice like this when it starts in an interactive mode:
+      </p>
+      <p>
+	&lt;program&gt; Copyright (C) &lt;year&gt;
+	&lt;name of author&gt;<br></br>
+        This program comes with ABSOLUTELY NO
+        WARRANTY; for details type `show w'.<br></br>
+        This is free software, and you are welcome to redistribute
+        it under certain conditions; type `show c' for details.
+      </p>
+      <p>
+        The hypothetical commands `show w' and `show c' should
+        show the appropriate parts of the General Public License.
+        Of course, your program's commands might be different;
+        for a GUI interface, you would use an “about box”.
+      </p>
+      <p>
+        You should also get your employer (if you work as a
+        programmer) or school, if any, to sign a “copyright disclaimer”
+        for the program, if necessary. For more information on
+	this, and how to apply and follow the GNU GPL, see
+	&lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.
+      </p>
+      <p>
+        The GNU General Public License does not permit incorporating
+        your program into proprietary programs. If your program is a
+        subroutine library, you may consider it more useful to permit
+        linking proprietary applications with the library. If this
+        is what you want to do, use the GNU Lesser General Public
+	License instead of this License. But first, please read
+	&lt;http<optional>s</optional>://www.gnu.org/philosophy/why-not-lgpl.html&gt;.
+      </p>
+    </optional>
+  </license>
+</SPDXLicenseCollection>

--- a/src/GPL-3.0-or-later.xml
+++ b/src/GPL-3.0-or-later.xml
@@ -11,16 +11,15 @@
       match=".+">&lt;year&gt; &lt;name of author&gt;</alt>
       [year] This program is free software: you can redistribute it and/or
       modify it under the terms of the GNU General Public License as
-      published by the Free Software Foundation, version. This program is
-      distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-      without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
-      PARTICULAR PURPOSE. See the GNU General Public License for more details.
-      You should have received a copy of the GNU General Public License
-      along with this program. If not, see http://www.gnu.org/licenses/
+      published by the Free Software Foundation, version 3 or any later version.
+      This program is distributed in the hope that it will be useful, but
+      WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+      or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+      for more details.  You should have received a copy of the GNU General
+      Public License along with this program. If not, see http://www.gnu.org/licenses/
     </standardLicenseHeader>
     <notes>
-      This license was released: 29 June 2007 This refers to when
-      this GPL 3.0 only is being used (as opposed to "or later).
+      This license was released: 29 June 2007
     </notes>
     <titleText>
       <p>

--- a/src/GPL-3.0.xml
+++ b/src/GPL-3.0.xml
@@ -1,599 +1,847 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isOsiApproved="true" licenseId="GPL-3.0"
-            name="GNU General Public License v3.0 only">
-      <crossRefs>
-         <crossRef>http://www.gnu.org/licenses/gpl-3.0-standalone.html</crossRef>
-         <crossRef>http://www.opensource.org/licenses/GPL-3.0</crossRef>
-      </crossRefs>
-      <standardLicenseHeader> Copyright (C) 
-    <alt match=".+" name="copyright">&lt;year&gt; &lt;name of author&gt;</alt>[year] This program is free software:
-    you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the
-    Free Software Foundation, version. This program is distributed in the hope that it will be useful, but WITHOUT
-    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-    GNU General Public License for more details. You should have received a copy of the GNU General Public License
-    along with this program. If not, see http://www.gnu.org/licenses/
-  </standardLicenseHeader>
-      <notes>This license was released: 29 June 2007 This refers to when this GPL 3.0 only is being used (as opposed to
-         "or later).</notes>
-      <titleText>
-         <p>GNU GENERAL PUBLIC LICENSE 
-        <br/>Version 3, 29 June 2007 
+  <license licenseId="GPL-3.0" isOsiApproved="true"
+  name="GNU General Public License v3.0 only">
+    <crossRefs>
+      <crossRef>http://www.gnu.org/licenses/gpl-3.0-standalone.html</crossRef>
+      <crossRef>http://www.opensource.org/licenses/GPL-3.0</crossRef>
+    </crossRefs>
+    <standardLicenseHeader>
+      Copyright (C)<alt name="copyright"
+      match=".+">&lt;year&gt; &lt;name of author&gt;</alt>
+      [year] This program is free software: you can redistribute it and/or
+      modify it under the terms of the GNU General Public License as
+      published by the Free Software Foundation, version. This program is
+      distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+      without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+      PARTICULAR PURPOSE. See the GNU General Public License for more details.
+      You should have received a copy of the GNU General Public License
+      along with this program. If not, see http://www.gnu.org/licenses/
+    </standardLicenseHeader>
+    <notes>
+      This license was released: 29 June 2007 This refers to when
+      this GPL 3.0 only is being used (as opposed to "or later).
+    </notes>
+    <titleText>
+      <p>
+        GNU GENERAL PUBLIC LICENSE<br></br>
+        Version 3, 29 June 2007
       </p>
-      </titleText>
-      <p>Copyright © 2007 Free Software Foundation, Inc. &lt;http<optional>s</optional>://fsf.org/&gt;</p>
-      <p>Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is
-         not allowed.</p>
-      <p>Preamble</p>
-      <p>The GNU General Public License is a free, copyleft license for software and other kinds of works.</p>
-      <p>The licenses for most software and other practical works are designed to take away your freedom to share
-         and change the works. By contrast, the GNU General Public License is intended to guarantee your
-         freedom to share and change all versions of a program--to make sure it remains free software for all
-         its users. We, the Free Software Foundation, use the GNU General Public License for most of our
-         software; it applies also to any other work released this way by its authors. You can apply it to your
-         programs, too.</p>
-      <p>When we speak of free software, we are referring to freedom, not price. Our General Public Licenses are
-         designed to make sure that you have the freedom to distribute copies of free software (and charge for
-         them if you wish), that you receive source code or can get it if you want it, that you can change the
-         software or use pieces of it in new free programs, and that you know you can do these things.</p>
-      <p>To protect your rights, we need to prevent others from denying you these rights or asking you to
-         surrender the rights. Therefore, you have certain responsibilities if you distribute copies of the
-         software, or if you modify it: responsibilities to respect the freedom of others.</p>
-      <p>For example, if you distribute copies of such a program, whether gratis or for a fee, you must pass on to
-         the recipients the same freedoms that you received. You must make sure that they, too, receive or can
-         get the source code. And you must show them these terms so they know their rights.</p>
-      <p>Developers that use the GNU GPL protect your rights with two steps: (1) assert copyright on the software,
-         and (2) offer you this License giving you legal permission to copy, distribute and/or modify it.</p>
-      <p>For the developers' and authors' protection, the GPL clearly explains that there is no warranty
-         for this free software. For both users' and authors' sake, the GPL requires that modified
-         versions be marked as changed, so that their problems will not be attributed erroneously to authors of
-         previous versions.</p>
-      <p>Some devices are designed to deny users access to install or run modified versions of the software inside
-         them, although the manufacturer can do so. This is fundamentally incompatible with the aim of
-         protecting users' freedom to change the software. The systematic pattern of such abuse occurs in
-         the area of products for individuals to use, which is precisely where it is most unacceptable.
-         Therefore, we have designed this version of the GPL to prohibit the practice for those products. If
-         such problems arise substantially in other domains, we stand ready to extend this provision to those
-         domains in future versions of the GPL, as needed to protect the freedom of users.</p>
-      <p>Finally, every program is threatened constantly by software patents. States should not allow patents to
-         restrict development and use of software on general-purpose computers, but in those that do, we wish
-         to avoid the special danger that patents applied to a free program could make it effectively
-         proprietary. To prevent this, the GPL assures that patents cannot be used to render the program
-         non-free.</p>
-      <p>The precise terms and conditions for copying, distribution and modification follow.</p>
-      <p>TERMS AND CONDITIONS</p>
-
-      <list>
-        <item>
-            <bullet>0.</bullet>
-          Definitions.
-          <p>“This License” refers to version 3 of the GNU General Public License.</p>
-            <p>“Copyright” also means copyright-like laws that apply to other kinds of works, such
-             as semiconductor masks.</p>
-            <p>“The Program” refers to any copyrightable work licensed under this License. Each
-             licensee is addressed as “you”. “Licensees” and
-             “recipients” may be individuals or organizations.</p>
-            <p>To “modify” a work means to copy from or adapt all or part of the work in a fashion
-             requiring copyright permission, other than the making of an exact copy. The resulting work is
-             called a “modified version” of the earlier work or a work “based
-             on” the earlier work.</p>
-            <p>A “covered work” means either the unmodified Program or a work based on the Program.</p>
-            <p>To “propagate” a work means to do anything with it that, without permission, would
-             make you directly or secondarily liable for infringement under applicable copyright law,
-             except executing it on a computer or modifying a private copy. Propagation includes copying,
-             distribution (with or without modification), making available to the public, and in some
-             countries other activities as well.</p>
-            <p>To “convey” a work means any kind of propagation that enables other parties to make
-             or receive copies. Mere interaction with a user through a computer network, with no transfer
-             of a copy, is not conveying.</p>
-            <p>An interactive user interface displays “Appropriate Legal Notices” to the extent
-             that it includes a convenient and prominently visible feature that (1) displays an appropriate
-             copyright notice, and (2) tells the user that there is no warranty for the work (except to the
-             extent that warranties are provided), that licensees may convey the work under this License,
-             and how to view a copy of this License. If the interface presents a list of user commands or
-             options, such as a menu, a prominent item in the list meets this criterion.</p>
-        </item>
-        <item>
-            <bullet>1.</bullet>
-          Source Code. 
-            <br/>The “source code” for a work means the preferred form of the work for making
-                 modifications to it. “Object code” means any non-source form of a work. 
-          
-          <p>A “Standard Interface” means an interface that either is an official standard
-             defined by a recognized standards body, or, in the case of interfaces specified for a
-             particular programming language, one that is widely used among developers working in that
-             language.</p>
-            <p>The “System Libraries” of an executable work include anything, other than the work
-             as a whole, that (a) is included in the normal form of packaging a Major Component, but which
-             is not part of that Major Component, and (b) serves only to enable use of the work with that
-             Major Component, or to implement a Standard Interface for which an implementation is available
-             to the public in source code form. A “Major Component”, in this context, means a
-             major essential component (kernel, window system, and so on) of the specific operating system
-             (if any) on which the executable work runs, or a compiler used to produce the work, or an
-             object code interpreter used to run it.</p>
-            <p>The “Corresponding Source” for a work in object code form means all the source code
-             needed to generate, install, and (for an executable work) run the object code and to modify
-             the work, including scripts to control those activities. However, it does not include the
-             work's System Libraries, or general-purpose tools or generally available free programs
-             which are used unmodified in performing those activities but which are not part of the work.
-             For example, Corresponding Source includes interface definition files associated with source
-             files for the work, and the source code for shared libraries and dynamically linked
-             subprograms that the work is specifically designed to require, such as by intimate data
-             communication or control flow between those subprograms and other parts of the work.</p>
-            <p>The Corresponding Source need not include anything that users can regenerate automatically from
-             other parts of the Corresponding Source.</p>
-            <p>The Corresponding Source for a work in source code form is that same work.</p>
-        </item>
-        <item>
-            <bullet>2.</bullet>
-          Basic Permissions. 
-            <br/>All rights granted under this License are granted for the term of copyright on the Program,
-                 and are irrevocable provided the stated conditions are met. This License explicitly
-                 affirms your unlimited permission to run the unmodified Program. The output from
-                 running a covered work is covered by this License only if the output, given its
-                 content, constitutes a covered work. This License acknowledges your rights of fair use
-                 or other equivalent, as provided by copyright law. 
-          
-          <p>You may make, run and propagate covered works that you do not convey, without conditions so long
-             as your license otherwise remains in force. You may convey covered works to others for the
-             sole purpose of having them make modifications exclusively for you, or provide you with
-             facilities for running those works, provided that you comply with the terms of this License in
-             conveying all material for which you do not control copyright. Those thus making or running
-             the covered works for you must do so exclusively on your behalf, under your direction and
-             control, on terms that prohibit them from making any copies of your copyrighted material
-             outside their relationship with you.</p>
-            <p>Conveying under any other circumstances is permitted solely under the conditions stated below.
-             Sublicensing is not allowed; section 10 makes it unnecessary.</p>
-        </item>
-        <item>
-            <bullet>3.</bullet>
-          Protecting Users' Legal Rights From Anti-Circumvention Law. 
-            <br/>No covered work shall be deemed part of an effective technological measure under any
-                 applicable law fulfilling obligations under article 11 of the WIPO copyright treaty
-                 adopted on 20 December 1996, or similar laws prohibiting or restricting circumvention
-                 of such measures. 
-          
-          <p>When you convey a covered work, you waive any legal power to forbid circumvention of
-             technological measures to the extent such circumvention is effected by exercising rights under
-             this License with respect to the covered work, and you disclaim any intention to limit
-             operation or modification of the work as a means of enforcing, against the work's users,
-             your or third parties' legal rights to forbid circumvention of technological
-             measures.</p>
-        </item>
-        <item>
-            <bullet>4.</bullet>
-          Conveying Verbatim Copies. 
-            <br/>You may convey verbatim copies of the Program's source code as you receive it, in any
-                 medium, provided that you conspicuously and appropriately publish on each copy an
-                 appropriate copyright notice; keep intact all notices stating that this License and
-                 any non-permissive terms added in accord with section 7 apply to the code; keep intact
-                 all notices of the absence of any warranty; and give all recipients a copy of this
-                 License along with the Program. 
-          
-          <p>You may charge any price or no price for each copy that you convey, and you may offer support or
-             warranty protection for a fee.</p>
-        </item>
-        <item>
-            <bullet>5.</bullet>
-          Conveying Modified Source Versions. 
-            <br/>You may convey a work based on the Program, or the modifications to produce it from the
-                 Program, in the form of source code under the terms of section 4, provided that you
-                 also meet all of these conditions: 
-          
+    </titleText>
+    <p>
+      Copyright © 2007 Free Software Foundation, Inc.
+      &lt;http<optional>s</optional>://fsf.org/&gt;
+    </p>
+    <p>
+      Everyone is permitted to copy and distribute verbatim copies
+      of this license document, but changing it is not allowed.
+    </p>
+    <p>
+      Preamble
+    </p>
+    <p>
+      The GNU General Public License is a free, copyleft
+      license for software and other kinds of works.
+    </p>
+    <p>
+      The licenses for most software and other practical works are designed to
+      take away your freedom to share and change the works. By contrast, the GNU
+      General Public License is intended to guarantee your freedom to share and
+      change all versions of a program--to make sure it remains free software
+      for all its users. We, the Free Software Foundation, use the GNU General
+      Public License for most of our software; it applies also to any other work
+      released this way by its authors. You can apply it to your programs, too.
+    </p>
+    <p>
+      When we speak of free software, we are referring to freedom, not
+      price. Our General Public Licenses are designed to make sure that you
+      have the freedom to distribute copies of free software (and charge
+      for them if you wish), that you receive source code or can get it
+      if you want it, that you can change the software or use pieces of
+      it in new free programs, and that you know you can do these things.
+    </p>
+    <p>
+      To protect your rights, we need to prevent others from denying you
+      these rights or asking you to surrender the rights. Therefore, you have
+      certain responsibilities if you distribute copies of the software, or
+      if you modify it: responsibilities to respect the freedom of others.
+    </p>
+    <p>
+      For example, if you distribute copies of such a program, whether gratis
+      or for a fee, you must pass on to the recipients the same freedoms that
+      you received. You must make sure that they, too, receive or can get the
+      source code. And you must show them these terms so they know their rights.
+    </p>
+    <p>
+      Developers that use the GNU GPL protect your rights with two steps:
+      (1) assert copyright on the software, and (2) offer you this License
+      giving you legal permission to copy, distribute and/or modify it.
+    </p>
+    <p>
+      For the developers' and authors' protection, the GPL clearly
+      explains that there is no warranty for this free software. For
+      both users' and authors' sake, the GPL requires that modified
+      versions be marked as changed, so that their problems will
+      not be attributed erroneously to authors of previous versions.
+    </p>
+    <p>
+      Some devices are designed to deny users access to install or run modified
+      versions of the software inside them, although the manufacturer can
+      do so. This is fundamentally incompatible with the aim of protecting
+      users' freedom to change the software. The systematic pattern of
+      such abuse occurs in the area of products for individuals to use,
+      which is precisely where it is most unacceptable. Therefore, we have
+      designed this version of the GPL to prohibit the practice for those
+      products. If such problems arise substantially in other domains,
+      we stand ready to extend this provision to those domains in future
+      versions of the GPL, as needed to protect the freedom of users.
+    </p>
+    <p>
+      Finally, every program is threatened constantly by software patents.
+      States should not allow patents to restrict development and use of
+      software on general-purpose computers, but in those that do, we wish
+      to avoid the special danger that patents applied to a free program
+      could make it effectively proprietary. To prevent this, the GPL
+      assures that patents cannot be used to render the program non-free.
+    </p>
+    <p>
+      The precise terms and conditions for copying,
+      distribution and modification follow.
+    </p>
+    <p>
+      TERMS AND CONDITIONS
+    </p>
+    <list>
+      <item>
+        <bullet>0.</bullet>
+        Definitions.
+        <p>
+          “This License” refers to version 3 of the GNU General Public License.
+        </p>
+        <p>
+          “Copyright” also means copyright-like laws that apply
+          to other kinds of works, such as semiconductor masks.
+        </p>
+        <p>
+          “The Program” refers to any copyrightable work licensed under
+          this License. Each licensee is addressed as “you”. “Licensees”
+          and “recipients” may be individuals or organizations.
+        </p>
+        <p>
+          To “modify” a work means to copy from or adapt all or part of the
+          work in a fashion requiring copyright permission, other than the
+          making of an exact copy. The resulting work is called a “modified
+          version” of the earlier work or a work “based on” the earlier work.
+        </p>
+        <p>
+          A “covered work” means either the unmodified
+          Program or a work based on the Program.
+        </p>
+        <p>
+          To “propagate” a work means to do anything with it that, without
+          permission, would make you directly or secondarily liable for
+          infringement under applicable copyright law, except executing it
+          on a computer or modifying a private copy. Propagation includes
+          copying, distribution (with or without modification), making available
+          to the public, and in some countries other activities as well.
+        </p>
+        <p>
+          To “convey” a work means any kind of propagation
+          that enables other parties to make or receive copies.
+          Mere interaction with a user through a computer
+          network, with no transfer of a copy, is not conveying.
+        </p>
+        <p>
+          An interactive user interface displays “Appropriate Legal Notices”
+          to the extent that it includes a convenient and prominently visible
+          feature that (1) displays an appropriate copyright notice, and (2)
+          tells the user that there is no warranty for the work (except to
+          the extent that warranties are provided), that licensees may convey
+          the work under this License, and how to view a copy of this License.
+          If the interface presents a list of user commands or options,
+          such as a menu, a prominent item in the list meets this criterion.
+        </p>
+      </item>
+      <item>
+        <bullet>1.</bullet>
+        Source Code.<br></br>
+        The “source code” for a work means the preferred
+        form of the work for making modifications to it.
+        “Object code” means any non-source form of a work.
+        <p>
+          A “Standard Interface” means an interface that either is an official
+          standard defined by a recognized standards body, or, in the case
+          of interfaces specified for a particular programming language,
+          one that is widely used among developers working in that language.
+        </p>
+        <p>
+          The “System Libraries” of an executable work include anything, other
+          than the work as a whole, that (a) is included in the normal form
+          of packaging a Major Component, but which is not part of that Major
+          Component, and (b) serves only to enable use of the work with that
+          Major Component, or to implement a Standard Interface for which an
+          implementation is available to the public in source code form. A
+          “Major Component”, in this context, means a major essential component
+          (kernel, window system, and so on) of the specific operating system
+          (if any) on which the executable work runs, or a compiler used to
+          produce the work, or an object code interpreter used to run it.
+        </p>
+        <p>
+          The “Corresponding Source” for a work in object code form means all
+          the source code needed to generate, install, and (for an executable
+          work) run the object code and to modify the work, including scripts
+          to control those activities. However, it does not include the work's
+          System Libraries, or general-purpose tools or generally available
+          free programs which are used unmodified in performing those activities
+          but which are not part of the work. For example, Corresponding
+          Source includes interface definition files associated with source
+          files for the work, and the source code for shared libraries
+          and dynamically linked subprograms that the work is specifically
+          designed to require, such as by intimate data communication or
+          control flow between those subprograms and other parts of the work.
+        </p>
+        <p>
+          The Corresponding Source need not include anything that users can
+          regenerate automatically from other parts of the Corresponding Source.
+        </p>
+        <p>
+          The Corresponding Source for a work
+          in source code form is that same work.
+        </p>
+      </item>
+      <item>
+        <bullet>2.</bullet>
+        Basic Permissions.<br></br>
+        All rights granted under this License are granted for the term of
+        copyright on the Program, and are irrevocable provided the stated
+        conditions are met. This License explicitly affirms your unlimited
+        permission to run the unmodified Program. The output from running a
+        covered work is covered by this License only if the output, given its
+        content, constitutes a covered work. This License acknowledges your
+        rights of fair use or other equivalent, as provided by copyright law.
+        <p>
+          You may make, run and propagate covered works that you do not convey,
+          without conditions so long as your license otherwise remains in force.
+          You may convey covered works to others for the sole purpose of having
+          them make modifications exclusively for you, or provide you with
+          facilities for running those works, provided that you comply with
+          the terms of this License in conveying all material for which you do
+          not control copyright. Those thus making or running the covered works
+          for you must do so exclusively on your behalf, under your direction
+          and control, on terms that prohibit them from making any copies
+          of your copyrighted material outside their relationship with you.
+        </p>
+        <p>
+          Conveying under any other circumstances is permitted
+          solely under the conditions stated below. Sublicensing
+          is not allowed; section 10 makes it unnecessary.
+        </p>
+      </item>
+      <item>
+        <bullet>3.</bullet>
+        Protecting Users' Legal Rights From Anti-Circumvention Law.<br></br>
+        No covered work shall be deemed part of an effective technological
+        measure under any applicable law fulfilling obligations under article
+        11 of the WIPO copyright treaty adopted on 20 December 1996, or
+        similar laws prohibiting or restricting circumvention of such measures.
+        <p>
+          When you convey a covered work, you waive any legal power to
+          forbid circumvention of technological measures to the extent
+          such circumvention is effected by exercising rights under this
+          License with respect to the covered work, and you disclaim any
+          intention to limit operation or modification of the work as a means
+          of enforcing, against the work's users, your or third parties'
+          legal rights to forbid circumvention of technological measures.
+        </p>
+      </item>
+      <item>
+        <bullet>4.</bullet>
+        Conveying Verbatim Copies.<br></br>
+        You may convey verbatim copies of the Program's source code as
+        you receive it, in any medium, provided that you conspicuously
+        and appropriately publish on each copy an appropriate copyright
+        notice; keep intact all notices stating that this License and any
+        non-permissive terms added in accord with section 7 apply to the
+        code; keep intact all notices of the absence of any warranty; and
+        give all recipients a copy of this License along with the Program.
+        <p>
+          You may charge any price or no price for each copy that you
+          convey, and you may offer support or warranty protection for a fee.
+        </p>
+      </item>
+      <item>
+        <bullet>5.</bullet>
+        Conveying Modified Source Versions.<br></br>
+        You may convey a work based on the Program, or the modifications to
+        produce it from the Program, in the form of source code under the terms
+        of section 4, provided that you also meet all of these conditions:
         <list>
-               <item>
-                  <bullet>a)</bullet>
-            The work must carry prominent notices stating that you modified it, and giving a relevant date.
+          <item>
+            <bullet>a)</bullet>
+            The work must carry prominent notices stating
+            that you modified it, and giving a relevant date.
           </item>
-               <item>
-                  <bullet>b)</bullet>
-            The work must carry prominent notices stating that it is released under this License and any
-               conditions added under section 7. This requirement modifies the requirement in section 4
-               to “keep intact all notices”.
+          <item>
+            <bullet>b)</bullet>
+            The work must carry prominent notices stating that
+            it is released under this License and any conditions
+            added under section 7. This requirement modifies the
+            requirement in section 4 to “keep intact all notices”.
           </item>
-               <item>
-                  <bullet>c)</bullet>
-            You must license the entire work, as a whole, under this License to anyone who comes into
-               possession of a copy. This License will therefore apply, along with any applicable section
-               7 additional terms, to the whole of the work, and all its parts, regardless of how they
-               are packaged. This License gives no permission to license the work in any other way, but
-               it does not invalidate such permission if you have separately received it.
+          <item>
+            <bullet>c)</bullet>
+            You must license the entire work, as a whole, under this License
+            to anyone who comes into possession of a copy. This License
+            will therefore apply, along with any applicable section 7
+            additional terms, to the whole of the work, and all its parts,
+            regardless of how they are packaged. This License gives no
+            permission to license the work in any other way, but it does not
+            invalidate such permission if you have separately received it.
           </item>
-               <item>
-                  <bullet>d)</bullet>
-            If the work has interactive user interfaces, each must display Appropriate Legal Notices;
-               however, if the Program has interactive interfaces that do not display Appropriate Legal
-               Notices, your work need not make them do so.
+          <item>
+            <bullet>d)</bullet>
+            If the work has interactive user interfaces, each must
+            display Appropriate Legal Notices; however, if the Program
+            has interactive interfaces that do not display Appropriate
+            Legal Notices, your work need not make them do so.
           </item>
-            </list>
-            <p>A compilation of a covered work with other separate and independent works, which are not by
-               their nature extensions of the covered work, and which are not combined with it such as to
-               form a larger program, in or on a volume of a storage or distribution medium, is called an
-               “aggregate” if the compilation and its resulting copyright are not used to
-               limit the access or legal rights of the compilation's users beyond what the
-               individual works permit. Inclusion of a covered work in an aggregate does not cause this
-               License to apply to the other parts of the aggregate.</p>
-        </item>
-        <item>
-            <bullet>6.</bullet>
-          Conveying Non-Source Forms. 
-            <br/>You may convey a covered work in object code form under the terms of sections 4 and 5,
-                 provided that you also convey the machine-readable Corresponding Source under the
-                 terms of this License, in one of these ways: 
-          
+        </list>
+        <p>
+          A compilation of a covered work with other separate and independent
+          works, which are not by their nature extensions of the covered
+          work, and which are not combined with it such as to form a larger
+          program, in or on a volume of a storage or distribution medium,
+          is called an “aggregate” if the compilation and its resulting
+          copyright are not used to limit the access or legal rights
+          of the compilation's users beyond what the individual works
+          permit. Inclusion of a covered work in an aggregate does not
+          cause this License to apply to the other parts of the aggregate.
+        </p>
+      </item>
+      <item>
+        <bullet>6.</bullet>
+        Conveying Non-Source Forms.<br></br>
+        You may convey a covered work in object code form
+        under the terms of sections 4 and 5, provided that you
+        also convey the machine-readable Corresponding Source
+        under the terms of this License, in one of these ways:
         <list>
-               <item>
-                  <bullet>a)</bullet>
-            Convey the object code in, or embodied in, a physical product (including a physical
-               distribution medium), accompanied by the Corresponding Source fixed on a durable physical
-               medium customarily used for software interchange.
+          <item>
+            <bullet>a)</bullet>
+            Convey the object code in, or embodied in, a physical
+            product (including a physical distribution medium),
+            accompanied by the Corresponding Source fixed on a durable
+            physical medium customarily used for software interchange.
           </item>
-               <item>
-                  <bullet>b)</bullet>
-            Convey the object code in, or embodied in, a physical product (including a physical
-               distribution medium), accompanied by a written offer, valid for at least three years and
-               valid for as long as you offer spare parts or customer support for that product model, to
-               give anyone who possesses the object code either (1) a copy of the Corresponding Source
-               for all the software in the product that is covered by this License, on a durable physical
-               medium customarily used for software interchange, for a price no more than your reasonable
-               cost of physically performing this conveying of source, or (2) access to copy the
-               Corresponding Source from a network server at no charge.
+          <item>
+            <bullet>b)</bullet>
+            Convey the object code in, or embodied in, a physical product
+            (including a physical distribution medium), accompanied by a
+            written offer, valid for at least three years and valid for
+            as long as you offer spare parts or customer support for that
+            product model, to give anyone who possesses the object code
+            either (1) a copy of the Corresponding Source for all the software
+            in the product that is covered by this License, on a durable
+            physical medium customarily used for software interchange,
+            for a price no more than your reasonable cost of physically
+            performing this conveying of source, or (2) access to copy
+            the Corresponding Source from a network server at no charge.
           </item>
-               <item>
-                  <bullet>c)</bullet>
-            Convey individual copies of the object code with a copy of the written offer to provide the
-               Corresponding Source. This alternative is allowed only occasionally and noncommercially,
-               and only if you received the object code with such an offer, in accord with subsection
-               6b.
+          <item>
+            <bullet>c)</bullet>
+            Convey individual copies of the object code with a
+            copy of the written offer to provide the Corresponding
+            Source. This alternative is allowed only occasionally
+            and noncommercially, and only if you received the object
+            code with such an offer, in accord with subsection 6b.
           </item>
-               <item>
-                  <bullet>d)</bullet>
-            Convey the object code by offering access from a designated place (gratis or for a charge),
-               and offer equivalent access to the Corresponding Source in the same way through the same
-               place at no further charge. You need not require recipients to copy the Corresponding
-               Source along with the object code. If the place to copy the object code is a network
-               server, the Corresponding Source may be on a different server (operated by you or a third
-               party) that supports equivalent copying facilities, provided you maintain clear directions
-               next to the object code saying where to find the Corresponding Source. Regardless of what
-               server hosts the Corresponding Source, you remain obligated to ensure that it is available
-               for as long as needed to satisfy these requirements.
+          <item>
+            <bullet>d)</bullet>
+            Convey the object code by offering access from a designated place
+            (gratis or for a charge), and offer equivalent access to the
+            Corresponding Source in the same way through the same place at
+            no further charge. You need not require recipients to copy the
+            Corresponding Source along with the object code. If the place
+            to copy the object code is a network server, the Corresponding
+            Source may be on a different server (operated by you or a third
+            party) that supports equivalent copying facilities, provided you
+            maintain clear directions next to the object code saying where
+            to find the Corresponding Source. Regardless of what server hosts
+            the Corresponding Source, you remain obligated to ensure that it
+            is available for as long as needed to satisfy these requirements.
           </item>
-               <item>
-                  <bullet>e)</bullet>
-            Convey the object code using peer-to-peer transmission, provided you inform other peers where
-               the object code and Corresponding Source of the work are being offered to the general
-               public at no charge under subsection 6d.
+          <item>
+            <bullet>e)</bullet>
+            Convey the object code using peer-to-peer transmission,
+            provided you inform other peers where the object code
+            and Corresponding Source of the work are being offered
+            to the general public at no charge under subsection 6d.
           </item>
-            </list>  
-            <p>A separable portion of the object code, whose source code is excluded from the Corresponding
-               Source as a System Library, need not be included in conveying the object code work.</p>
-            <p>A “User Product” is either (1) a “consumer product”, which means
-               any tangible personal property which is normally used for personal, family, or household
-               purposes, or (2) anything designed or sold for incorporation into a dwelling. In
-               determining whether a product is a consumer product, doubtful cases shall be resolved in
-               favor of coverage. For a particular product received by a particular user,
-               “normally used” refers to a typical or common use of that class of product,
-               regardless of the status of the particular user or of the way in which the particular user
-               actually uses, or expects or is expected to use, the product. A product is a consumer
-               product regardless of whether the product has substantial commercial, industrial or
-               non-consumer uses, unless such uses represent the only significant mode of use of the
-               product.</p>
-            <p>“Installation Information” for a User Product means any methods, procedures,
-               authorization keys, or other information required to install and execute modified versions
-               of a covered work in that User Product from a modified version of its Corresponding
-               Source. The information must suffice to ensure that the continued functioning of the
-               modified object code is in no case prevented or interfered with solely because
-               modification has been made.</p>
-            <p>If you convey an object code work under this section in, or with, or specifically for use in,
-               a User Product, and the conveying occurs as part of a transaction in which the right of
-               possession and use of the User Product is transferred to the recipient in perpetuity or
-               for a fixed term (regardless of how the transaction is characterized), the Corresponding
-               Source conveyed under this section must be accompanied by the Installation Information.
-               But this requirement does not apply if neither you nor any third party retains the ability
-               to install modified object code on the User Product (for example, the work has been
-               installed in ROM).</p>
-            <p>The requirement to provide Installation Information does not include a requirement to
-               continue to provide support service, warranty, or updates for a work that has been
-               modified or installed by the recipient, or for the User Product in which it has been
-               modified or installed. Access to a network may be denied when the modification itself
-               materially and adversely affects the operation of the network or violates the rules and
-               protocols for communication across the network.</p>
-            <p>Corresponding Source conveyed, and Installation Information provided, in accord with this
-               section must be in a format that is publicly documented (and with an implementation
-               available to the public in source code form), and must require no special password or key
-               for unpacking, reading or copying.</p>
-        </item>
-        <item>
-            <bullet>7.</bullet>
-          Additional Terms. 
-            <br/>“Additional permissions” are terms that supplement the terms of this License
-                 by making exceptions from one or more of its conditions. Additional permissions that
-                 are applicable to the entire Program shall be treated as though they were included in
-                 this License, to the extent that they are valid under applicable law. If additional
-                 permissions apply only to part of the Program, that part may be used separately under
-                 those permissions, but the entire Program remains governed by this License without
-                 regard to the additional permissions. 
-          
-          <p>When you convey a copy of a covered work, you may at your option remove any additional
-             permissions from that copy, or from any part of it. (Additional permissions may be written to
-             require their own removal in certain cases when you modify the work.) You may place additional
-             permissions on material, added by you to a covered work, for which you have or can give
-             appropriate copyright permission.</p>
-            <p>Notwithstanding any other provision of this License, for material you add to a covered work, you
-             may (if authorized by the copyright holders of that material) supplement the terms of this
-             License with terms:</p>
-            <list>
-               <item>
-                  <bullet>a)</bullet>
-            Disclaiming warranty or limiting liability differently from the terms of sections 15 and 16
-               of this License; or
+        </list>
+        <p>
+          A separable portion of the object code, whose source code is
+          excluded from the Corresponding Source as a System Library,
+          need not be included in conveying the object code work.
+        </p>
+        <p>
+          A “User Product” is either (1) a “consumer product”, which means
+          any tangible personal property which is normally used for personal,
+          family, or household purposes, or (2) anything designed or sold
+          for incorporation into a dwelling. In determining whether a product
+          is a consumer product, doubtful cases shall be resolved in favor
+          of coverage. For a particular product received by a particular
+          user, “normally used” refers to a typical or common use of that
+          class of product, regardless of the status of the particular
+          user or of the way in which the particular user actually uses,
+          or expects or is expected to use, the product. A product is a
+          consumer product regardless of whether the product has substantial
+          commercial, industrial or non-consumer uses, unless such uses
+          represent the only significant mode of use of the product.
+        </p>
+        <p>
+          “Installation Information” for a User Product means any methods,
+          procedures, authorization keys, or other information required
+          to install and execute modified versions of a covered work in
+          that User Product from a modified version of its Corresponding
+          Source. The information must suffice to ensure that the continued
+          functioning of the modified object code is in no case prevented
+          or interfered with solely because modification has been made.
+        </p>
+        <p>
+          If you convey an object code work under this section in, or with,
+          or specifically for use in, a User Product, and the conveying
+          occurs as part of a transaction in which the right of possession
+          and use of the User Product is transferred to the recipient in
+          perpetuity or for a fixed term (regardless of how the transaction
+          is characterized), the Corresponding Source conveyed under this
+          section must be accompanied by the Installation Information.
+          But this requirement does not apply if neither you nor any third
+          party retains the ability to install modified object code on the
+          User Product (for example, the work has been installed in ROM).
+        </p>
+        <p>
+          The requirement to provide Installation Information does not
+          include a requirement to continue to provide support service,
+          warranty, or updates for a work that has been modified
+          or installed by the recipient, or for the User Product in
+          which it has been modified or installed. Access to a network
+          may be denied when the modification itself materially and
+          adversely affects the operation of the network or violates
+          the rules and protocols for communication across the network.
+        </p>
+        <p>
+          Corresponding Source conveyed, and Installation Information
+          provided, in accord with this section must be in a format that
+          is publicly documented (and with an implementation available
+          to the public in source code form), and must require no
+          special password or key for unpacking, reading or copying.
+        </p>
+      </item>
+      <item>
+        <bullet>7.</bullet>
+        Additional Terms.<br></br>
+        “Additional permissions” are terms that supplement the terms of this
+        License by making exceptions from one or more of its conditions.
+        Additional permissions that are applicable to the entire Program
+        shall be treated as though they were included in this License, to
+        the extent that they are valid under applicable law. If additional
+        permissions apply only to part of the Program, that part may be used
+        separately under those permissions, but the entire Program remains
+        governed by this License without regard to the additional permissions.
+        <p>
+          When you convey a copy of a covered work, you may at your option
+          remove any additional permissions from that copy, or from any part
+          of it. (Additional permissions may be written to require their own
+          removal in certain cases when you modify the work.) You may place
+          additional permissions on material, added by you to a covered work,
+          for which you have or can give appropriate copyright permission.
+        </p>
+        <p>
+          Notwithstanding any other provision of this License, for material you
+          add to a covered work, you may (if authorized by the copyright holders
+          of that material) supplement the terms of this License with terms:
+        </p>
+        <list>
+          <item>
+            <bullet>a)</bullet>
+            Disclaiming warranty or limiting liability differently
+            from the terms of sections 15 and 16 of this License; or
           </item>
-               <item>
-                  <bullet>b)</bullet>
-            Requiring preservation of specified reasonable legal notices or author attributions in that
-               material or in the Appropriate Legal Notices displayed by works containing it; or
+          <item>
+            <bullet>b)</bullet>
+            Requiring preservation of specified reasonable legal
+            notices or author attributions in that material or in the
+            Appropriate Legal Notices displayed by works containing it; or
           </item>
-               <item>
-                  <bullet>c)</bullet>
-            Prohibiting misrepresentation of the origin of that material, or requiring that modified
-               versions of such material be marked in reasonable ways as different from the original
-               version; or
+          <item>
+            <bullet>c)</bullet>
+            Prohibiting misrepresentation of the origin of that material,
+            or requiring that modified versions of such material be marked
+            in reasonable ways as different from the original version; or
           </item>
-               <item>
-                  <bullet>d)</bullet>
-            Limiting the use for publicity purposes of names of licensors or authors of the material; or
+          <item>
+            <bullet>d)</bullet>
+            Limiting the use for publicity purposes of names
+            of licensors or authors of the material; or
           </item>
-               <item>
-                  <bullet>e)</bullet>
-            Declining to grant rights under trademark law for use of some trade names, trademarks, or
-               service marks; or
+          <item>
+            <bullet>e)</bullet>
+            Declining to grant rights under trademark law for use
+            of some trade names, trademarks, or service marks; or
           </item>
-               <item>
-                  <bullet>f)</bullet>
-            Requiring indemnification of licensors and authors of that material by anyone who conveys the
-               material (or modified versions of it) with contractual assumptions of liability to the
-               recipient, for any liability that these contractual assumptions directly impose on those
-               licensors and authors.
+          <item>
+            <bullet>f)</bullet>
+            Requiring indemnification of licensors and authors of that
+            material by anyone who conveys the material (or modified
+            versions of it) with contractual assumptions of liability
+            to the recipient, for any liability that these contractual
+            assumptions directly impose on those licensors and authors.
           </item>
-            </list>
-            <p>All other non-permissive additional terms are considered “further restrictions”
-               within the meaning of section 10. If the Program as you received it, or any part of it,
-               contains a notice stating that it is governed by this License along with a term that is a
-               further restriction, you may remove that term. If a license document contains a further
-               restriction but permits relicensing or conveying under this License, you may add to a
-               covered work material governed by the terms of that license document, provided that the
-               further restriction does not survive such relicensing or conveying.</p>
-            <p>If you add terms to a covered work in accord with this section, you must place, in the
-               relevant source files, a statement of the additional terms that apply to those files, or a
-               notice indicating where to find the applicable terms.</p>
-            <p>Additional terms, permissive or non-permissive, may be stated in the form of a separately
-               written license, or stated as exceptions; the above requirements apply either way.</p>
-        </item>
-        <item>
-            <bullet>8.</bullet>
-          Termination. 
-            <br/>You may not propagate or modify a covered work except as expressly provided under this
-                 License. Any attempt otherwise to propagate or modify it is void, and will
-                 automatically terminate your rights under this License (including any patent licenses
-                 granted under the third paragraph of section 11). 
-          
-          <p>However, if you cease all violation of this License, then your license from a particular
-             copyright holder is reinstated (a) provisionally, unless and until the copyright holder
-             explicitly and finally terminates your license, and (b) permanently, if the copyright holder
-             fails to notify you of the violation by some reasonable means prior to 60 days after the
-             cessation.</p>
-            <p>Moreover, your license from a particular copyright holder is reinstated permanently if the
-             copyright holder notifies you of the violation by some reasonable means, this is the first
-             time you have received notice of violation of this License (for any work) from that copyright
-             holder, and you cure the violation prior to 30 days after your receipt of the notice.</p>
-            <p>Termination of your rights under this section does not terminate the licenses of parties who have
-             received copies or rights from you under this License. If your rights have been terminated and
-             not permanently reinstated, you do not qualify to receive new licenses for the same material
-             under section 10.</p>
-        </item>
-        <item>
-            <bullet>9.</bullet>
-          Acceptance Not Required for Having Copies. 
-            <br/>You are not required to accept this License in order to receive or run a copy of the
-                 Program. Ancillary propagation of a covered work occurring solely as a consequence of
-                 using peer-to-peer transmission to receive a copy likewise does not require
-                 acceptance. However, nothing other than this License grants you permission to
-                 propagate or modify any covered work. These actions infringe copyright if you do not
-                 accept this License. Therefore, by modifying or propagating a covered work, you
-                 indicate your acceptance of this License to do so. 
-          
-        </item>
-        <item>
-            <bullet>10.</bullet>
-          Automatic Licensing of Downstream Recipients. 
-            <br/>Each time you convey a covered work, the recipient automatically receives a license from
-                 the original licensors, to run, modify and propagate that work, subject to this
-                 License. You are not responsible for enforcing compliance by third parties with this
-                 License. 
-          
-          <p>An “entity transaction” is a transaction transferring control of an organization,
-             or substantially all assets of one, or subdividing an organization, or merging organizations.
-             If propagation of a covered work results from an entity transaction, each party to that
-             transaction who receives a copy of the work also receives whatever licenses to the work the
-             party's predecessor in interest had or could give under the previous paragraph, plus a
-             right to possession of the Corresponding Source of the work from the predecessor in interest,
-             if the predecessor has it or can get it with reasonable efforts.</p>
-            <p>You may not impose any further restrictions on the exercise of the rights granted or affirmed
-             under this License. For example, you may not impose a license fee, royalty, or other charge
-             for exercise of rights granted under this License, and you may not initiate litigation
-             (including a cross-claim or counterclaim in a lawsuit) alleging that any patent claim is
-             infringed by making, using, selling, offering for sale, or importing the Program or any
-             portion of it.</p>
-        </item>
-        <item>
-            <bullet>11.</bullet>
-          Patents. 
-            <br/>A “contributor” is a copyright holder who authorizes use under this License
-                 of the Program or a work on which the Program is based. The work thus licensed is
-                 called the contributor's “contributor version”. 
-          
-          <p>A contributor's “essential patent claims” are all patent claims owned or
-             controlled by the contributor, whether already acquired or hereafter acquired, that would be
-             infringed by some manner, permitted by this License, of making, using, or selling its
-             contributor version, but do not include claims that would be infringed only as a consequence
-             of further modification of the contributor version. For purposes of this definition,
-             “control” includes the right to grant patent sublicenses in a manner consistent
-             with the requirements of this License.</p>
-            <p>Each contributor grants you a non-exclusive, worldwide, royalty-free patent license under the
-             contributor's essential patent claims, to make, use, sell, offer for sale, import and
-             otherwise run, modify and propagate the contents of its contributor version.</p>
-            <p>In the following three paragraphs, a “patent license” is any express agreement or
-             commitment, however denominated, not to enforce a patent (such as an express permission to
-             practice a patent or covenant not to sue for patent infringement). To “grant”
-             such a patent license to a party means to make such an agreement or commitment not to enforce
-             a patent against the party.</p>
-            <p>If you convey a covered work, knowingly relying on a patent license, and the Corresponding Source
-             of the work is not available for anyone to copy, free of charge and under the terms of this
-             License, through a publicly available network server or other readily accessible means, then
-             you must either (1) cause the Corresponding Source to be so available, or (2) arrange to
-             deprive yourself of the benefit of the patent license for this particular work, or (3)
-             arrange, in a manner consistent with the requirements of this License, to extend the patent
-             license to downstream recipients. “Knowingly relying” means you have actual
-             knowledge that, but for the patent license, your conveying the covered work in a country, or
-             your recipient's use of the covered work in a country, would infringe one or more
-             identifiable patents in that country that you have reason to believe are valid.</p>
-            <p>If, pursuant to or in connection with a single transaction or arrangement, you convey, or
-             propagate by procuring conveyance of, a covered work, and grant a patent license to some of
-             the parties receiving the covered work authorizing them to use, propagate, modify or convey a
-             specific copy of the covered work, then the patent license you grant is automatically extended
-             to all recipients of the covered work and works based on it.</p>
-            <p>A patent license is “discriminatory” if it does not include within the scope of its
-             coverage, prohibits the exercise of, or is conditioned on the non-exercise of one or more of
-             the rights that are specifically granted under this License. You may not convey a covered work
-             if you are a party to an arrangement with a third party that is in the business of
-             distributing software, under which you make payment to the third party based on the extent of
-             your activity of conveying the work, and under which the third party grants, to any of the
-             parties who would receive the covered work from you, a discriminatory patent license (a) in
-             connection with copies of the covered work conveyed by you (or copies made from those copies),
-             or (b) primarily for and in connection with specific products or compilations that contain the
-             covered work, unless you entered into that arrangement, or that patent license was granted,
-             prior to 28 March 2007.</p>
-            <p>Nothing in this License shall be construed as excluding or limiting any implied license or other
-             defenses to infringement that may otherwise be available to you under applicable patent
-             law.</p>
-        </item>
-        <item>
-            <bullet>12.</bullet>
-          No Surrender of Others' Freedom. 
-            <br/>If conditions are imposed on you (whether by court order, agreement or otherwise) that
-                 contradict the conditions of this License, they do not excuse you from the conditions
-                 of this License. If you cannot convey a covered work so as to satisfy simultaneously
-                 your obligations under this License and any other pertinent obligations, then as a
-                 consequence you may not convey it at all. For example, if you agree to terms that
-                 obligate you to collect a royalty for further conveying from those to whom you convey
-                 the Program, the only way you could satisfy both those terms and this License would be
-                 to refrain entirely from conveying the Program. 
-          
-        </item>
-        <item>
-            <bullet>13.</bullet>
-          Use with the GNU Affero General Public License. 
-            <br/>Notwithstanding any other provision of this License, you have permission to link or combine
-                 any covered work with a work licensed under version 3 of the GNU Affero General Public
-                 License into a single combined work, and to convey the resulting work. The terms of
-                 this License will continue to apply to the part which is the covered work, but the
-                 special requirements of the GNU Affero General Public License, section 13, concerning
-                 interaction through a network will apply to the combination as such. 
-          
-        </item>
-        <item>
-            <bullet>14.</bullet>
-          Revised Versions of this License. 
-            <br/>The Free Software Foundation may publish revised and/or new versions of the GNU General
-                 Public License from time to time. Such new versions will be similar in spirit to the
-                 present version, but may differ in detail to address new problems or concerns. 
-          
-          <p>Each version is given a distinguishing version number. If the Program specifies that a certain
-             numbered version of the GNU General Public License “or any later version”
-             applies to it, you have the option of following the terms and conditions either of that
-             numbered version or of any later version published by the Free Software Foundation. If the
-             Program does not specify a version number of the GNU General Public License, you may choose
-             any version ever published by the Free Software Foundation.</p>
-            <p>If the Program specifies that a proxy can decide which future versions of the GNU General Public
-             License can be used, that proxy's public statement of acceptance of a version permanently
-             authorizes you to choose that version for the Program.</p>
-            <p>Later license versions may give you additional or different permissions. However, no additional
-             obligations are imposed on any author or copyright holder as a result of your choosing to
-             follow a later version.</p>
-        </item>
-        <item>
-            <bullet>15.</bullet>
-          Disclaimer of Warranty. 
-            <br/>THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT
-                 WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE
-                 THE PROGRAM “AS IS” WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR
-                 IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
-                 FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF
-                 THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
-                 ALL NECESSARY SERVICING, REPAIR OR CORRECTION. 
-          
-        </item>
-        <item>
-            <bullet>16.</bullet>
-          Limitation of Liability. 
-            <br/>IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY COPYRIGHT
-                 HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS THE PROGRAM AS PERMITTED ABOVE,
-                 BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
-                 CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM
-                 (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES
-                 SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY
-                 OTHER PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
-                 POSSIBILITY OF SUCH DAMAGES. 
-          
-        </item>
-        <item>
-            <bullet>17.</bullet>
-          Interpretation of Sections 15 and 16.
-        </item>
-      </list>
-      <p>If the disclaimer of warranty and limitation of liability provided above cannot be given local legal
-         effect according to their terms, reviewing courts shall apply local law that most closely approximates
-         an absolute waiver of all civil liability in connection with the Program, unless a warranty or
-         assumption of liability accompanies a copy of the Program in return for a fee.</p>
-      <optional>
-         <p>END OF TERMS AND CONDITIONS</p>
-         <p>How to Apply These Terms to Your New Programs</p>
-         <p>If you develop a new program, and you want it to be of the greatest possible use to the public, the best
-         way to achieve this is to make it free software which everyone can redistribute and change under these
-         terms.</p>
-         <p>To do so, attach the following notices to the program. It is safest to attach them to the start of each
-         source file to most effectively state the exclusion of warranty; and each file should have at least
-         the “copyright” line and a pointer to where the full notice is found.</p>
-         <p>&lt;one line to give the program's name and a brief idea of what it does.&gt; 
-        <br/>Copyright (C) &lt;year&gt; &lt;name of author&gt; 
+        </list>
+        <p>
+          All other non-permissive additional terms are considered “further
+          restrictions” within the meaning of section 10. If the Program
+          as you received it, or any part of it, contains a notice stating
+          that it is governed by this License along with a term that is
+          a further restriction, you may remove that term. If a license
+          document contains a further restriction but permits relicensing or
+          conveying under this License, you may add to a covered work material
+          governed by the terms of that license document, provided that the
+          further restriction does not survive such relicensing or conveying.
+        </p>
+        <p>
+          If you add terms to a covered work in accord with this
+          section, you must place, in the relevant source files, a
+          statement of the additional terms that apply to those files,
+          or a notice indicating where to find the applicable terms.
+        </p>
+        <p>
+          Additional terms, permissive or non-permissive, may be
+          stated in the form of a separately written license, or stated
+          as exceptions; the above requirements apply either way.
+        </p>
+      </item>
+      <item>
+        <bullet>8.</bullet>
+        Termination.<br></br>
+        You may not propagate or modify a covered work except as
+        expressly provided under this License. Any attempt otherwise
+        to propagate or modify it is void, and will automatically
+        terminate your rights under this License (including any patent
+        licenses granted under the third paragraph of section 11).
+        <p>
+          However, if you cease all violation of this License, then your
+          license from a particular copyright holder is reinstated (a)
+          provisionally, unless and until the copyright holder explicitly
+          and finally terminates your license, and (b) permanently, if
+          the copyright holder fails to notify you of the violation by
+          some reasonable means prior to 60 days after the cessation.
+        </p>
+        <p>
+          Moreover, your license from a particular copyright holder is
+          reinstated permanently if the copyright holder notifies you
+          of the violation by some reasonable means, this is the first
+          time you have received notice of violation of this License
+          (for any work) from that copyright holder, and you cure the
+          violation prior to 30 days after your receipt of the notice.
+        </p>
+        <p>
+          Termination of your rights under this section does not
+          terminate the licenses of parties who have received copies or
+          rights from you under this License. If your rights have been
+          terminated and not permanently reinstated, you do not qualify
+          to receive new licenses for the same material under section 10.
+        </p>
+      </item>
+      <item>
+        <bullet>9.</bullet>
+        Acceptance Not Required for Having Copies.<br></br>
+        You are not required to accept this License in order to receive or
+        run a copy of the Program. Ancillary propagation of a covered work
+        occurring solely as a consequence of using peer-to-peer transmission
+        to receive a copy likewise does not require acceptance. However,
+        nothing other than this License grants you permission to propagate
+        or modify any covered work. These actions infringe copyright if you
+        do not accept this License. Therefore, by modifying or propagating a
+        covered work, you indicate your acceptance of this License to do so.
+      </item>
+      <item>
+        <bullet>10.</bullet>
+        Automatic Licensing of Downstream Recipients.<br></br>
+        Each time you convey a covered work, the recipient automatically
+        receives a license from the original licensors, to run, modify and
+        propagate that work, subject to this License. You are not responsible
+        for enforcing compliance by third parties with this License.
+        <p>
+          An “entity transaction” is a transaction transferring control of
+          an organization, or substantially all assets of one, or subdividing
+          an organization, or merging organizations. If propagation of a
+          covered work results from an entity transaction, each party to that
+          transaction who receives a copy of the work also receives whatever
+          licenses to the work the party's predecessor in interest had or could
+          give under the previous paragraph, plus a right to possession of the
+          Corresponding Source of the work from the predecessor in interest,
+          if the predecessor has it or can get it with reasonable efforts.
+        </p>
+        <p>
+          You may not impose any further restrictions on the exercise of the
+          rights granted or affirmed under this License. For example, you
+          may not impose a license fee, royalty, or other charge for exercise
+          of rights granted under this License, and you may not initiate
+          litigation (including a cross-claim or counterclaim in a lawsuit)
+          alleging that any patent claim is infringed by making, using, selling,
+          offering for sale, or importing the Program or any portion of it.
+        </p>
+      </item>
+      <item>
+        <bullet>11.</bullet>
+        Patents.<br></br>
+        A “contributor” is a copyright holder who authorizes use under this
+        License of the Program or a work on which the Program is based. The
+        work thus licensed is called the contributor's “contributor version”.
+        <p>
+          A contributor's “essential patent claims” are all patent
+          claims owned or controlled by the contributor, whether already
+          acquired or hereafter acquired, that would be infringed by some
+          manner, permitted by this License, of making, using, or selling
+          its contributor version, but do not include claims that would
+          be infringed only as a consequence of further modification
+          of the contributor version. For purposes of this definition,
+          “control” includes the right to grant patent sublicenses in
+          a manner consistent with the requirements of this License.
+        </p>
+        <p>
+          Each contributor grants you a non-exclusive, worldwide, royalty-free
+          patent license under the contributor's essential patent claims,
+          to make, use, sell, offer for sale, import and otherwise run,
+          modify and propagate the contents of its contributor version.
+        </p>
+        <p>
+          In the following three paragraphs, a “patent license” is any
+          express agreement or commitment, however denominated, not to
+          enforce a patent (such as an express permission to practice
+          a patent or covenant not to sue for patent infringement). To
+          “grant” such a patent license to a party means to make such an
+          agreement or commitment not to enforce a patent against the party.
+        </p>
+        <p>
+          If you convey a covered work, knowingly relying on a patent license,
+          and the Corresponding Source of the work is not available for anyone
+          to copy, free of charge and under the terms of this License, through
+          a publicly available network server or other readily accessible
+          means, then you must either (1) cause the Corresponding Source to
+          be so available, or (2) arrange to deprive yourself of the benefit
+          of the patent license for this particular work, or (3) arrange, in
+          a manner consistent with the requirements of this License, to extend
+          the patent license to downstream recipients. “Knowingly relying”
+          means you have actual knowledge that, but for the patent license, your
+          conveying the covered work in a country, or your recipient's use of
+          the covered work in a country, would infringe one or more identifiable
+          patents in that country that you have reason to believe are valid.
+        </p>
+        <p>
+          If, pursuant to or in connection with a single transaction or
+          arrangement, you convey, or propagate by procuring conveyance
+          of, a covered work, and grant a patent license to some of the
+          parties receiving the covered work authorizing them to use,
+          propagate, modify or convey a specific copy of the covered work,
+          then the patent license you grant is automatically extended
+          to all recipients of the covered work and works based on it.
+        </p>
+        <p>
+          A patent license is “discriminatory” if it does not include within the
+          scope of its coverage, prohibits the exercise of, or is conditioned
+          on the non-exercise of one or more of the rights that are specifically
+          granted under this License. You may not convey a covered work if
+          you are a party to an arrangement with a third party that is in the
+          business of distributing software, under which you make payment to
+          the third party based on the extent of your activity of conveying
+          the work, and under which the third party grants, to any of the
+          parties who would receive the covered work from you, a discriminatory
+          patent license (a) in connection with copies of the covered work
+          conveyed by you (or copies made from those copies), or (b) primarily
+          for and in connection with specific products or compilations that
+          contain the covered work, unless you entered into that arrangement,
+          or that patent license was granted, prior to 28 March 2007.
+        </p>
+        <p>
+          Nothing in this License shall be construed as excluding or
+          limiting any implied license or other defenses to infringement
+          that may otherwise be available to you under applicable patent law.
+        </p>
+      </item>
+      <item>
+        <bullet>12.</bullet>
+        No Surrender of Others' Freedom.<br></br>
+        If conditions are imposed on you (whether by court order, agreement
+        or otherwise) that contradict the conditions of this License,
+        they do not excuse you from the conditions of this License. If
+        you cannot convey a covered work so as to satisfy simultaneously
+        your obligations under this License and any other pertinent
+        obligations, then as a consequence you may not convey it at all.
+        For example, if you agree to terms that obligate you to collect
+        a royalty for further conveying from those to whom you convey the
+        Program, the only way you could satisfy both those terms and this
+        License would be to refrain entirely from conveying the Program.
+      </item>
+      <item>
+        <bullet>13.</bullet>
+        Use with the GNU Affero General Public License.<br></br>
+        Notwithstanding any other provision of this License, you have
+        permission to link or combine any covered work with a work licensed
+        under version 3 of the GNU Affero General Public License into
+        a single combined work, and to convey the resulting work. The
+        terms of this License will continue to apply to the part which
+        is the covered work, but the special requirements of the GNU
+        Affero General Public License, section 13, concerning interaction
+        through a network will apply to the combination as such.
+      </item>
+      <item>
+        <bullet>14.</bullet>
+        Revised Versions of this License.<br></br>
+        The Free Software Foundation may publish revised and/or new
+        versions of the GNU General Public License from time to time. Such
+        new versions will be similar in spirit to the present version,
+        but may differ in detail to address new problems or concerns.
+        <p>
+          Each version is given a distinguishing version number. If the
+          Program specifies that a certain numbered version of the GNU
+          General Public License “or any later version” applies to it,
+          you have the option of following the terms and conditions either
+          of that numbered version or of any later version published by
+          the Free Software Foundation. If the Program does not specify a
+          version number of the GNU General Public License, you may choose
+          any version ever published by the Free Software Foundation.
+        </p>
+        <p>
+          If the Program specifies that a proxy can decide which future
+          versions of the GNU General Public License can be used, that
+          proxy's public statement of acceptance of a version permanently
+          authorizes you to choose that version for the Program.
+        </p>
+        <p>
+          Later license versions may give you additional or
+          different permissions. However, no additional obligations
+          are imposed on any author or copyright holder as a
+          result of your choosing to follow a later version.
+        </p>
+      </item>
+      <item>
+        <bullet>15.</bullet>
+        Disclaimer of Warranty.<br></br>
+        THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+        APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+        HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM “AS IS” WITHOUT
+        WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT
+        LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+        A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE
+        OF THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU
+        ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+      </item>
+      <item>
+        <bullet>16.</bullet>
+        Limitation of Liability.<br></br>
+        IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+        WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR
+        CONVEYS THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+        INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES
+        ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING
+        BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE
+        OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE
+        PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER
+        OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+      </item>
+      <item>
+        <bullet>17.</bullet>
+        Interpretation of Sections 15 and 16.
+      </item>
+    </list>
+    <p>
+      If the disclaimer of warranty and limitation of liability
+      provided above cannot be given local legal effect according to
+      their terms, reviewing courts shall apply local law that most
+      closely approximates an absolute waiver of all civil liability in
+      connection with the Program, unless a warranty or assumption of
+      liability accompanies a copy of the Program in return for a fee.
+    </p>
+    <optional>
+      <p>
+        END OF TERMS AND CONDITIONS
       </p>
-         <p>This program is free software: you can redistribute it and/or modify it under the terms of the GNU
-         General Public License as published by the Free Software Foundation, either version 3 of the License,
-         or (at your option) any later version.</p>
-         <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
-         the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
-         Public License for more details.</p>
-         <p>You should have received a copy of the GNU General Public License along with this program. If not, see
-         &lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.</p>
-         <p>Also add information on how to contact you by electronic and paper mail.</p>
-         <p>If the program does terminal interaction, make it output a short notice like this when it starts in an
-         interactive mode:</p>
-         <p>&lt;program&gt; Copyright (C) &lt;year&gt; &lt;name of author&gt; 
-        <br/>This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'. 
-        <br/>This is free software, and you are welcome to redistribute it under certain conditions; type `show
-             c' for details. 
+      <p>
+        How to Apply These Terms to Your New Programs
       </p>
-         <p>The hypothetical commands `show w' and `show c' should show the appropriate parts of the
-         General Public License. Of course, your program's commands might be different; for a GUI
-         interface, you would use an “about box”.</p>
-         <p>You should also get your employer (if you work as a programmer) or school, if any, to sign a
-         “copyright disclaimer” for the program, if necessary. For more information on this, and
-         how to apply and follow the GNU GPL, see &lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.</p>
-         <p>The GNU General Public License does not permit incorporating your program into proprietary programs. If
-         your program is a subroutine library, you may consider it more useful to permit linking proprietary
-         applications with the library. If this is what you want to do, use the GNU Lesser General Public
-         License instead of this License. But first, please read
-         &lt;http<optional>s</optional>://www.gnu.org/philosophy/why-not-lgpl.html&gt;.</p>
-      </optional>
+      <p>
+        If you develop a new program, and you want it to be
+        of the greatest possible use to the public, the best
+        way to achieve this is to make it free software which
+        everyone can redistribute and change under these terms.
+      </p>
+      <p>
+        To do so, attach the following notices to the program. It is safest
+        to attach them to the start of each source file to most effectively
+        state the exclusion of warranty; and each file should have at least
+        the “copyright” line and a pointer to where the full notice is found.
+      </p>
+      <p>
+        &lt;one line to give the program's name and
+        a brief idea of what it does.&gt;<br></br>
+        Copyright (C) &lt;year&gt; &lt;name of author&gt;
+      </p>
+      <p>
+        This program is free software: you can redistribute it and/or
+        modify it under the terms of the GNU General Public License
+        as published by the Free Software Foundation, either version
+        3 of the License, or (at your option) any later version.
+      </p>
+      <p>
+        This program is distributed in the hope that it will be
+        useful, but WITHOUT ANY WARRANTY; without even the implied
+        warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+        PURPOSE. See the GNU General Public License for more details.
+      </p>
+      <p>
+        You should have received a copy of the GNU General
+	Public License along with this program. If not, see
+	&lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.
+      </p>
+      <p>
+        Also add information on how to contact you by electronic and paper mail.
+      </p>
+      <p>
+        If the program does terminal interaction, make it output a
+        short notice like this when it starts in an interactive mode:
+      </p>
+      <p>
+	&lt;program&gt; Copyright (C) &lt;year&gt;
+	&lt;name of author&gt;<br></br>
+        This program comes with ABSOLUTELY NO
+        WARRANTY; for details type `show w'.<br></br>
+        This is free software, and you are welcome to redistribute
+        it under certain conditions; type `show c' for details.
+      </p>
+      <p>
+        The hypothetical commands `show w' and `show c' should
+        show the appropriate parts of the General Public License.
+        Of course, your program's commands might be different;
+        for a GUI interface, you would use an “about box”.
+      </p>
+      <p>
+        You should also get your employer (if you work as a
+        programmer) or school, if any, to sign a “copyright disclaimer”
+        for the program, if necessary. For more information on
+	this, and how to apply and follow the GNU GPL, see
+	&lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.
+      </p>
+      <p>
+        The GNU General Public License does not permit incorporating
+        your program into proprietary programs. If your program is a
+        subroutine library, you may consider it more useful to permit
+        linking proprietary applications with the library. If this
+        is what you want to do, use the GNU Lesser General Public
+	License instead of this License. But first, please read
+	&lt;http<optional>s</optional>://www.gnu.org/philosophy/why-not-lgpl.html&gt;.
+      </p>
+    </optional>
   </license>
 </SPDXLicenseCollection>

--- a/src/GPL-3.0.xml
+++ b/src/GPL-3.0.xml
@@ -1,11 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
   <license licenseId="GPL-3.0" isOsiApproved="true"
-  name="GNU General Public License v3.0 only">
+  name="GNU General Public License v3.0 only"
+  isDeprecated="true" deprecatedVersion="3.0">
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/gpl-3.0-standalone.html</crossRef>
       <crossRef>http://www.opensource.org/licenses/GPL-3.0</crossRef>
     </crossRefs>
+    <notes>
+      DEPRECATED: Deprecated in lieu of more
+      explicit license identifier of GPL-3.0-only
+    </notes>
     <standardLicenseHeader>
       Copyright (C)<alt name="copyright"
       match=".+">&lt;year&gt; &lt;name of author&gt;</alt>

--- a/src/LGPL-2.0-only.xml
+++ b/src/LGPL-2.0-only.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-  <license licenseId="LGPL-2.0" isOsiApproved="true"
+  <license licenseId="LGPL-2.0-only" isOsiApproved="true"
   name="GNU Library General Public License v2 only">
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html</crossRef>

--- a/src/LGPL-2.0-only.xml
+++ b/src/LGPL-2.0-only.xml
@@ -1,0 +1,635 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SPDXLicenseCollection xmlns="http://www.spdx.org/license">
+  <license licenseId="LGPL-2.0" isOsiApproved="true"
+  name="GNU Library General Public License v2 only">
+    <crossRefs>
+      <crossRef>http://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html</crossRef>
+    </crossRefs>
+    <standardLicenseHeader>
+      Copyright (C)<alt name="copyright" match=".+">year name of author</alt>
+      This library is free software; you can redistribute it and/or modify it
+      under the terms of the GNU Library General Public License as published
+      by the Free Software Foundation; version 2. This library is distributed
+      in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+      even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+      PURPOSE. See the GNU Library General Public License for more details.
+      You should have received a copy of the GNU Library General Public
+      License along with this library; if not, write to the Free Software
+      Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
+    </standardLicenseHeader>
+    <notes>
+      This license was released: June 1991. This license has
+      been superseded by LGPL v2.1 This refers to when this
+      LGPL 2.0 only is being used (as opposed to "or later).
+    </notes>
+    <titleText>
+      <p>
+        GNU LIBRARY GENERAL PUBLIC LICENSE
+      </p>
+      <p>
+        Version 2, June 1991
+      </p>
+    </titleText>
+    <copyrightText>
+      <p>
+        Copyright (C) 1991 Free Software Foundation, Inc.<br></br>
+        51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+      </p>
+    </copyrightText>
+    <p>
+      Everyone is permitted to copy and distribute verbatim copies
+      of this license document, but changing it is not allowed.
+    </p>
+    <p>
+      [This is the first released version of the library GPL. It is
+      numbered 2 because it goes with version 2 of the ordinary GPL.]
+    </p>
+    <p>
+      Preamble
+    </p>
+    <p>
+      The licenses for most software are designed to take away your
+      freedom to share and change it. By contrast, the GNU General Public
+      Licenses are intended to guarantee your freedom to share and change
+      free software--to make sure the software is free for all its users.
+    </p>
+    <p>
+      This license, the Library General Public License, applies
+      to some specially designated Free Software Foundation
+      software, and to any other libraries whose authors
+      decide to use it. You can use it for your libraries, too.
+    </p>
+    <p>
+      When we speak of free software, we are referring to freedom, not price.
+      Our General Public Licenses are designed to make sure that you have
+      the freedom to distribute copies of free software (and charge for
+      this service if you wish), that you receive source code or can get
+      it if you want it, that you can change the software or use pieces of
+      it in new free programs; and that you know you can do these things.
+    </p>
+    <p>
+      To protect your rights, we need to make restrictions that forbid
+      anyone to deny you these rights or to ask you to surrender the
+      rights. These restrictions translate to certain responsibilities for
+      you if you distribute copies of the library, or if you modify it.
+    </p>
+    <p>
+      For example, if you distribute copies of the library, whether gratis
+      or for a fee, you must give the recipients all the rights that we
+      gave you. You must make sure that they, too, receive or can get the
+      source code. If you link a program with the library, you must provide
+      complete object files to the recipients so that they can relink them
+      with the library, after making changes to the library and recompiling
+      it. And you must show them these terms so they know their rights.
+    </p>
+    <p>
+      Our method of protecting your rights has two steps: (1) copyright
+      the library, and (2) offer you this license which gives you
+      legal permission to copy, distribute and/or modify the library.
+    </p>
+    <p>
+      Also, for each distributor's protection, we want to make certain
+      that everyone understands that there is no warranty for this
+      free library. If the library is modified by someone else and
+      passed on, we want its recipients to know that what they have
+      is not the original version, so that any problems introduced by
+      others will not reflect on the original authors' reputations.
+    </p>
+    <p>
+      Finally, any free program is threatened constantly by software
+      patents. We wish to avoid the danger that companies distributing
+      free software will individually obtain patent licenses, thus
+      in effect transforming the program into proprietary software.
+      To prevent this, we have made it clear that any patent must
+      be licensed for everyone's free use or not licensed at all.
+    </p>
+    <p>
+      Most GNU software, including some libraries, is covered by the
+      ordinary GNU General Public License, which was designed for utility
+      programs. This license, the GNU Library General Public License,
+      applies to certain designated libraries. This license is quite
+      different from the ordinary one; be sure to read it in full, and don't
+      assume that anything in it is the same as in the ordinary license.
+    </p>
+    <p>
+      The reason we have a separate public license for some libraries is
+      that they blur the distinction we usually make between modifying
+      or adding to a program and simply using it. Linking a program with
+      a library, without changing the library, is in some sense simply
+      using the library, and is analogous to running a utility program
+      or application program. However, in a textual and legal sense, the
+      linked executable is a combined work, a derivative of the original
+      library, and the ordinary General Public License treats it as such.
+    </p>
+    <p>
+      Because of this blurred distinction, using the ordinary General
+      Public License for libraries did not effectively promote software
+      sharing, because most developers did not use the libraries. We
+      concluded that weaker conditions might promote sharing better.
+    </p>
+    <p>
+      However, unrestricted linking of non-free programs would deprive the
+      users of those programs of all benefit from the free status of the
+      libraries themselves. This Library General Public License is intended
+      to permit developers of non-free programs to use free libraries, while
+      preserving your freedom as a user of such programs to change the free
+      libraries that are incorporated in them. (We have not seen how to
+      achieve this as regards changes in header files, but we have achieved
+      it as regards changes in the actual functions of the Library.) The
+      hope is that this will lead to faster development of free libraries.
+    </p>
+    <p>
+      The precise terms and conditions for copying, distribution
+      and modification follow. Pay close attention to the difference
+      between a "work based on the library" and a "work that uses
+      the library". The former contains code derived from the
+      library, while the latter only works together with the library.
+    </p>
+    <p>
+      Note that it is possible for a library to be covered by the
+      ordinary General Public License rather than by this special one.
+    </p>
+    <p>
+      TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+    </p>
+    <list>
+      <item>
+        <bullet>0.</bullet>
+        This License Agreement applies to any software library
+        which contains a notice placed by the copyright holder or
+        other authorized party saying it may be distributed under
+        the terms of this Library General Public License (also
+        called "this License"). Each licensee is addressed as "you".
+        <p>
+          A "library" means a collection of software functions and/or data
+          prepared so as to be conveniently linked with application programs
+          (which use some of those functions and data) to form executables.
+        </p>
+        <p>
+          The "Library", below, refers to any such software library or work
+          which has been distributed under these terms. A "work based on
+          the Library" means either the Library or any derivative work under
+          copyright law: that is to say, a work containing the Library or a
+          portion of it, either verbatim or with modifications and/or translated
+          straightforwardly into another language. (Hereinafter, translation
+          is included without limitation in the term "modification".)
+        </p>
+        <p>
+          "Source code" for a work means the preferred form of the work
+          for making modifications to it. For a library, complete source
+          code means all the source code for all modules it contains,
+          plus any associated interface definition files, plus the scripts
+          used to control compilation and installation of the library.
+        </p>
+        <p>
+          Activities other than copying, distribution and modification are
+          not covered by this License; they are outside its scope. The act of
+          running a program using the Library is not restricted, and output
+          from such a program is covered only if its contents constitute a
+          work based on the Library (independent of the use of the Library
+          in a tool for writing it). Whether that is true depends on what
+          the Library does and what the program that uses the Library does.
+        </p>
+      </item>
+      <item>
+        <bullet>1.</bullet>
+        You may copy and distribute verbatim copies of the Library's complete
+        source code as you receive it, in any medium, provided that you
+        conspicuously and appropriately publish on each copy an appropriate
+        copyright notice and disclaimer of warranty; keep intact all the
+        notices that refer to this License and to the absence of any warranty;
+        and distribute a copy of this License along with the Library.
+        <p>
+          You may charge a fee for the physical act of
+          transferring a copy, and you may at your option
+          offer warranty protection in exchange for a fee.
+        </p>
+      </item>
+      <item>
+        <bullet>2.</bullet>
+        You may modify your copy or copies of the Library or any portion
+        of it, thus forming a work based on the Library, and copy and
+        distribute such modifications or work under the terms of Section
+        1 above, provided that you also meet all of these conditions:
+        <list>
+          <item>
+            <bullet>a)</bullet>
+            The modified work must itself be a software library.
+          </item>
+          <item>
+            <bullet>b)</bullet>
+            You must cause the files modified to carry prominent notices
+            stating that you changed the files and the date of any change.
+          </item>
+          <item>
+            <bullet>c)</bullet>
+            You must cause the whole of the work to be licensed at no
+            charge to all third parties under the terms of this License.
+          </item>
+          <item>
+            <bullet>d)</bullet>
+            If a facility in the modified Library refers to a function
+            or a table of data to be supplied by an application program
+            that uses the facility, other than as an argument passed
+            when the facility is invoked, then you must make a good faith
+            effort to ensure that, in the event an application does not
+            supply such function or table, the facility still operates,
+            and performs whatever part of its purpose remains meaningful.
+            <p>
+              (For example, a function in a library to compute square roots
+              has a purpose that is entirely well-defined independent of
+              the application. Therefore, Subsection 2d requires that any
+              application-supplied function or table used by this function
+              must be optional: if the application does not supply it,
+              the square root function must still compute square roots.)
+            </p>
+          </item>
+        </list>
+        <p>
+          These requirements apply to the modified work as a whole. If
+          identifiable sections of that work are not derived from the
+          Library, and can be reasonably considered independent and separate
+          works in themselves, then this License, and its terms, do not
+          apply to those sections when you distribute them as separate
+          works. But when you distribute the same sections as part of a
+          whole which is a work based on the Library, the distribution
+          of the whole must be on the terms of this License, whose
+          permissions for other licensees extend to the entire whole,
+          and thus to each and every part regardless of who wrote it.
+        </p>
+        <p>
+          Thus, it is not the intent of this section to claim rights or
+          contest your rights to work written entirely by you; rather,
+          the intent is to exercise the right to control the distribution
+          of derivative or collective works based on the Library.
+        </p>
+        <p>
+          In addition, mere aggregation of another work not based on
+          the Library with the Library (or with a work based on the
+          Library) on a volume of a storage or distribution medium does
+          not bring the other work under the scope of this License.
+        </p>
+      </item>
+      <item>
+        <bullet>3.</bullet>
+        You may opt to apply the terms of the ordinary GNU General
+        Public License instead of this License to a given copy of the
+        Library. To do this, you must alter all the notices that refer
+        to this License, so that they refer to the ordinary GNU General
+        Public License, version 2, instead of to this License. (If a
+        newer version than version 2 of the ordinary GNU General Public
+        License has appeared, then you can specify that version instead
+        if you wish.) Do not make any other change in these notices.
+        <p>
+          Once this change is made in a given copy, it is irreversible for
+          that copy, so the ordinary GNU General Public License applies to
+          all subsequent copies and derivative works made from that copy.
+        </p>
+        <p>
+          This option is useful when you wish to copy part of the
+          code of the Library into a program that is not a library.
+        </p>
+      </item>
+      <item>
+        <bullet>4.</bullet>
+        You may copy and distribute the Library (or a portion or derivative
+        of it, under Section 2) in object code or executable form under
+        the terms of Sections 1 and 2 above provided that you accompany
+        it with the complete corresponding machine-readable source code,
+        which must be distributed under the terms of Sections 1 and 2
+        above on a medium customarily used for software interchange.
+        <p>
+          If distribution of object code is made by offering access to copy
+          from a designated place, then offering equivalent access to copy
+          the source code from the same place satisfies the requirement
+          to distribute the source code, even though third parties are
+          not compelled to copy the source along with the object code.
+        </p>
+      </item>
+      <item>
+        <bullet>5.</bullet>
+        A program that contains no derivative of any portion of the
+        Library, but is designed to work with the Library by being compiled
+        or linked with it, is called a "work that uses the Library".
+        Such a work, in isolation, is not a derivative work of the
+        Library, and therefore falls outside the scope of this License.
+        <p>
+          However, linking a "work that uses the Library" with the Library
+          creates an executable that is a derivative of the Library (because
+          it contains portions of the Library), rather than a "work that uses
+          the library". The executable is therefore covered by this License.
+          Section 6 states terms for distribution of such executables.
+        </p>
+        <p>
+          When a "work that uses the Library" uses material from a header
+          file that is part of the Library, the object code for the work may
+          be a derivative work of the Library even though the source code is
+          not. Whether this is true is especially significant if the work can
+          be linked without the Library, or if the work is itself a library.
+          The threshold for this to be true is not precisely defined by law.
+        </p>
+        <p>
+          If such an object file uses only numerical parameters, data
+          structure layouts and accessors, and small macros and small inline
+          functions (ten lines or less in length), then the use of the
+          object file is unrestricted, regardless of whether it is legally
+          a derivative work. (Executables containing this object code
+          plus portions of the Library will still fall under Section 6.)
+        </p>
+        <p>
+          Otherwise, if the work is a derivative of the Library, you may
+          distribute the object code for the work under the terms of Section
+          6. Any executables containing that work also fall under Section 6,
+          whether or not they are linked directly with the Library itself.
+        </p>
+      </item>
+      <item>
+        <bullet>6.</bullet>
+        As an exception to the Sections above, you may also compile or
+        link a "work that uses the Library" with the Library to produce
+        a work containing portions of the Library, and distribute
+        that work under terms of your choice, provided that the terms
+        permit modification of the work for the customer's own use
+        and reverse engineering for debugging such modifications.
+        <p>
+          You must give prominent notice with each copy of the work
+          that the Library is used in it and that the Library and its
+          use are covered by this License. You must supply a copy of
+          this License. If the work during execution displays copyright
+          notices, you must include the copyright notice for the Library
+          among them, as well as a reference directing the user to the
+          copy of this License. Also, you must do one of these things:
+        </p>
+        <list>
+          <item>
+            <bullet>a)</bullet>
+            Accompany the work with the complete corresponding machine-readable
+            source code for the Library including whatever changes were used in
+            the work (which must be distributed under Sections 1 and 2 above);
+            and, if the work is an executable linked with the Library, with the
+            complete machine-readable "work that uses the Library", as object
+            code and/or source code, so that the user can modify the Library
+            and then relink to produce a modified executable containing the
+            modified Library. (It is understood that the user who changes the
+            contents of definitions files in the Library will not necessarily be
+            able to recompile the application to use the modified definitions.)
+          </item>
+          <item>
+            <bullet>b)</bullet>
+            Accompany the work with a written offer, valid for at
+            least three years, to give the same user the materials
+            specified in Subsection 6a, above, for a charge no
+            more than the cost of performing this distribution.
+          </item>
+          <item>
+            <bullet>c)</bullet>
+            If distribution of the work is made by offering access to
+            copy from a designated place, offer equivalent access to
+            copy the above specified materials from the same place.
+          </item>
+          <item>
+            <bullet>d)</bullet>
+            Verify that the user has already received a copy of these
+            materials or that you have already sent this user a copy.
+          </item>
+        </list>
+        <p>
+          For an executable, the required form of the "work that uses
+          the Library" must include any data and utility programs needed
+          for reproducing the executable from it. However, as a special
+          exception, the source code distributed need not include
+          anything that is normally distributed (in either source or
+          binary form) with the major components (compiler, kernel,
+          and so on) of the operating system on which the executable
+          runs, unless that component itself accompanies the executable.
+        </p>
+        <p>
+          It may happen that this requirement contradicts the
+          license restrictions of other proprietary libraries that
+          do not normally accompany the operating system. Such
+          a contradiction means you cannot use both them and the
+          Library together in an executable that you distribute.
+        </p>
+      </item>
+      <item>
+        <bullet>7.</bullet>
+        You may place library facilities that are a work based on the
+        Library side-by-side in a single library together with other library
+        facilities not covered by this License, and distribute such a
+        combined library, provided that the separate distribution of the
+        work based on the Library and of the other library facilities is
+        otherwise permitted, and provided that you do these two things:
+      </item>
+      <list>
+        <item>
+          <bullet>a)</bullet>
+          Accompany the combined library with a copy of the same work based
+          on the Library, uncombined with any other library facilities.
+          This must be distributed under the terms of the Sections above.
+        </item>
+        <item>
+          <bullet>b)</bullet>
+          Give prominent notice with the combined library of the fact
+          that part of it is a work based on the Library, and explaining
+          where to find the accompanying uncombined form of the same work.
+        </item>
+      </list>
+      <item>
+        <bullet>8.</bullet>
+        You may not copy, modify, sublicense, link with, or distribute the
+        Library except as expressly provided under this License. Any attempt
+        otherwise to copy, modify, sublicense, link with, or distribute
+        the Library is void, and will automatically terminate your rights
+        under this License. However, parties who have received copies, or
+        rights, from you under this License will not have their licenses
+        terminated so long as such parties remain in full compliance.
+      </item>
+      <item>
+        <bullet>9.</bullet>
+        You are not required to accept this License, since you have
+        not signed it. However, nothing else grants you permission to
+        modify or distribute the Library or its derivative works. These
+        actions are prohibited by law if you do not accept this License.
+        Therefore, by modifying or distributing the Library (or any
+        work based on the Library), you indicate your acceptance of this
+        License to do so, and all its terms and conditions for copying,
+        distributing or modifying the Library or works based on it.
+      </item>
+      <item>
+        <bullet>10.</bullet>
+        Each time you redistribute the Library (or any work based on
+        the Library), the recipient automatically receives a license
+        from the original licensor to copy, distribute, link with or
+        modify the Library subject to these terms and conditions. You
+        may not impose any further restrictions on the recipients'
+        exercise of the rights granted herein. You are not responsible
+        for enforcing compliance by third parties to this License.
+      </item>
+      <item>
+        <bullet>11.</bullet>
+        If, as a consequence of a court judgment or allegation of patent
+        infringement or for any other reason (not limited to patent issues),
+        conditions are imposed on you (whether by court order, agreement
+        or otherwise) that contradict the conditions of this License,
+        they do not excuse you from the conditions of this License. If you
+        cannot distribute so as to satisfy simultaneously your obligations
+        under this License and any other pertinent obligations, then as a
+        consequence you may not distribute the Library at all. For example,
+        if a patent license would not permit royalty-free redistribution of
+        the Library by all those who receive copies directly or indirectly
+        through you, then the only way you could satisfy both it and this
+        License would be to refrain entirely from distribution of the Library.
+        <p>
+          If any portion of this section is held invalid or
+          unenforceable under any particular circumstance, the
+          balance of the section is intended to apply, and the section
+          as a whole is intended to apply in other circumstances.
+        </p>
+        <p>
+          It is not the purpose of this section to induce you to infringe
+          any patents or other property right claims or to contest
+          validity of any such claims; this section has the sole purpose
+          of protecting the integrity of the free software distribution
+          system which is implemented by public license practices. Many
+          people have made generous contributions to the wide range of
+          software distributed through that system in reliance on consistent
+          application of that system; it is up to the author/donor to
+          decide if he or she is willing to distribute software through
+          any other system and a licensee cannot impose that choice.
+        </p>
+        <p>
+          This section is intended to make thoroughly clear what is
+          believed to be a consequence of the rest of this License.
+        </p>
+      </item>
+      <item>
+        <bullet>12.</bullet>
+        If the distribution and/or use of the Library is restricted in
+        certain countries either by patents or by copyrighted interfaces,
+        the original copyright holder who places the Library under this
+        License may add an explicit geographical distribution limitation
+        excluding those countries, so that distribution is permitted only
+        in or among countries not thus excluded. In such case, this License
+        incorporates the limitation as if written in the body of this License.
+      </item>
+      <item>
+        <bullet>13.</bullet>
+        The Free Software Foundation may publish revised and/or new versions
+        of the Library General Public License from time to time. Such
+        new versions will be similar in spirit to the present version,
+        but may differ in detail to address new problems or concerns.
+        <p>
+          Each version is given a distinguishing version number. If
+          the Library specifies a version number of this License which
+          applies to it and "any later version", you have the option of
+          following the terms and conditions either of that version or of
+          any later version published by the Free Software Foundation. If
+          the Library does not specify a license version number, you may
+          choose any version ever published by the Free Software Foundation.
+        </p>
+      </item>
+      <item>
+        <bullet>14.</bullet>
+        If you wish to incorporate parts of the Library into other free programs
+        whose distribution conditions are incompatible with these, write to
+        the author to ask for permission. For software which is copyrighted by
+        the Free Software Foundation, write to the Free Software Foundation; we
+        sometimes make exceptions for this. Our decision will be guided by the
+        two goals of preserving the free status of all derivatives of our free
+        software and of promoting the sharing and reuse of software generally.
+        <p>
+          NO WARRANTY
+        </p>
+      </item>
+      <item>
+        <bullet>15.</bullet>
+        BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+        FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT
+        WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER
+        PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY KIND,
+        EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+        IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+        PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF
+        THE LIBRARY IS WITH YOU. SHOULD THE LIBRARY PROVE DEFECTIVE, YOU
+        ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+      </item>
+      <item>
+        <bullet>16.</bullet>
+        IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+        WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+        REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU FOR
+        DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL
+        DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE LIBRARY
+        (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED
+        INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF
+        THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF SUCH HOLDER
+        OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+      </item>
+    </list>
+    <optional>
+      <p>
+        END OF TERMS AND CONDITIONS
+      </p>
+      <p>
+        How to Apply These Terms to Your New Libraries
+      </p>
+      <p>
+        If you develop a new library, and you want it to be of the greatest
+        possible use to the public, we recommend making it free software
+        that everyone can redistribute and change. You can do so by
+        permitting redistribution under these terms (or, alternatively,
+        under the terms of the ordinary General Public License).
+      </p>
+      <p>
+        To apply these terms, attach the following notices to the
+        library. It is safest to attach them to the start of each
+        source file to most effectively convey the exclusion of
+        warranty; and each file should have at least the "copyright"
+        line and a pointer to where the full notice is found.
+      </p>
+      <p>
+        one line to give the library's name
+        and an idea of what it does.<br></br>
+        Copyright (C) year name of author
+      </p>
+      <p>
+        This library is free software; you can redistribute it and/or
+        modify it under the terms of the GNU Library General Public
+        License as published by the Free Software Foundation; either
+        version 2 of the License, or (at your option) any later version.
+      </p>
+      <p>
+        This library is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty
+        of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+        the GNU Library General Public License for more details.
+      </p>
+      <p>
+        You should have received a copy of the GNU Library
+        General Public License along with this library; if
+        not, write to the Free Software Foundation, Inc., 51
+        Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
+      </p>
+      <p>
+        Also add information on how to contact you by electronic and paper mail.
+      </p>
+      <p>
+        You should also get your employer (if you work as a programmer)
+        or your school, if any, to sign a "copyright disclaimer" for
+        the library, if necessary. Here is a sample; alter the names:
+      </p>
+      <p>
+        Yoyodyne, Inc., hereby disclaims all copyright interest in<br></br>
+        the library `Frob' (a library for tweaking knobs) written<br></br>
+        by James Random Hacker.
+      </p>
+      <p>
+        signature of Ty Coon, 1 April 1990<br></br>
+        Ty Coon, President of Vice
+      </p>
+      <p>
+        That's all there is to it!
+      </p>
+    </optional>
+  </license>
+</SPDXLicenseCollection>

--- a/src/LGPL-2.0-or-later.xml
+++ b/src/LGPL-2.0-or-later.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-  <license licenseId="LGPL-2.0" isOsiApproved="true"
-  name="GNU Library General Public License v2 only">
+  <license licenseId="LGPL-2.0-or-later" isOsiApproved="true"
+  name="GNU Library General Public License v2 or later">
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html</crossRef>
     </crossRefs>

--- a/src/LGPL-2.0-or-later.xml
+++ b/src/LGPL-2.0-or-later.xml
@@ -9,18 +9,17 @@
       Copyright (C)<alt name="copyright" match=".+">year name of author</alt>
       This library is free software; you can redistribute it and/or modify it
       under the terms of the GNU Library General Public License as published
-      by the Free Software Foundation; version 2. This library is distributed
-      in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
-      even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-      PURPOSE. See the GNU Library General Public License for more details.
-      You should have received a copy of the GNU Library General Public
-      License along with this library; if not, write to the Free Software
+      by the Free Software Foundation; version 2 or any later version. This
+      library is distributed in the hope that it will be useful, but WITHOUT ANY
+      WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+      FOR A PARTICULAR PURPOSE. See the GNU Library General Public License for
+      more details.  You should have received a copy of the GNU Library General
+      Public License along with this library; if not, write to the Free Software
       Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     </standardLicenseHeader>
     <notes>
       This license was released: June 1991. This license has
-      been superseded by LGPL v2.1 This refers to when this
-      LGPL 2.0 only is being used (as opposed to "or later).
+      been superseded by LGPL v2.1
     </notes>
     <titleText>
       <p>

--- a/src/LGPL-2.0-or-later.xml
+++ b/src/LGPL-2.0-or-later.xml
@@ -1,0 +1,635 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SPDXLicenseCollection xmlns="http://www.spdx.org/license">
+  <license licenseId="LGPL-2.0" isOsiApproved="true"
+  name="GNU Library General Public License v2 only">
+    <crossRefs>
+      <crossRef>http://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html</crossRef>
+    </crossRefs>
+    <standardLicenseHeader>
+      Copyright (C)<alt name="copyright" match=".+">year name of author</alt>
+      This library is free software; you can redistribute it and/or modify it
+      under the terms of the GNU Library General Public License as published
+      by the Free Software Foundation; version 2. This library is distributed
+      in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+      even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+      PURPOSE. See the GNU Library General Public License for more details.
+      You should have received a copy of the GNU Library General Public
+      License along with this library; if not, write to the Free Software
+      Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
+    </standardLicenseHeader>
+    <notes>
+      This license was released: June 1991. This license has
+      been superseded by LGPL v2.1 This refers to when this
+      LGPL 2.0 only is being used (as opposed to "or later).
+    </notes>
+    <titleText>
+      <p>
+        GNU LIBRARY GENERAL PUBLIC LICENSE
+      </p>
+      <p>
+        Version 2, June 1991
+      </p>
+    </titleText>
+    <copyrightText>
+      <p>
+        Copyright (C) 1991 Free Software Foundation, Inc.<br></br>
+        51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+      </p>
+    </copyrightText>
+    <p>
+      Everyone is permitted to copy and distribute verbatim copies
+      of this license document, but changing it is not allowed.
+    </p>
+    <p>
+      [This is the first released version of the library GPL. It is
+      numbered 2 because it goes with version 2 of the ordinary GPL.]
+    </p>
+    <p>
+      Preamble
+    </p>
+    <p>
+      The licenses for most software are designed to take away your
+      freedom to share and change it. By contrast, the GNU General Public
+      Licenses are intended to guarantee your freedom to share and change
+      free software--to make sure the software is free for all its users.
+    </p>
+    <p>
+      This license, the Library General Public License, applies
+      to some specially designated Free Software Foundation
+      software, and to any other libraries whose authors
+      decide to use it. You can use it for your libraries, too.
+    </p>
+    <p>
+      When we speak of free software, we are referring to freedom, not price.
+      Our General Public Licenses are designed to make sure that you have
+      the freedom to distribute copies of free software (and charge for
+      this service if you wish), that you receive source code or can get
+      it if you want it, that you can change the software or use pieces of
+      it in new free programs; and that you know you can do these things.
+    </p>
+    <p>
+      To protect your rights, we need to make restrictions that forbid
+      anyone to deny you these rights or to ask you to surrender the
+      rights. These restrictions translate to certain responsibilities for
+      you if you distribute copies of the library, or if you modify it.
+    </p>
+    <p>
+      For example, if you distribute copies of the library, whether gratis
+      or for a fee, you must give the recipients all the rights that we
+      gave you. You must make sure that they, too, receive or can get the
+      source code. If you link a program with the library, you must provide
+      complete object files to the recipients so that they can relink them
+      with the library, after making changes to the library and recompiling
+      it. And you must show them these terms so they know their rights.
+    </p>
+    <p>
+      Our method of protecting your rights has two steps: (1) copyright
+      the library, and (2) offer you this license which gives you
+      legal permission to copy, distribute and/or modify the library.
+    </p>
+    <p>
+      Also, for each distributor's protection, we want to make certain
+      that everyone understands that there is no warranty for this
+      free library. If the library is modified by someone else and
+      passed on, we want its recipients to know that what they have
+      is not the original version, so that any problems introduced by
+      others will not reflect on the original authors' reputations.
+    </p>
+    <p>
+      Finally, any free program is threatened constantly by software
+      patents. We wish to avoid the danger that companies distributing
+      free software will individually obtain patent licenses, thus
+      in effect transforming the program into proprietary software.
+      To prevent this, we have made it clear that any patent must
+      be licensed for everyone's free use or not licensed at all.
+    </p>
+    <p>
+      Most GNU software, including some libraries, is covered by the
+      ordinary GNU General Public License, which was designed for utility
+      programs. This license, the GNU Library General Public License,
+      applies to certain designated libraries. This license is quite
+      different from the ordinary one; be sure to read it in full, and don't
+      assume that anything in it is the same as in the ordinary license.
+    </p>
+    <p>
+      The reason we have a separate public license for some libraries is
+      that they blur the distinction we usually make between modifying
+      or adding to a program and simply using it. Linking a program with
+      a library, without changing the library, is in some sense simply
+      using the library, and is analogous to running a utility program
+      or application program. However, in a textual and legal sense, the
+      linked executable is a combined work, a derivative of the original
+      library, and the ordinary General Public License treats it as such.
+    </p>
+    <p>
+      Because of this blurred distinction, using the ordinary General
+      Public License for libraries did not effectively promote software
+      sharing, because most developers did not use the libraries. We
+      concluded that weaker conditions might promote sharing better.
+    </p>
+    <p>
+      However, unrestricted linking of non-free programs would deprive the
+      users of those programs of all benefit from the free status of the
+      libraries themselves. This Library General Public License is intended
+      to permit developers of non-free programs to use free libraries, while
+      preserving your freedom as a user of such programs to change the free
+      libraries that are incorporated in them. (We have not seen how to
+      achieve this as regards changes in header files, but we have achieved
+      it as regards changes in the actual functions of the Library.) The
+      hope is that this will lead to faster development of free libraries.
+    </p>
+    <p>
+      The precise terms and conditions for copying, distribution
+      and modification follow. Pay close attention to the difference
+      between a "work based on the library" and a "work that uses
+      the library". The former contains code derived from the
+      library, while the latter only works together with the library.
+    </p>
+    <p>
+      Note that it is possible for a library to be covered by the
+      ordinary General Public License rather than by this special one.
+    </p>
+    <p>
+      TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+    </p>
+    <list>
+      <item>
+        <bullet>0.</bullet>
+        This License Agreement applies to any software library
+        which contains a notice placed by the copyright holder or
+        other authorized party saying it may be distributed under
+        the terms of this Library General Public License (also
+        called "this License"). Each licensee is addressed as "you".
+        <p>
+          A "library" means a collection of software functions and/or data
+          prepared so as to be conveniently linked with application programs
+          (which use some of those functions and data) to form executables.
+        </p>
+        <p>
+          The "Library", below, refers to any such software library or work
+          which has been distributed under these terms. A "work based on
+          the Library" means either the Library or any derivative work under
+          copyright law: that is to say, a work containing the Library or a
+          portion of it, either verbatim or with modifications and/or translated
+          straightforwardly into another language. (Hereinafter, translation
+          is included without limitation in the term "modification".)
+        </p>
+        <p>
+          "Source code" for a work means the preferred form of the work
+          for making modifications to it. For a library, complete source
+          code means all the source code for all modules it contains,
+          plus any associated interface definition files, plus the scripts
+          used to control compilation and installation of the library.
+        </p>
+        <p>
+          Activities other than copying, distribution and modification are
+          not covered by this License; they are outside its scope. The act of
+          running a program using the Library is not restricted, and output
+          from such a program is covered only if its contents constitute a
+          work based on the Library (independent of the use of the Library
+          in a tool for writing it). Whether that is true depends on what
+          the Library does and what the program that uses the Library does.
+        </p>
+      </item>
+      <item>
+        <bullet>1.</bullet>
+        You may copy and distribute verbatim copies of the Library's complete
+        source code as you receive it, in any medium, provided that you
+        conspicuously and appropriately publish on each copy an appropriate
+        copyright notice and disclaimer of warranty; keep intact all the
+        notices that refer to this License and to the absence of any warranty;
+        and distribute a copy of this License along with the Library.
+        <p>
+          You may charge a fee for the physical act of
+          transferring a copy, and you may at your option
+          offer warranty protection in exchange for a fee.
+        </p>
+      </item>
+      <item>
+        <bullet>2.</bullet>
+        You may modify your copy or copies of the Library or any portion
+        of it, thus forming a work based on the Library, and copy and
+        distribute such modifications or work under the terms of Section
+        1 above, provided that you also meet all of these conditions:
+        <list>
+          <item>
+            <bullet>a)</bullet>
+            The modified work must itself be a software library.
+          </item>
+          <item>
+            <bullet>b)</bullet>
+            You must cause the files modified to carry prominent notices
+            stating that you changed the files and the date of any change.
+          </item>
+          <item>
+            <bullet>c)</bullet>
+            You must cause the whole of the work to be licensed at no
+            charge to all third parties under the terms of this License.
+          </item>
+          <item>
+            <bullet>d)</bullet>
+            If a facility in the modified Library refers to a function
+            or a table of data to be supplied by an application program
+            that uses the facility, other than as an argument passed
+            when the facility is invoked, then you must make a good faith
+            effort to ensure that, in the event an application does not
+            supply such function or table, the facility still operates,
+            and performs whatever part of its purpose remains meaningful.
+            <p>
+              (For example, a function in a library to compute square roots
+              has a purpose that is entirely well-defined independent of
+              the application. Therefore, Subsection 2d requires that any
+              application-supplied function or table used by this function
+              must be optional: if the application does not supply it,
+              the square root function must still compute square roots.)
+            </p>
+          </item>
+        </list>
+        <p>
+          These requirements apply to the modified work as a whole. If
+          identifiable sections of that work are not derived from the
+          Library, and can be reasonably considered independent and separate
+          works in themselves, then this License, and its terms, do not
+          apply to those sections when you distribute them as separate
+          works. But when you distribute the same sections as part of a
+          whole which is a work based on the Library, the distribution
+          of the whole must be on the terms of this License, whose
+          permissions for other licensees extend to the entire whole,
+          and thus to each and every part regardless of who wrote it.
+        </p>
+        <p>
+          Thus, it is not the intent of this section to claim rights or
+          contest your rights to work written entirely by you; rather,
+          the intent is to exercise the right to control the distribution
+          of derivative or collective works based on the Library.
+        </p>
+        <p>
+          In addition, mere aggregation of another work not based on
+          the Library with the Library (or with a work based on the
+          Library) on a volume of a storage or distribution medium does
+          not bring the other work under the scope of this License.
+        </p>
+      </item>
+      <item>
+        <bullet>3.</bullet>
+        You may opt to apply the terms of the ordinary GNU General
+        Public License instead of this License to a given copy of the
+        Library. To do this, you must alter all the notices that refer
+        to this License, so that they refer to the ordinary GNU General
+        Public License, version 2, instead of to this License. (If a
+        newer version than version 2 of the ordinary GNU General Public
+        License has appeared, then you can specify that version instead
+        if you wish.) Do not make any other change in these notices.
+        <p>
+          Once this change is made in a given copy, it is irreversible for
+          that copy, so the ordinary GNU General Public License applies to
+          all subsequent copies and derivative works made from that copy.
+        </p>
+        <p>
+          This option is useful when you wish to copy part of the
+          code of the Library into a program that is not a library.
+        </p>
+      </item>
+      <item>
+        <bullet>4.</bullet>
+        You may copy and distribute the Library (or a portion or derivative
+        of it, under Section 2) in object code or executable form under
+        the terms of Sections 1 and 2 above provided that you accompany
+        it with the complete corresponding machine-readable source code,
+        which must be distributed under the terms of Sections 1 and 2
+        above on a medium customarily used for software interchange.
+        <p>
+          If distribution of object code is made by offering access to copy
+          from a designated place, then offering equivalent access to copy
+          the source code from the same place satisfies the requirement
+          to distribute the source code, even though third parties are
+          not compelled to copy the source along with the object code.
+        </p>
+      </item>
+      <item>
+        <bullet>5.</bullet>
+        A program that contains no derivative of any portion of the
+        Library, but is designed to work with the Library by being compiled
+        or linked with it, is called a "work that uses the Library".
+        Such a work, in isolation, is not a derivative work of the
+        Library, and therefore falls outside the scope of this License.
+        <p>
+          However, linking a "work that uses the Library" with the Library
+          creates an executable that is a derivative of the Library (because
+          it contains portions of the Library), rather than a "work that uses
+          the library". The executable is therefore covered by this License.
+          Section 6 states terms for distribution of such executables.
+        </p>
+        <p>
+          When a "work that uses the Library" uses material from a header
+          file that is part of the Library, the object code for the work may
+          be a derivative work of the Library even though the source code is
+          not. Whether this is true is especially significant if the work can
+          be linked without the Library, or if the work is itself a library.
+          The threshold for this to be true is not precisely defined by law.
+        </p>
+        <p>
+          If such an object file uses only numerical parameters, data
+          structure layouts and accessors, and small macros and small inline
+          functions (ten lines or less in length), then the use of the
+          object file is unrestricted, regardless of whether it is legally
+          a derivative work. (Executables containing this object code
+          plus portions of the Library will still fall under Section 6.)
+        </p>
+        <p>
+          Otherwise, if the work is a derivative of the Library, you may
+          distribute the object code for the work under the terms of Section
+          6. Any executables containing that work also fall under Section 6,
+          whether or not they are linked directly with the Library itself.
+        </p>
+      </item>
+      <item>
+        <bullet>6.</bullet>
+        As an exception to the Sections above, you may also compile or
+        link a "work that uses the Library" with the Library to produce
+        a work containing portions of the Library, and distribute
+        that work under terms of your choice, provided that the terms
+        permit modification of the work for the customer's own use
+        and reverse engineering for debugging such modifications.
+        <p>
+          You must give prominent notice with each copy of the work
+          that the Library is used in it and that the Library and its
+          use are covered by this License. You must supply a copy of
+          this License. If the work during execution displays copyright
+          notices, you must include the copyright notice for the Library
+          among them, as well as a reference directing the user to the
+          copy of this License. Also, you must do one of these things:
+        </p>
+        <list>
+          <item>
+            <bullet>a)</bullet>
+            Accompany the work with the complete corresponding machine-readable
+            source code for the Library including whatever changes were used in
+            the work (which must be distributed under Sections 1 and 2 above);
+            and, if the work is an executable linked with the Library, with the
+            complete machine-readable "work that uses the Library", as object
+            code and/or source code, so that the user can modify the Library
+            and then relink to produce a modified executable containing the
+            modified Library. (It is understood that the user who changes the
+            contents of definitions files in the Library will not necessarily be
+            able to recompile the application to use the modified definitions.)
+          </item>
+          <item>
+            <bullet>b)</bullet>
+            Accompany the work with a written offer, valid for at
+            least three years, to give the same user the materials
+            specified in Subsection 6a, above, for a charge no
+            more than the cost of performing this distribution.
+          </item>
+          <item>
+            <bullet>c)</bullet>
+            If distribution of the work is made by offering access to
+            copy from a designated place, offer equivalent access to
+            copy the above specified materials from the same place.
+          </item>
+          <item>
+            <bullet>d)</bullet>
+            Verify that the user has already received a copy of these
+            materials or that you have already sent this user a copy.
+          </item>
+        </list>
+        <p>
+          For an executable, the required form of the "work that uses
+          the Library" must include any data and utility programs needed
+          for reproducing the executable from it. However, as a special
+          exception, the source code distributed need not include
+          anything that is normally distributed (in either source or
+          binary form) with the major components (compiler, kernel,
+          and so on) of the operating system on which the executable
+          runs, unless that component itself accompanies the executable.
+        </p>
+        <p>
+          It may happen that this requirement contradicts the
+          license restrictions of other proprietary libraries that
+          do not normally accompany the operating system. Such
+          a contradiction means you cannot use both them and the
+          Library together in an executable that you distribute.
+        </p>
+      </item>
+      <item>
+        <bullet>7.</bullet>
+        You may place library facilities that are a work based on the
+        Library side-by-side in a single library together with other library
+        facilities not covered by this License, and distribute such a
+        combined library, provided that the separate distribution of the
+        work based on the Library and of the other library facilities is
+        otherwise permitted, and provided that you do these two things:
+      </item>
+      <list>
+        <item>
+          <bullet>a)</bullet>
+          Accompany the combined library with a copy of the same work based
+          on the Library, uncombined with any other library facilities.
+          This must be distributed under the terms of the Sections above.
+        </item>
+        <item>
+          <bullet>b)</bullet>
+          Give prominent notice with the combined library of the fact
+          that part of it is a work based on the Library, and explaining
+          where to find the accompanying uncombined form of the same work.
+        </item>
+      </list>
+      <item>
+        <bullet>8.</bullet>
+        You may not copy, modify, sublicense, link with, or distribute the
+        Library except as expressly provided under this License. Any attempt
+        otherwise to copy, modify, sublicense, link with, or distribute
+        the Library is void, and will automatically terminate your rights
+        under this License. However, parties who have received copies, or
+        rights, from you under this License will not have their licenses
+        terminated so long as such parties remain in full compliance.
+      </item>
+      <item>
+        <bullet>9.</bullet>
+        You are not required to accept this License, since you have
+        not signed it. However, nothing else grants you permission to
+        modify or distribute the Library or its derivative works. These
+        actions are prohibited by law if you do not accept this License.
+        Therefore, by modifying or distributing the Library (or any
+        work based on the Library), you indicate your acceptance of this
+        License to do so, and all its terms and conditions for copying,
+        distributing or modifying the Library or works based on it.
+      </item>
+      <item>
+        <bullet>10.</bullet>
+        Each time you redistribute the Library (or any work based on
+        the Library), the recipient automatically receives a license
+        from the original licensor to copy, distribute, link with or
+        modify the Library subject to these terms and conditions. You
+        may not impose any further restrictions on the recipients'
+        exercise of the rights granted herein. You are not responsible
+        for enforcing compliance by third parties to this License.
+      </item>
+      <item>
+        <bullet>11.</bullet>
+        If, as a consequence of a court judgment or allegation of patent
+        infringement or for any other reason (not limited to patent issues),
+        conditions are imposed on you (whether by court order, agreement
+        or otherwise) that contradict the conditions of this License,
+        they do not excuse you from the conditions of this License. If you
+        cannot distribute so as to satisfy simultaneously your obligations
+        under this License and any other pertinent obligations, then as a
+        consequence you may not distribute the Library at all. For example,
+        if a patent license would not permit royalty-free redistribution of
+        the Library by all those who receive copies directly or indirectly
+        through you, then the only way you could satisfy both it and this
+        License would be to refrain entirely from distribution of the Library.
+        <p>
+          If any portion of this section is held invalid or
+          unenforceable under any particular circumstance, the
+          balance of the section is intended to apply, and the section
+          as a whole is intended to apply in other circumstances.
+        </p>
+        <p>
+          It is not the purpose of this section to induce you to infringe
+          any patents or other property right claims or to contest
+          validity of any such claims; this section has the sole purpose
+          of protecting the integrity of the free software distribution
+          system which is implemented by public license practices. Many
+          people have made generous contributions to the wide range of
+          software distributed through that system in reliance on consistent
+          application of that system; it is up to the author/donor to
+          decide if he or she is willing to distribute software through
+          any other system and a licensee cannot impose that choice.
+        </p>
+        <p>
+          This section is intended to make thoroughly clear what is
+          believed to be a consequence of the rest of this License.
+        </p>
+      </item>
+      <item>
+        <bullet>12.</bullet>
+        If the distribution and/or use of the Library is restricted in
+        certain countries either by patents or by copyrighted interfaces,
+        the original copyright holder who places the Library under this
+        License may add an explicit geographical distribution limitation
+        excluding those countries, so that distribution is permitted only
+        in or among countries not thus excluded. In such case, this License
+        incorporates the limitation as if written in the body of this License.
+      </item>
+      <item>
+        <bullet>13.</bullet>
+        The Free Software Foundation may publish revised and/or new versions
+        of the Library General Public License from time to time. Such
+        new versions will be similar in spirit to the present version,
+        but may differ in detail to address new problems or concerns.
+        <p>
+          Each version is given a distinguishing version number. If
+          the Library specifies a version number of this License which
+          applies to it and "any later version", you have the option of
+          following the terms and conditions either of that version or of
+          any later version published by the Free Software Foundation. If
+          the Library does not specify a license version number, you may
+          choose any version ever published by the Free Software Foundation.
+        </p>
+      </item>
+      <item>
+        <bullet>14.</bullet>
+        If you wish to incorporate parts of the Library into other free programs
+        whose distribution conditions are incompatible with these, write to
+        the author to ask for permission. For software which is copyrighted by
+        the Free Software Foundation, write to the Free Software Foundation; we
+        sometimes make exceptions for this. Our decision will be guided by the
+        two goals of preserving the free status of all derivatives of our free
+        software and of promoting the sharing and reuse of software generally.
+        <p>
+          NO WARRANTY
+        </p>
+      </item>
+      <item>
+        <bullet>15.</bullet>
+        BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+        FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT
+        WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER
+        PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY KIND,
+        EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+        IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+        PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF
+        THE LIBRARY IS WITH YOU. SHOULD THE LIBRARY PROVE DEFECTIVE, YOU
+        ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+      </item>
+      <item>
+        <bullet>16.</bullet>
+        IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+        WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+        REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU FOR
+        DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL
+        DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE LIBRARY
+        (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED
+        INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF
+        THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF SUCH HOLDER
+        OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+      </item>
+    </list>
+    <optional>
+      <p>
+        END OF TERMS AND CONDITIONS
+      </p>
+      <p>
+        How to Apply These Terms to Your New Libraries
+      </p>
+      <p>
+        If you develop a new library, and you want it to be of the greatest
+        possible use to the public, we recommend making it free software
+        that everyone can redistribute and change. You can do so by
+        permitting redistribution under these terms (or, alternatively,
+        under the terms of the ordinary General Public License).
+      </p>
+      <p>
+        To apply these terms, attach the following notices to the
+        library. It is safest to attach them to the start of each
+        source file to most effectively convey the exclusion of
+        warranty; and each file should have at least the "copyright"
+        line and a pointer to where the full notice is found.
+      </p>
+      <p>
+        one line to give the library's name
+        and an idea of what it does.<br></br>
+        Copyright (C) year name of author
+      </p>
+      <p>
+        This library is free software; you can redistribute it and/or
+        modify it under the terms of the GNU Library General Public
+        License as published by the Free Software Foundation; either
+        version 2 of the License, or (at your option) any later version.
+      </p>
+      <p>
+        This library is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty
+        of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+        the GNU Library General Public License for more details.
+      </p>
+      <p>
+        You should have received a copy of the GNU Library
+        General Public License along with this library; if
+        not, write to the Free Software Foundation, Inc., 51
+        Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
+      </p>
+      <p>
+        Also add information on how to contact you by electronic and paper mail.
+      </p>
+      <p>
+        You should also get your employer (if you work as a programmer)
+        or your school, if any, to sign a "copyright disclaimer" for
+        the library, if necessary. Here is a sample; alter the names:
+      </p>
+      <p>
+        Yoyodyne, Inc., hereby disclaims all copyright interest in<br></br>
+        the library `Frob' (a library for tweaking knobs) written<br></br>
+        by James Random Hacker.
+      </p>
+      <p>
+        signature of Ty Coon, 1 April 1990<br></br>
+        Ty Coon, President of Vice
+      </p>
+      <p>
+        That's all there is to it!
+      </p>
+    </optional>
+  </license>
+</SPDXLicenseCollection>

--- a/src/LGPL-2.0.xml
+++ b/src/LGPL-2.0.xml
@@ -1,10 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
   <license licenseId="LGPL-2.0" isOsiApproved="true"
-  name="GNU Library General Public License v2 only">
+  name="GNU Library General Public License v2 only"
+  isDeprecated="true" deprecatedVersion="3.0">
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html</crossRef>
     </crossRefs>
+    <notes>
+      DEPRECATED: Deprecated in lieu of more
+      explicit license identifier of LGPL-2.0-only
+    </notes>
     <standardLicenseHeader>
       Copyright (C)<alt name="copyright" match=".+">year name of author</alt>
       This library is free software; you can redistribute it and/or modify it

--- a/src/LGPL-2.0.xml
+++ b/src/LGPL-2.0.xml
@@ -1,432 +1,635 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isOsiApproved="true" licenseId="LGPL-2.0"
-            name="GNU Library General Public License v2 only">
-      <crossRefs>
-         <crossRef>http://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html</crossRef>
-      </crossRefs>
-      <standardLicenseHeader> Copyright (C) 
-    <alt match=".+" name="copyright">year name of author</alt> This library is free software; you can redistribute
-    it and/or modify it under the terms of the GNU Library General Public License as published by the Free Software
-    Foundation; version 2. This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-    without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Library
-    General Public License for more details. You should have received a copy of the GNU Library General Public
-    License along with this library; if not, write to the Free Software Foundation, Inc., 51 Franklin St, Fifth
-    Floor, Boston, MA 02110-1301, USA. 
-  </standardLicenseHeader>
-      <notes>This license was released: June 1991. This license has been superseded by LGPL v2.1 This refers to when this
-         LGPL 2.0 only is being used (as opposed to "or later).</notes>
-      <titleText>
-         <p>GNU LIBRARY GENERAL PUBLIC LICENSE</p>
-         <p>Version 2, June 1991</p>
-      </titleText>
-      <copyrightText>
-         <p>Copyright (C) 1991 Free Software Foundation, Inc. 
-        <br/>51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA 
+  <license licenseId="LGPL-2.0" isOsiApproved="true"
+  name="GNU Library General Public License v2 only">
+    <crossRefs>
+      <crossRef>http://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html</crossRef>
+    </crossRefs>
+    <standardLicenseHeader>
+      Copyright (C)<alt name="copyright" match=".+">year name of author</alt>
+      This library is free software; you can redistribute it and/or modify it
+      under the terms of the GNU Library General Public License as published
+      by the Free Software Foundation; version 2. This library is distributed
+      in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+      even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+      PURPOSE. See the GNU Library General Public License for more details.
+      You should have received a copy of the GNU Library General Public
+      License along with this library; if not, write to the Free Software
+      Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
+    </standardLicenseHeader>
+    <notes>
+      This license was released: June 1991. This license has
+      been superseded by LGPL v2.1 This refers to when this
+      LGPL 2.0 only is being used (as opposed to "or later).
+    </notes>
+    <titleText>
+      <p>
+        GNU LIBRARY GENERAL PUBLIC LICENSE
       </p>
-      </copyrightText>
-      <p>Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is
-         not allowed.</p>
-      <p>[This is the first released version of the library GPL. It is numbered 2 because it goes with version 2
-         of the ordinary GPL.]</p>
-      <p>Preamble</p>
-      <p>The licenses for most software are designed to take away your freedom to share and change it. By
-         contrast, the GNU General Public Licenses are intended to guarantee your freedom to share and change
-         free software--to make sure the software is free for all its users.</p>
-      <p>This license, the Library General Public License, applies to some specially designated Free Software
-         Foundation software, and to any other libraries whose authors decide to use it. You can use it for
-         your libraries, too.</p>
-      <p>When we speak of free software, we are referring to freedom, not price. Our General Public Licenses are
-         designed to make sure that you have the freedom to distribute copies of free software (and charge for
-         this service if you wish), that you receive source code or can get it if you want it, that you can
-         change the software or use pieces of it in new free programs; and that you know you can do these
-         things.</p>
-      <p>To protect your rights, we need to make restrictions that forbid anyone to deny you these rights or to
-         ask you to surrender the rights. These restrictions translate to certain responsibilities for you if
-         you distribute copies of the library, or if you modify it.</p>
-      <p>For example, if you distribute copies of the library, whether gratis or for a fee, you must give the
-         recipients all the rights that we gave you. You must make sure that they, too, receive or can get the
-         source code. If you link a program with the library, you must provide complete object files to the
-         recipients so that they can relink them with the library, after making changes to the library and
-         recompiling it. And you must show them these terms so they know their rights.</p>
-      <p>Our method of protecting your rights has two steps: (1) copyright the library, and (2) offer you this
-         license which gives you legal permission to copy, distribute and/or modify the library.</p>
-      <p>Also, for each distributor's protection, we want to make certain that everyone understands that
-         there is no warranty for this free library. If the library is modified by someone else and passed on,
-         we want its recipients to know that what they have is not the original version, so that any problems
-         introduced by others will not reflect on the original authors' reputations.</p>
-      <p>Finally, any free program is threatened constantly by software patents. We wish to avoid the danger that
-         companies distributing free software will individually obtain patent licenses, thus in effect
-         transforming the program into proprietary software. To prevent this, we have made it clear that any
-         patent must be licensed for everyone's free use or not licensed at all.</p>
-      <p>Most GNU software, including some libraries, is covered by the ordinary GNU General Public License, which
-         was designed for utility programs. This license, the GNU Library General Public License, applies to
-         certain designated libraries. This license is quite different from the ordinary one; be sure to read
-         it in full, and don't assume that anything in it is the same as in the ordinary license.</p>
-      <p>The reason we have a separate public license for some libraries is that they blur the distinction we
-         usually make between modifying or adding to a program and simply using it. Linking a program with a
-         library, without changing the library, is in some sense simply using the library, and is analogous to
-         running a utility program or application program. However, in a textual and legal sense, the linked
-         executable is a combined work, a derivative of the original library, and the ordinary General Public
-         License treats it as such.</p>
-      <p>Because of this blurred distinction, using the ordinary General Public License for libraries did not
-         effectively promote software sharing, because most developers did not use the libraries. We concluded
-         that weaker conditions might promote sharing better.</p>
-      <p>However, unrestricted linking of non-free programs would deprive the users of those programs of all
-         benefit from the free status of the libraries themselves. This Library General Public License is
-         intended to permit developers of non-free programs to use free libraries, while preserving your
-         freedom as a user of such programs to change the free libraries that are incorporated in them. (We
-         have not seen how to achieve this as regards changes in header files, but we have achieved it as
-         regards changes in the actual functions of the Library.) The hope is that this will lead to faster
-         development of free libraries.</p>
-      <p>The precise terms and conditions for copying, distribution and modification follow. Pay close attention
-         to the difference between a "work based on the library" and a "work that uses the
-         library". The former contains code derived from the library, while the latter only works together
-         with the library.</p>
-      <p>Note that it is possible for a library to be covered by the ordinary General Public License rather than
-         by this special one.</p>
-      <p>TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION</p>
-      <list>
-        <item>
-            <bullet>0.</bullet>
-          This License Agreement applies to any software library which contains a notice placed by the
-             copyright holder or other authorized party saying it may be distributed under the terms of
-             this Library General Public License (also called "this License"). Each licensee is
-             addressed as "you".
-          <p>A "library" means a collection of software functions and/or data prepared so as to be
-             conveniently linked with application programs (which use some of those functions and data) to
-             form executables.</p>
-            <p>The "Library", below, refers to any such software library or work which has been
-             distributed under these terms. A "work based on the Library" means either the
-             Library or any derivative work under copyright law: that is to say, a work containing the
-             Library or a portion of it, either verbatim or with modifications and/or translated
-             straightforwardly into another language. (Hereinafter, translation is included without
-             limitation in the term "modification".)</p>
-            <p>"Source code" for a work means the preferred form of the work for making modifications
-             to it. For a library, complete source code means all the source code for all modules it
-             contains, plus any associated interface definition files, plus the scripts used to control
-             compilation and installation of the library.</p>
-            <p>Activities other than copying, distribution and modification are not covered by this License;
-             they are outside its scope. The act of running a program using the Library is not restricted,
-             and output from such a program is covered only if its contents constitute a work based on the
-             Library (independent of the use of the Library in a tool for writing it). Whether that is true
-             depends on what the Library does and what the program that uses the Library does.</p>
-        </item>
-        <item>
-            <bullet>1.</bullet>
-          You may copy and distribute verbatim copies of the Library's complete source code as you
-             receive it, in any medium, provided that you conspicuously and appropriately publish on each
-             copy an appropriate copyright notice and disclaimer of warranty; keep intact all the notices
-             that refer to this License and to the absence of any warranty; and distribute a copy of this
-             License along with the Library.
-          <p>You may charge a fee for the physical act of transferring a copy, and you may at your option
-             offer warranty protection in exchange for a fee.</p>
-        </item>
-        <item>
-            <bullet>2.</bullet>
-          You may modify your copy or copies of the Library or any portion of it, thus forming a work based
-             on the Library, and copy and distribute such modifications or work under the terms of Section
-             1 above, provided that you also meet all of these conditions:
+      <p>
+        Version 2, June 1991
+      </p>
+    </titleText>
+    <copyrightText>
+      <p>
+        Copyright (C) 1991 Free Software Foundation, Inc.<br></br>
+        51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+      </p>
+    </copyrightText>
+    <p>
+      Everyone is permitted to copy and distribute verbatim copies
+      of this license document, but changing it is not allowed.
+    </p>
+    <p>
+      [This is the first released version of the library GPL. It is
+      numbered 2 because it goes with version 2 of the ordinary GPL.]
+    </p>
+    <p>
+      Preamble
+    </p>
+    <p>
+      The licenses for most software are designed to take away your
+      freedom to share and change it. By contrast, the GNU General Public
+      Licenses are intended to guarantee your freedom to share and change
+      free software--to make sure the software is free for all its users.
+    </p>
+    <p>
+      This license, the Library General Public License, applies
+      to some specially designated Free Software Foundation
+      software, and to any other libraries whose authors
+      decide to use it. You can use it for your libraries, too.
+    </p>
+    <p>
+      When we speak of free software, we are referring to freedom, not price.
+      Our General Public Licenses are designed to make sure that you have
+      the freedom to distribute copies of free software (and charge for
+      this service if you wish), that you receive source code or can get
+      it if you want it, that you can change the software or use pieces of
+      it in new free programs; and that you know you can do these things.
+    </p>
+    <p>
+      To protect your rights, we need to make restrictions that forbid
+      anyone to deny you these rights or to ask you to surrender the
+      rights. These restrictions translate to certain responsibilities for
+      you if you distribute copies of the library, or if you modify it.
+    </p>
+    <p>
+      For example, if you distribute copies of the library, whether gratis
+      or for a fee, you must give the recipients all the rights that we
+      gave you. You must make sure that they, too, receive or can get the
+      source code. If you link a program with the library, you must provide
+      complete object files to the recipients so that they can relink them
+      with the library, after making changes to the library and recompiling
+      it. And you must show them these terms so they know their rights.
+    </p>
+    <p>
+      Our method of protecting your rights has two steps: (1) copyright
+      the library, and (2) offer you this license which gives you
+      legal permission to copy, distribute and/or modify the library.
+    </p>
+    <p>
+      Also, for each distributor's protection, we want to make certain
+      that everyone understands that there is no warranty for this
+      free library. If the library is modified by someone else and
+      passed on, we want its recipients to know that what they have
+      is not the original version, so that any problems introduced by
+      others will not reflect on the original authors' reputations.
+    </p>
+    <p>
+      Finally, any free program is threatened constantly by software
+      patents. We wish to avoid the danger that companies distributing
+      free software will individually obtain patent licenses, thus
+      in effect transforming the program into proprietary software.
+      To prevent this, we have made it clear that any patent must
+      be licensed for everyone's free use or not licensed at all.
+    </p>
+    <p>
+      Most GNU software, including some libraries, is covered by the
+      ordinary GNU General Public License, which was designed for utility
+      programs. This license, the GNU Library General Public License,
+      applies to certain designated libraries. This license is quite
+      different from the ordinary one; be sure to read it in full, and don't
+      assume that anything in it is the same as in the ordinary license.
+    </p>
+    <p>
+      The reason we have a separate public license for some libraries is
+      that they blur the distinction we usually make between modifying
+      or adding to a program and simply using it. Linking a program with
+      a library, without changing the library, is in some sense simply
+      using the library, and is analogous to running a utility program
+      or application program. However, in a textual and legal sense, the
+      linked executable is a combined work, a derivative of the original
+      library, and the ordinary General Public License treats it as such.
+    </p>
+    <p>
+      Because of this blurred distinction, using the ordinary General
+      Public License for libraries did not effectively promote software
+      sharing, because most developers did not use the libraries. We
+      concluded that weaker conditions might promote sharing better.
+    </p>
+    <p>
+      However, unrestricted linking of non-free programs would deprive the
+      users of those programs of all benefit from the free status of the
+      libraries themselves. This Library General Public License is intended
+      to permit developers of non-free programs to use free libraries, while
+      preserving your freedom as a user of such programs to change the free
+      libraries that are incorporated in them. (We have not seen how to
+      achieve this as regards changes in header files, but we have achieved
+      it as regards changes in the actual functions of the Library.) The
+      hope is that this will lead to faster development of free libraries.
+    </p>
+    <p>
+      The precise terms and conditions for copying, distribution
+      and modification follow. Pay close attention to the difference
+      between a "work based on the library" and a "work that uses
+      the library". The former contains code derived from the
+      library, while the latter only works together with the library.
+    </p>
+    <p>
+      Note that it is possible for a library to be covered by the
+      ordinary General Public License rather than by this special one.
+    </p>
+    <p>
+      TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+    </p>
+    <list>
+      <item>
+        <bullet>0.</bullet>
+        This License Agreement applies to any software library
+        which contains a notice placed by the copyright holder or
+        other authorized party saying it may be distributed under
+        the terms of this Library General Public License (also
+        called "this License"). Each licensee is addressed as "you".
+        <p>
+          A "library" means a collection of software functions and/or data
+          prepared so as to be conveniently linked with application programs
+          (which use some of those functions and data) to form executables.
+        </p>
+        <p>
+          The "Library", below, refers to any such software library or work
+          which has been distributed under these terms. A "work based on
+          the Library" means either the Library or any derivative work under
+          copyright law: that is to say, a work containing the Library or a
+          portion of it, either verbatim or with modifications and/or translated
+          straightforwardly into another language. (Hereinafter, translation
+          is included without limitation in the term "modification".)
+        </p>
+        <p>
+          "Source code" for a work means the preferred form of the work
+          for making modifications to it. For a library, complete source
+          code means all the source code for all modules it contains,
+          plus any associated interface definition files, plus the scripts
+          used to control compilation and installation of the library.
+        </p>
+        <p>
+          Activities other than copying, distribution and modification are
+          not covered by this License; they are outside its scope. The act of
+          running a program using the Library is not restricted, and output
+          from such a program is covered only if its contents constitute a
+          work based on the Library (independent of the use of the Library
+          in a tool for writing it). Whether that is true depends on what
+          the Library does and what the program that uses the Library does.
+        </p>
+      </item>
+      <item>
+        <bullet>1.</bullet>
+        You may copy and distribute verbatim copies of the Library's complete
+        source code as you receive it, in any medium, provided that you
+        conspicuously and appropriately publish on each copy an appropriate
+        copyright notice and disclaimer of warranty; keep intact all the
+        notices that refer to this License and to the absence of any warranty;
+        and distribute a copy of this License along with the Library.
+        <p>
+          You may charge a fee for the physical act of
+          transferring a copy, and you may at your option
+          offer warranty protection in exchange for a fee.
+        </p>
+      </item>
+      <item>
+        <bullet>2.</bullet>
+        You may modify your copy or copies of the Library or any portion
+        of it, thus forming a work based on the Library, and copy and
+        distribute such modifications or work under the terms of Section
+        1 above, provided that you also meet all of these conditions:
         <list>
-               <item>
-                  <bullet>a)</bullet>
+          <item>
+            <bullet>a)</bullet>
             The modified work must itself be a software library.
           </item>
-               <item>
-                  <bullet>b)</bullet>
-            You must cause the files modified to carry prominent notices stating that you changed the
-               files and the date of any change.
+          <item>
+            <bullet>b)</bullet>
+            You must cause the files modified to carry prominent notices
+            stating that you changed the files and the date of any change.
           </item>
-               <item>
-                  <bullet>c)</bullet>
-            You must cause the whole of the work to be licensed at no charge to all third parties under
-               the terms of this License.
+          <item>
+            <bullet>c)</bullet>
+            You must cause the whole of the work to be licensed at no
+            charge to all third parties under the terms of this License.
           </item>
-               <item>
-                  <bullet>d)</bullet>
-            If a facility in the modified Library refers to a function or a table of data to be supplied
-               by an application program that uses the facility, other than as an argument passed when
-               the facility is invoked, then you must make a good faith effort to ensure that, in the
-               event an application does not supply such function or table, the facility still operates,
-               and performs whatever part of its purpose remains meaningful.
-            <p>(For example, a function in a library to compute square roots has a purpose that is entirely
-               well-defined independent of the application. Therefore, Subsection 2d requires that any
-               application-supplied function or table used by this function must be optional: if the
-               application does not supply it, the square root function must still compute square
-               roots.)</p>
-               </item>
-            </list>
-            <p>These requirements apply to the modified work as a whole. If identifiable sections of that
-               work are not derived from the Library, and can be reasonably considered independent and
-               separate works in themselves, then this License, and its terms, do not apply to those
-               sections when you distribute them as separate works. But when you distribute the same
-               sections as part of a whole which is a work based on the Library, the distribution of the
-               whole must be on the terms of this License, whose permissions for other licensees extend
-               to the entire whole, and thus to each and every part regardless of who wrote it.</p>
-            <p>Thus, it is not the intent of this section to claim rights or contest your rights to work
-               written entirely by you; rather, the intent is to exercise the right to control the
-               distribution of derivative or collective works based on the Library.</p>
-            <p>In addition, mere aggregation of another work not based on the Library with the Library (or
-               with a work based on the Library) on a volume of a storage or distribution medium does not
-               bring the other work under the scope of this License.</p>
-        </item>
-        <item>
-            <bullet>3.</bullet>
-          You may opt to apply the terms of the ordinary GNU General Public License instead of this License
-             to a given copy of the Library. To do this, you must alter all the notices that refer to this
-             License, so that they refer to the ordinary GNU General Public License, version 2, instead of
-             to this License. (If a newer version than version 2 of the ordinary GNU General Public License
-             has appeared, then you can specify that version instead if you wish.) Do not make any other
-             change in these notices.
-          <p>Once this change is made in a given copy, it is irreversible for that copy, so the ordinary GNU
-             General Public License applies to all subsequent copies and derivative works made from that
-             copy.</p>
-            <p>This option is useful when you wish to copy part of the code of the Library into a program that
-             is not a library.</p>
-        </item>
-        <item>
-            <bullet>4.</bullet>
-          You may copy and distribute the Library (or a portion or derivative of it, under Section 2) in
-             object code or executable form under the terms of Sections 1 and 2 above provided that you
-             accompany it with the complete corresponding machine-readable source code, which must be
-             distributed under the terms of Sections 1 and 2 above on a medium customarily used for
-             software interchange.
-          <p>If distribution of object code is made by offering access to copy from a designated place, then
-             offering equivalent access to copy the source code from the same place satisfies the
-             requirement to distribute the source code, even though third parties are not compelled to copy
-             the source along with the object code.</p>
-        </item>
-        <item>
-            <bullet>5.</bullet>
-          A program that contains no derivative of any portion of the Library, but is designed to work with
-             the Library by being compiled or linked with it, is called a "work that uses the
-             Library". Such a work, in isolation, is not a derivative work of the Library, and
-             therefore falls outside the scope of this License.
-          <p>However, linking a "work that uses the Library" with the Library creates an executable
-             that is a derivative of the Library (because it contains portions of the Library), rather than
-             a "work that uses the library". The executable is therefore covered by this License.
-             Section 6 states terms for distribution of such executables.</p>
-            <p>When a "work that uses the Library" uses material from a header file that is part of
-             the Library, the object code for the work may be a derivative work of the Library even though
-             the source code is not. Whether this is true is especially significant if the work can be
-             linked without the Library, or if the work is itself a library. The threshold for this to be
-             true is not precisely defined by law.</p>
-            <p>If such an object file uses only numerical parameters, data structure layouts and accessors, and
-             small macros and small inline functions (ten lines or less in length), then the use of the
-             object file is unrestricted, regardless of whether it is legally a derivative work.
-             (Executables containing this object code plus portions of the Library will still fall under
-             Section 6.)</p>
-            <p>Otherwise, if the work is a derivative of the Library, you may distribute the object code for the
-             work under the terms of Section 6. Any executables containing that work also fall under
-             Section 6, whether or not they are linked directly with the Library itself.</p>
-        </item>
-        <item>
-            <bullet>6.</bullet>
-          As an exception to the Sections above, you may also compile or link a "work that uses the
-             Library" with the Library to produce a work containing portions of the Library, and
-             distribute that work under terms of your choice, provided that the terms permit modification
-             of the work for the customer's own use and reverse engineering for debugging such
-             modifications.
-          <p>You must give prominent notice with each copy of the work that the Library is used in it and that
-             the Library and its use are covered by this License. You must supply a copy of this License.
-             If the work during execution displays copyright notices, you must include the copyright notice
-             for the Library among them, as well as a reference directing the user to the copy of this
-             License. Also, you must do one of these things:</p>
-            <list>
-               <item>
-                  <bullet>a)</bullet>
-            Accompany the work with the complete corresponding machine-readable source code for the
-               Library including whatever changes were used in the work (which must be distributed under
-               Sections 1 and 2 above); and, if the work is an executable linked with the Library, with
-               the complete machine-readable "work that uses the Library", as object code
-               and/or source code, so that the user can modify the Library and then relink to produce a
-               modified executable containing the modified Library. (It is understood that the user who
-               changes the contents of definitions files in the Library will not necessarily be able to
-               recompile the application to use the modified definitions.)
-          </item>
-               <item>
-                  <bullet>b)</bullet>
-            Accompany the work with a written offer, valid for at least three years, to give the same
-               user the materials specified in Subsection 6a, above, for a charge no more than the cost
-               of performing this distribution.
-          </item>
-               <item>
-                  <bullet>c)</bullet>
-            If distribution of the work is made by offering access to copy from a designated place, offer
-               equivalent access to copy the above specified materials from the same place.
-          </item>
-               <item>
-                  <bullet>d)</bullet>
-            Verify that the user has already received a copy of these materials or that you have already
-               sent this user a copy.
-          </item>
-            </list>
-            <p>For an executable, the required form of the "work that uses the Library" must
-               include any data and utility programs needed for reproducing the executable from it.
-               However, as a special exception, the source code distributed need not include anything
-               that is normally distributed (in either source or binary form) with the major components
-               (compiler, kernel, and so on) of the operating system on which the executable runs, unless
-               that component itself accompanies the executable.</p>
-            <p>It may happen that this requirement contradicts the license restrictions of other proprietary
-               libraries that do not normally accompany the operating system. Such a contradiction means
-               you cannot use both them and the Library together in an executable that you
-               distribute.</p>
-        </item>
-        <item>
-            <bullet>7.</bullet>
-          You may place library facilities that are a work based on the Library side-by-side in a single
-             library together with other library facilities not covered by this License, and distribute
-             such a combined library, provided that the separate distribution of the work based on the
-             Library and of the other library facilities is otherwise permitted, and provided that you do
-             these two things:
-        </item>
-        <list>
-            <item>
-               <bullet>a)</bullet>
-            Accompany the combined library with a copy of the same work based on the Library, uncombined
-               with any other library facilities. This must be distributed under the terms of the
-               Sections above.
-          </item>
-            <item>
-               <bullet>b)</bullet>
-            Give prominent notice with the combined library of the fact that part of it is a work based
-               on the Library, and explaining where to find the accompanying uncombined form of the same
-               work.
+          <item>
+            <bullet>d)</bullet>
+            If a facility in the modified Library refers to a function
+            or a table of data to be supplied by an application program
+            that uses the facility, other than as an argument passed
+            when the facility is invoked, then you must make a good faith
+            effort to ensure that, in the event an application does not
+            supply such function or table, the facility still operates,
+            and performs whatever part of its purpose remains meaningful.
+            <p>
+              (For example, a function in a library to compute square roots
+              has a purpose that is entirely well-defined independent of
+              the application. Therefore, Subsection 2d requires that any
+              application-supplied function or table used by this function
+              must be optional: if the application does not supply it,
+              the square root function must still compute square roots.)
+            </p>
           </item>
         </list>
+        <p>
+          These requirements apply to the modified work as a whole. If
+          identifiable sections of that work are not derived from the
+          Library, and can be reasonably considered independent and separate
+          works in themselves, then this License, and its terms, do not
+          apply to those sections when you distribute them as separate
+          works. But when you distribute the same sections as part of a
+          whole which is a work based on the Library, the distribution
+          of the whole must be on the terms of this License, whose
+          permissions for other licensees extend to the entire whole,
+          and thus to each and every part regardless of who wrote it.
+        </p>
+        <p>
+          Thus, it is not the intent of this section to claim rights or
+          contest your rights to work written entirely by you; rather,
+          the intent is to exercise the right to control the distribution
+          of derivative or collective works based on the Library.
+        </p>
+        <p>
+          In addition, mere aggregation of another work not based on
+          the Library with the Library (or with a work based on the
+          Library) on a volume of a storage or distribution medium does
+          not bring the other work under the scope of this License.
+        </p>
+      </item>
+      <item>
+        <bullet>3.</bullet>
+        You may opt to apply the terms of the ordinary GNU General
+        Public License instead of this License to a given copy of the
+        Library. To do this, you must alter all the notices that refer
+        to this License, so that they refer to the ordinary GNU General
+        Public License, version 2, instead of to this License. (If a
+        newer version than version 2 of the ordinary GNU General Public
+        License has appeared, then you can specify that version instead
+        if you wish.) Do not make any other change in these notices.
+        <p>
+          Once this change is made in a given copy, it is irreversible for
+          that copy, so the ordinary GNU General Public License applies to
+          all subsequent copies and derivative works made from that copy.
+        </p>
+        <p>
+          This option is useful when you wish to copy part of the
+          code of the Library into a program that is not a library.
+        </p>
+      </item>
+      <item>
+        <bullet>4.</bullet>
+        You may copy and distribute the Library (or a portion or derivative
+        of it, under Section 2) in object code or executable form under
+        the terms of Sections 1 and 2 above provided that you accompany
+        it with the complete corresponding machine-readable source code,
+        which must be distributed under the terms of Sections 1 and 2
+        above on a medium customarily used for software interchange.
+        <p>
+          If distribution of object code is made by offering access to copy
+          from a designated place, then offering equivalent access to copy
+          the source code from the same place satisfies the requirement
+          to distribute the source code, even though third parties are
+          not compelled to copy the source along with the object code.
+        </p>
+      </item>
+      <item>
+        <bullet>5.</bullet>
+        A program that contains no derivative of any portion of the
+        Library, but is designed to work with the Library by being compiled
+        or linked with it, is called a "work that uses the Library".
+        Such a work, in isolation, is not a derivative work of the
+        Library, and therefore falls outside the scope of this License.
+        <p>
+          However, linking a "work that uses the Library" with the Library
+          creates an executable that is a derivative of the Library (because
+          it contains portions of the Library), rather than a "work that uses
+          the library". The executable is therefore covered by this License.
+          Section 6 states terms for distribution of such executables.
+        </p>
+        <p>
+          When a "work that uses the Library" uses material from a header
+          file that is part of the Library, the object code for the work may
+          be a derivative work of the Library even though the source code is
+          not. Whether this is true is especially significant if the work can
+          be linked without the Library, or if the work is itself a library.
+          The threshold for this to be true is not precisely defined by law.
+        </p>
+        <p>
+          If such an object file uses only numerical parameters, data
+          structure layouts and accessors, and small macros and small inline
+          functions (ten lines or less in length), then the use of the
+          object file is unrestricted, regardless of whether it is legally
+          a derivative work. (Executables containing this object code
+          plus portions of the Library will still fall under Section 6.)
+        </p>
+        <p>
+          Otherwise, if the work is a derivative of the Library, you may
+          distribute the object code for the work under the terms of Section
+          6. Any executables containing that work also fall under Section 6,
+          whether or not they are linked directly with the Library itself.
+        </p>
+      </item>
+      <item>
+        <bullet>6.</bullet>
+        As an exception to the Sections above, you may also compile or
+        link a "work that uses the Library" with the Library to produce
+        a work containing portions of the Library, and distribute
+        that work under terms of your choice, provided that the terms
+        permit modification of the work for the customer's own use
+        and reverse engineering for debugging such modifications.
+        <p>
+          You must give prominent notice with each copy of the work
+          that the Library is used in it and that the Library and its
+          use are covered by this License. You must supply a copy of
+          this License. If the work during execution displays copyright
+          notices, you must include the copyright notice for the Library
+          among them, as well as a reference directing the user to the
+          copy of this License. Also, you must do one of these things:
+        </p>
+        <list>
+          <item>
+            <bullet>a)</bullet>
+            Accompany the work with the complete corresponding machine-readable
+            source code for the Library including whatever changes were used in
+            the work (which must be distributed under Sections 1 and 2 above);
+            and, if the work is an executable linked with the Library, with the
+            complete machine-readable "work that uses the Library", as object
+            code and/or source code, so that the user can modify the Library
+            and then relink to produce a modified executable containing the
+            modified Library. (It is understood that the user who changes the
+            contents of definitions files in the Library will not necessarily be
+            able to recompile the application to use the modified definitions.)
+          </item>
+          <item>
+            <bullet>b)</bullet>
+            Accompany the work with a written offer, valid for at
+            least three years, to give the same user the materials
+            specified in Subsection 6a, above, for a charge no
+            more than the cost of performing this distribution.
+          </item>
+          <item>
+            <bullet>c)</bullet>
+            If distribution of the work is made by offering access to
+            copy from a designated place, offer equivalent access to
+            copy the above specified materials from the same place.
+          </item>
+          <item>
+            <bullet>d)</bullet>
+            Verify that the user has already received a copy of these
+            materials or that you have already sent this user a copy.
+          </item>
+        </list>
+        <p>
+          For an executable, the required form of the "work that uses
+          the Library" must include any data and utility programs needed
+          for reproducing the executable from it. However, as a special
+          exception, the source code distributed need not include
+          anything that is normally distributed (in either source or
+          binary form) with the major components (compiler, kernel,
+          and so on) of the operating system on which the executable
+          runs, unless that component itself accompanies the executable.
+        </p>
+        <p>
+          It may happen that this requirement contradicts the
+          license restrictions of other proprietary libraries that
+          do not normally accompany the operating system. Such
+          a contradiction means you cannot use both them and the
+          Library together in an executable that you distribute.
+        </p>
+      </item>
+      <item>
+        <bullet>7.</bullet>
+        You may place library facilities that are a work based on the
+        Library side-by-side in a single library together with other library
+        facilities not covered by this License, and distribute such a
+        combined library, provided that the separate distribution of the
+        work based on the Library and of the other library facilities is
+        otherwise permitted, and provided that you do these two things:
+      </item>
+      <list>
         <item>
-            <bullet>8.</bullet>
-          You may not copy, modify, sublicense, link with, or distribute the Library except as expressly
-             provided under this License. Any attempt otherwise to copy, modify, sublicense, link with, or
-             distribute the Library is void, and will automatically terminate your rights under this
-             License. However, parties who have received copies, or rights, from you under this License
-             will not have their licenses terminated so long as such parties remain in full compliance.
+          <bullet>a)</bullet>
+          Accompany the combined library with a copy of the same work based
+          on the Library, uncombined with any other library facilities.
+          This must be distributed under the terms of the Sections above.
         </item>
         <item>
-            <bullet>9.</bullet>
-          You are not required to accept this License, since you have not signed it. However, nothing else
-             grants you permission to modify or distribute the Library or its derivative works. These
-             actions are prohibited by law if you do not accept this License. Therefore, by modifying or
-             distributing the Library (or any work based on the Library), you indicate your acceptance of
-             this License to do so, and all its terms and conditions for copying, distributing or modifying
-             the Library or works based on it.
-        </item>
-        <item>
-            <bullet>10.</bullet>
-          Each time you redistribute the Library (or any work based on the Library), the recipient
-             automatically receives a license from the original licensor to copy, distribute, link with or
-             modify the Library subject to these terms and conditions. You may not impose any further
-             restrictions on the recipients' exercise of the rights granted herein. You are not
-             responsible for enforcing compliance by third parties to this License.
-        </item>
-        <item>
-            <bullet>11.</bullet>
-          If, as a consequence of a court judgment or allegation of patent infringement or for any other
-             reason (not limited to patent issues), conditions are imposed on you (whether by court order,
-             agreement or otherwise) that contradict the conditions of this License, they do not excuse you
-             from the conditions of this License. If you cannot distribute so as to satisfy simultaneously
-             your obligations under this License and any other pertinent obligations, then as a consequence
-             you may not distribute the Library at all. For example, if a patent license would not permit
-             royalty-free redistribution of the Library by all those who receive copies directly or
-             indirectly through you, then the only way you could satisfy both it and this License would be
-             to refrain entirely from distribution of the Library.
-          <p>If any portion of this section is held invalid or unenforceable under any particular
-             circumstance, the balance of the section is intended to apply, and the section as a whole is
-             intended to apply in other circumstances.</p>
-            <p>It is not the purpose of this section to induce you to infringe any patents or other property
-             right claims or to contest validity of any such claims; this section has the sole purpose of
-             protecting the integrity of the free software distribution system which is implemented by
-             public license practices. Many people have made generous contributions to the wide range of
-             software distributed through that system in reliance on consistent application of that system;
-             it is up to the author/donor to decide if he or she is willing to distribute software through
-             any other system and a licensee cannot impose that choice.</p>
-            <p>This section is intended to make thoroughly clear what is believed to be a consequence of the
-             rest of this License.</p>
-        </item>
-        <item>
-            <bullet>12.</bullet>
-          If the distribution and/or use of the Library is restricted in certain countries either by
-             patents or by copyrighted interfaces, the original copyright holder who places the Library
-             under this License may add an explicit geographical distribution limitation excluding those
-             countries, so that distribution is permitted only in or among countries not thus excluded. In
-             such case, this License incorporates the limitation as if written in the body of this
-             License.
-        </item>
-        <item>
-            <bullet>13.</bullet>
-          The Free Software Foundation may publish revised and/or new versions of the Library General
-             Public License from time to time. Such new versions will be similar in spirit to the present
-             version, but may differ in detail to address new problems or concerns.
-          <p>Each version is given a distinguishing version number. If the Library specifies a version number
-             of this License which applies to it and "any later version", you have the option of
-             following the terms and conditions either of that version or of any later version published by
-             the Free Software Foundation. If the Library does not specify a license version number, you
-             may choose any version ever published by the Free Software Foundation.</p>
-        </item>
-        <item>
-            <bullet>14.</bullet>
-          If you wish to incorporate parts of the Library into other free programs whose distribution
-             conditions are incompatible with these, write to the author to ask for permission. For
-             software which is copyrighted by the Free Software Foundation, write to the Free Software
-             Foundation; we sometimes make exceptions for this. Our decision will be guided by the two
-             goals of preserving the free status of all derivatives of our free software and of promoting
-             the sharing and reuse of software generally.
-          <p>NO WARRANTY</p>
-        </item>
-        <item>
-            <bullet>15.</bullet>
-          BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY FOR THE LIBRARY, TO THE
-             EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
-             HOLDERS AND/OR OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
-             KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-             MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND
-             PERFORMANCE OF THE LIBRARY IS WITH YOU. SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME THE
-             COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
-        </item>
-        <item>
-            <bullet>16.</bullet>
-          IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY COPYRIGHT HOLDER,
-             OR ANY OTHER PARTY WHO MAY MODIFY AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE
-             LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES
-             ARISING OUT OF THE USE OR INABILITY TO USE THE LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF
-             DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
-             FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF SUCH HOLDER OR OTHER PARTY
-             HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+          <bullet>b)</bullet>
+          Give prominent notice with the combined library of the fact
+          that part of it is a work based on the Library, and explaining
+          where to find the accompanying uncombined form of the same work.
         </item>
       </list>
-      <optional>
-         <p>END OF TERMS AND CONDITIONS</p>
-         <p>How to Apply These Terms to Your New Libraries</p>
-         <p>If you develop a new library, and you want it to be of the greatest possible use to the public, we
-         recommend making it free software that everyone can redistribute and change. You can do so by
-         permitting redistribution under these terms (or, alternatively, under the terms of the ordinary
-         General Public License).</p>
-         <p>To apply these terms, attach the following notices to the library. It is safest to attach them to the
-         start of each source file to most effectively convey the exclusion of warranty; and each file should
-         have at least the "copyright" line and a pointer to where the full notice is found.</p>
-         <p>one line to give the library's name and an idea of what it does. 
-        <br/>Copyright (C) year name of author 
+      <item>
+        <bullet>8.</bullet>
+        You may not copy, modify, sublicense, link with, or distribute the
+        Library except as expressly provided under this License. Any attempt
+        otherwise to copy, modify, sublicense, link with, or distribute
+        the Library is void, and will automatically terminate your rights
+        under this License. However, parties who have received copies, or
+        rights, from you under this License will not have their licenses
+        terminated so long as such parties remain in full compliance.
+      </item>
+      <item>
+        <bullet>9.</bullet>
+        You are not required to accept this License, since you have
+        not signed it. However, nothing else grants you permission to
+        modify or distribute the Library or its derivative works. These
+        actions are prohibited by law if you do not accept this License.
+        Therefore, by modifying or distributing the Library (or any
+        work based on the Library), you indicate your acceptance of this
+        License to do so, and all its terms and conditions for copying,
+        distributing or modifying the Library or works based on it.
+      </item>
+      <item>
+        <bullet>10.</bullet>
+        Each time you redistribute the Library (or any work based on
+        the Library), the recipient automatically receives a license
+        from the original licensor to copy, distribute, link with or
+        modify the Library subject to these terms and conditions. You
+        may not impose any further restrictions on the recipients'
+        exercise of the rights granted herein. You are not responsible
+        for enforcing compliance by third parties to this License.
+      </item>
+      <item>
+        <bullet>11.</bullet>
+        If, as a consequence of a court judgment or allegation of patent
+        infringement or for any other reason (not limited to patent issues),
+        conditions are imposed on you (whether by court order, agreement
+        or otherwise) that contradict the conditions of this License,
+        they do not excuse you from the conditions of this License. If you
+        cannot distribute so as to satisfy simultaneously your obligations
+        under this License and any other pertinent obligations, then as a
+        consequence you may not distribute the Library at all. For example,
+        if a patent license would not permit royalty-free redistribution of
+        the Library by all those who receive copies directly or indirectly
+        through you, then the only way you could satisfy both it and this
+        License would be to refrain entirely from distribution of the Library.
+        <p>
+          If any portion of this section is held invalid or
+          unenforceable under any particular circumstance, the
+          balance of the section is intended to apply, and the section
+          as a whole is intended to apply in other circumstances.
+        </p>
+        <p>
+          It is not the purpose of this section to induce you to infringe
+          any patents or other property right claims or to contest
+          validity of any such claims; this section has the sole purpose
+          of protecting the integrity of the free software distribution
+          system which is implemented by public license practices. Many
+          people have made generous contributions to the wide range of
+          software distributed through that system in reliance on consistent
+          application of that system; it is up to the author/donor to
+          decide if he or she is willing to distribute software through
+          any other system and a licensee cannot impose that choice.
+        </p>
+        <p>
+          This section is intended to make thoroughly clear what is
+          believed to be a consequence of the rest of this License.
+        </p>
+      </item>
+      <item>
+        <bullet>12.</bullet>
+        If the distribution and/or use of the Library is restricted in
+        certain countries either by patents or by copyrighted interfaces,
+        the original copyright holder who places the Library under this
+        License may add an explicit geographical distribution limitation
+        excluding those countries, so that distribution is permitted only
+        in or among countries not thus excluded. In such case, this License
+        incorporates the limitation as if written in the body of this License.
+      </item>
+      <item>
+        <bullet>13.</bullet>
+        The Free Software Foundation may publish revised and/or new versions
+        of the Library General Public License from time to time. Such
+        new versions will be similar in spirit to the present version,
+        but may differ in detail to address new problems or concerns.
+        <p>
+          Each version is given a distinguishing version number. If
+          the Library specifies a version number of this License which
+          applies to it and "any later version", you have the option of
+          following the terms and conditions either of that version or of
+          any later version published by the Free Software Foundation. If
+          the Library does not specify a license version number, you may
+          choose any version ever published by the Free Software Foundation.
+        </p>
+      </item>
+      <item>
+        <bullet>14.</bullet>
+        If you wish to incorporate parts of the Library into other free programs
+        whose distribution conditions are incompatible with these, write to
+        the author to ask for permission. For software which is copyrighted by
+        the Free Software Foundation, write to the Free Software Foundation; we
+        sometimes make exceptions for this. Our decision will be guided by the
+        two goals of preserving the free status of all derivatives of our free
+        software and of promoting the sharing and reuse of software generally.
+        <p>
+          NO WARRANTY
+        </p>
+      </item>
+      <item>
+        <bullet>15.</bullet>
+        BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+        FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT
+        WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER
+        PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY KIND,
+        EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+        IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+        PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF
+        THE LIBRARY IS WITH YOU. SHOULD THE LIBRARY PROVE DEFECTIVE, YOU
+        ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+      </item>
+      <item>
+        <bullet>16.</bullet>
+        IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+        WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+        REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU FOR
+        DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL
+        DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE LIBRARY
+        (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED
+        INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF
+        THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF SUCH HOLDER
+        OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+      </item>
+    </list>
+    <optional>
+      <p>
+        END OF TERMS AND CONDITIONS
       </p>
-         <p>This library is free software; you can redistribute it and/or modify it under the terms of the GNU
-         Library General Public License as published by the Free Software Foundation; either version 2 of the
-         License, or (at your option) any later version.</p>
-         <p>This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
-         the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Library
-         General Public License for more details.</p>
-         <p>You should have received a copy of the GNU Library General Public License along with this library; if
-         not, write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301,
-         USA.</p>
-         <p>Also add information on how to contact you by electronic and paper mail.</p>
-         <p>You should also get your employer (if you work as a programmer) or your school, if any, to sign a
-         "copyright disclaimer" for the library, if necessary. Here is a sample; alter the names:</p>
-         <p>Yoyodyne, Inc., hereby disclaims all copyright interest in 
-        <br/>the library `Frob' (a library for tweaking knobs) written 
-        <br/>by James Random Hacker. 
+      <p>
+        How to Apply These Terms to Your New Libraries
       </p>
-         <p>signature of Ty Coon, 1 April 1990 
-        <br/>Ty Coon, President of Vice 
+      <p>
+        If you develop a new library, and you want it to be of the greatest
+        possible use to the public, we recommend making it free software
+        that everyone can redistribute and change. You can do so by
+        permitting redistribution under these terms (or, alternatively,
+        under the terms of the ordinary General Public License).
       </p>
-         <p>That's all there is to it!</p>
-      </optional>
+      <p>
+        To apply these terms, attach the following notices to the
+        library. It is safest to attach them to the start of each
+        source file to most effectively convey the exclusion of
+        warranty; and each file should have at least the "copyright"
+        line and a pointer to where the full notice is found.
+      </p>
+      <p>
+        one line to give the library's name
+        and an idea of what it does.<br></br>
+        Copyright (C) year name of author
+      </p>
+      <p>
+        This library is free software; you can redistribute it and/or
+        modify it under the terms of the GNU Library General Public
+        License as published by the Free Software Foundation; either
+        version 2 of the License, or (at your option) any later version.
+      </p>
+      <p>
+        This library is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty
+        of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+        the GNU Library General Public License for more details.
+      </p>
+      <p>
+        You should have received a copy of the GNU Library
+        General Public License along with this library; if
+        not, write to the Free Software Foundation, Inc., 51
+        Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
+      </p>
+      <p>
+        Also add information on how to contact you by electronic and paper mail.
+      </p>
+      <p>
+        You should also get your employer (if you work as a programmer)
+        or your school, if any, to sign a "copyright disclaimer" for
+        the library, if necessary. Here is a sample; alter the names:
+      </p>
+      <p>
+        Yoyodyne, Inc., hereby disclaims all copyright interest in<br></br>
+        the library `Frob' (a library for tweaking knobs) written<br></br>
+        by James Random Hacker.
+      </p>
+      <p>
+        signature of Ty Coon, 1 April 1990<br></br>
+        Ty Coon, President of Vice
+      </p>
+      <p>
+        That's all there is to it!
+      </p>
+    </optional>
   </license>
 </SPDXLicenseCollection>

--- a/src/LGPL-2.1-only.xml
+++ b/src/LGPL-2.1-only.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-  <license licenseId="LGPL-2.1" isOsiApproved="true"
+  <license licenseId="LGPL-2.1-only" isOsiApproved="true"
   name="GNU Lesser General Public License v2.1 only">
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</crossRef>

--- a/src/LGPL-2.1-only.xml
+++ b/src/LGPL-2.1-only.xml
@@ -1,0 +1,659 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SPDXLicenseCollection xmlns="http://www.spdx.org/license">
+  <license licenseId="LGPL-2.1" isOsiApproved="true"
+  name="GNU Lesser General Public License v2.1 only">
+    <crossRefs>
+      <crossRef>http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</crossRef>
+      <crossRef>http://www.opensource.org/licenses/LGPL-2.1</crossRef>
+    </crossRefs>
+    <standardLicenseHeader>
+      Copyright (C)<alt name="copyright" match=".+">year name of author</alt>
+      <p>
+        This library is free software; you can redistribute it and/or
+        modify it under the terms of the GNU Lesser General Public
+        License as published by the Free Software Foundation; version 2.1.
+      </p>
+      <p>
+        This library is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty
+        of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+        See the GNU Lesser General Public License for more details.
+      </p>
+      <p>
+        You should have received a copy of the GNU Lesser General Public License
+        along with this library; if not, write to the Free Software Foundation,
+        Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+      </p>
+    </standardLicenseHeader>
+    <notes>
+      This license was released: February 1999. This refers to when
+      this LGPL 2.1 only is being used (as opposed to "or later).
+    </notes>
+    <titleText>
+      <p>
+        GNU LESSER GENERAL PUBLIC LICENSE
+      </p>
+      <p>
+        Version 2.1, February 1999
+      </p>
+    </titleText>
+    <p>
+      Copyright (C) 1991, 1999 Free Software Foundation, Inc.<br></br>
+      51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+    </p>
+    <p>
+      Everyone is permitted to copy and distribute verbatim copies
+      of this license document, but changing it is not allowed.
+    </p>
+    <p>
+      [This is the first released version of the Lesser GPL.
+      It also counts as the successor of the GNU Library
+      Public License, version 2, hence the version number 2.1.]
+    </p>
+    <p>
+      Preamble
+    </p>
+    <p>
+      The licenses for most software are designed to take away your
+      freedom to share and change it. By contrast, the GNU General Public
+      Licenses are intended to guarantee your freedom to share and change
+      free software--to make sure the software is free for all its users.
+    </p>
+    <p>
+      This license, the Lesser General Public License, applies to some
+      specially designated software packages--typically libraries--of the
+      Free Software Foundation and other authors who decide to use it. You
+      can use it too, but we suggest you first think carefully about whether
+      this license or the ordinary General Public License is the better
+      strategy to use in any particular case, based on the explanations below.
+    </p>
+    <p>
+      When we speak of free software, we are referring to freedom of use, not
+      price. Our General Public Licenses are designed to make sure that you
+      have the freedom to distribute copies of free software (and charge for
+      this service if you wish); that you receive source code or can get it if
+      you want it; that you can change the software and use pieces of it in new
+      free programs; and that you are informed that you can do these things.
+    </p>
+    <p>
+      To protect your rights, we need to make restrictions that forbid
+      distributors to deny you these rights or to ask you to surrender
+      these rights. These restrictions translate to certain responsibilities
+      for you if you distribute copies of the library or if you modify it.
+    </p>
+    <p>
+      For example, if you distribute copies of the library, whether gratis
+      or for a fee, you must give the recipients all the rights that we
+      gave you. You must make sure that they, too, receive or can get the
+      source code. If you link other code with the library, you must provide
+      complete object files to the recipients, so that they can relink them
+      with the library after making changes to the library and recompiling
+      it. And you must show them these terms so they know their rights.
+    </p>
+    <p>
+      We protect your rights with a two-step method: (1) we copyright
+      the library, and (2) we offer you this license, which gives you
+      legal permission to copy, distribute and/or modify the library.
+    </p>
+    <p>
+      To protect each distributor, we want to make it very clear that there
+      is no warranty for the free library. Also, if the library is modified
+      by someone else and passed on, the recipients should know that what they
+      have is not the original version, so that the original author's reputation
+      will not be affected by problems that might be introduced by others.
+    </p>
+    <p>
+      Finally, software patents pose a constant threat to the existence
+      of any free program. We wish to make sure that a company cannot
+      effectively restrict the users of a free program by obtaining a
+      restrictive license from a patent holder. Therefore, we insist that
+      any patent license obtained for a version of the library must be
+      consistent with the full freedom of use specified in this license.
+    </p>
+    <p>
+      Most GNU software, including some libraries, is covered by
+      the ordinary GNU General Public License. This license, the GNU
+      Lesser General Public License, applies to certain designated
+      libraries, and is quite different from the ordinary General
+      Public License. We use this license for certain libraries in
+      order to permit linking those libraries into non-free programs.
+    </p>
+    <p>
+      When a program is linked with a library, whether statically or using
+      a shared library, the combination of the two is legally speaking a
+      combined work, a derivative of the original library. The ordinary
+      General Public License therefore permits such linking only if the entire
+      combination fits its criteria of freedom. The Lesser General Public
+      License permits more lax criteria for linking other code with the library.
+    </p>
+    <p>
+      We call this license the "Lesser" General Public License
+      because it does Less to protect the user's freedom than the
+      ordinary General Public License. It also provides other free
+      software developers Less of an advantage over competing non-free
+      programs. These disadvantages are the reason we use the ordinary
+      General Public License for many libraries. However, the Lesser
+      license provides advantages in certain special circumstances.
+    </p>
+    <p>
+      For example, on rare occasions, there may be a special need to
+      encourage the widest possible use of a certain library, so that
+      it becomes a de-facto standard. To achieve this, non-free programs
+      must be allowed to use the library. A more frequent case is that a
+      free library does the same job as widely used non-free libraries.
+      In this case, there is little to gain by limiting the free library
+      to free software only, so we use the Lesser General Public License.
+    </p>
+    <p>
+      In other cases, permission to use a particular library in non-free
+      programs enables a greater number of people to use a large body of free
+      software. For example, permission to use the GNU C Library in non-free
+      programs enables many more people to use the whole GNU operating
+      system, as well as its variant, the GNU/Linux operating system.
+    </p>
+    <p>
+      Although the Lesser General Public License is Less protective of
+      the users' freedom, it does ensure that the user of a program that
+      is linked with the Library has the freedom and the wherewithal
+      to run that program using a modified version of the Library.
+    </p>
+    <p>
+      The precise terms and conditions for copying, distribution and
+      modification follow. Pay close attention to the difference between
+      a "work based on the library" and a "work that uses the library".
+      The former contains code derived from the library, whereas
+      the latter must be combined with the library in order to run.
+    </p>
+    <p>
+      TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+    </p>
+    <list>
+      <item>
+        <bullet>0.</bullet>
+        This License Agreement applies to any software library or
+        other program which contains a notice placed by the copyright
+        holder or other authorized party saying it may be distributed
+        under the terms of this Lesser General Public License (also
+        called "this License"). Each licensee is addressed as "you".
+        <p>
+          A "library" means a collection of software functions and/or data
+          prepared so as to be conveniently linked with application programs
+          (which use some of those functions and data) to form executables.
+        </p>
+        <p>
+          The "Library", below, refers to any such software library or work
+          which has been distributed under these terms. A "work based on
+          the Library" means either the Library or any derivative work under
+          copyright law: that is to say, a work containing the Library or a
+          portion of it, either verbatim or with modifications and/or translated
+          straightforwardly into another language. (Hereinafter, translation
+          is included without limitation in the term "modification".)
+        </p>
+        <p>
+          "Source code" for a work means the preferred form of the work
+          for making modifications to it. For a library, complete source
+          code means all the source code for all modules it contains,
+          plus any associated interface definition files, plus the scripts
+          used to control compilation and installation of the library.
+        </p>
+        <p>
+          Activities other than copying, distribution and modification are
+          not covered by this License; they are outside its scope. The act of
+          running a program using the Library is not restricted, and output
+          from such a program is covered only if its contents constitute a
+          work based on the Library (independent of the use of the Library
+          in a tool for writing it). Whether that is true depends on what
+          the Library does and what the program that uses the Library does.
+        </p>
+      </item>
+      <item>
+        <bullet>1.</bullet>
+        You may copy and distribute verbatim copies of the Library's complete
+        source code as you receive it, in any medium, provided that you
+        conspicuously and appropriately publish on each copy an appropriate
+        copyright notice and disclaimer of warranty; keep intact all the
+        notices that refer to this License and to the absence of any warranty;
+        and distribute a copy of this License along with the Library.
+        <p>
+          You may charge a fee for the physical act of
+          transferring a copy, and you may at your option
+          offer warranty protection in exchange for a fee.
+        </p>
+      </item>
+      <item>
+        <bullet>2.</bullet>
+        You may modify your copy or copies of the Library or any portion
+        of it, thus forming a work based on the Library, and copy and
+        distribute such modifications or work under the terms of Section
+        1 above, provided that you also meet all of these conditions:
+        <list>
+          <item>
+            <bullet>a)</bullet>
+            The modified work must itself be a software library.
+          </item>
+          <item>
+            <bullet>b)</bullet>
+            You must cause the files modified to carry prominent notices
+            stating that you changed the files and the date of any change.
+          </item>
+          <item>
+            <bullet>c)</bullet>
+            You must cause the whole of the work to be licensed at no
+            charge to all third parties under the terms of this License.
+          </item>
+          <item>
+            <bullet>d)</bullet>
+            If a facility in the modified Library refers to a function
+            or a table of data to be supplied by an application program
+            that uses the facility, other than as an argument passed
+            when the facility is invoked, then you must make a good faith
+            effort to ensure that, in the event an application does not
+            supply such function or table, the facility still operates,
+            and performs whatever part of its purpose remains meaningful.
+          </item>
+        </list>
+        <p>
+          (For example, a function in a library to compute square roots
+          has a purpose that is entirely well-defined independent of
+          the application. Therefore, Subsection 2d requires that any
+          application-supplied function or table used by this function
+          must be optional: if the application does not supply it,
+          the square root function must still compute square roots.)
+        </p>
+        <p>
+          These requirements apply to the modified work as a whole. If
+          identifiable sections of that work are not derived from the
+          Library, and can be reasonably considered independent and separate
+          works in themselves, then this License, and its terms, do not
+          apply to those sections when you distribute them as separate
+          works. But when you distribute the same sections as part of a
+          whole which is a work based on the Library, the distribution
+          of the whole must be on the terms of this License, whose
+          permissions for other licensees extend to the entire whole,
+          and thus to each and every part regardless of who wrote it.
+        </p>
+        <p>
+          Thus, it is not the intent of this section to claim rights or
+          contest your rights to work written entirely by you; rather,
+          the intent is to exercise the right to control the distribution
+          of derivative or collective works based on the Library.
+        </p>
+        <p>
+          In addition, mere aggregation of another work not based on
+          the Library with the Library (or with a work based on the
+          Library) on a volume of a storage or distribution medium does
+          not bring the other work under the scope of this License.
+        </p>
+      </item>
+      <item>
+        <bullet>3.</bullet>
+        You may opt to apply the terms of the ordinary GNU General
+        Public License instead of this License to a given copy of the
+        Library. To do this, you must alter all the notices that refer
+        to this License, so that they refer to the ordinary GNU General
+        Public License, version 2, instead of to this License. (If a
+        newer version than version 2 of the ordinary GNU General Public
+        License has appeared, then you can specify that version instead
+        if you wish.) Do not make any other change in these notices.
+        <p>
+          Once this change is made in a given copy, it is irreversible for
+          that copy, so the ordinary GNU General Public License applies to
+          all subsequent copies and derivative works made from that copy.
+        </p>
+        <p>
+          This option is useful when you wish to copy part of the
+          code of the Library into a program that is not a library.
+        </p>
+      </item>
+      <item>
+        <bullet>4.</bullet>
+        You may copy and distribute the Library (or a portion or derivative
+        of it, under Section 2) in object code or executable form under
+        the terms of Sections 1 and 2 above provided that you accompany
+        it with the complete corresponding machine-readable source code,
+        which must be distributed under the terms of Sections 1 and 2
+        above on a medium customarily used for software interchange.
+        <p>
+          If distribution of object code is made by offering access to copy
+          from a designated place, then offering equivalent access to copy
+          the source code from the same place satisfies the requirement
+          to distribute the source code, even though third parties are
+          not compelled to copy the source along with the object code.
+        </p>
+      </item>
+      <item>
+        <bullet>5.</bullet>
+        A program that contains no derivative of any portion of the
+        Library, but is designed to work with the Library by being compiled
+        or linked with it, is called a "work that uses the Library".
+        Such a work, in isolation, is not a derivative work of the
+        Library, and therefore falls outside the scope of this License.
+        <p>
+          However, linking a "work that uses the Library" with the Library
+          creates an executable that is a derivative of the Library (because
+          it contains portions of the Library), rather than a "work that uses
+          the library". The executable is therefore covered by this License.
+          Section 6 states terms for distribution of such executables.
+        </p>
+        <p>
+          When a "work that uses the Library" uses material from a header
+          file that is part of the Library, the object code for the work may
+          be a derivative work of the Library even though the source code is
+          not. Whether this is true is especially significant if the work can
+          be linked without the Library, or if the work is itself a library.
+          The threshold for this to be true is not precisely defined by law.
+        </p>
+        <p>
+          If such an object file uses only numerical parameters, data
+          structure layouts and accessors, and small macros and small inline
+          functions (ten lines or less in length), then the use of the
+          object file is unrestricted, regardless of whether it is legally
+          a derivative work. (Executables containing this object code
+          plus portions of the Library will still fall under Section 6.)
+        </p>
+        <p>
+          Otherwise, if the work is a derivative of the Library, you may
+          distribute the object code for the work under the terms of Section
+          6. Any executables containing that work also fall under Section 6,
+          whether or not they are linked directly with the Library itself.
+        </p>
+      </item>
+      <item>
+        <bullet>6.</bullet>
+        As an exception to the Sections above, you may also combine or
+        link a "work that uses the Library" with the Library to produce
+        a work containing portions of the Library, and distribute
+        that work under terms of your choice, provided that the terms
+        permit modification of the work for the customer's own use
+        and reverse engineering for debugging such modifications.
+        <p>
+          You must give prominent notice with each copy of the work
+          that the Library is used in it and that the Library and its
+          use are covered by this License. You must supply a copy of
+          this License. If the work during execution displays copyright
+          notices, you must include the copyright notice for the Library
+          among them, as well as a reference directing the user to the
+          copy of this License. Also, you must do one of these things:
+        </p>
+        <list>
+          <item>
+            <bullet>a)</bullet>
+            Accompany the work with the complete corresponding machine-readable
+            source code for the Library including whatever changes were used in
+            the work (which must be distributed under Sections 1 and 2 above);
+            and, if the work is an executable linked with the Library, with the
+            complete machine-readable "work that uses the Library", as object
+            code and/or source code, so that the user can modify the Library
+            and then relink to produce a modified executable containing the
+            modified Library. (It is understood that the user who changes the
+            contents of definitions files in the Library will not necessarily be
+            able to recompile the application to use the modified definitions.)
+          </item>
+          <item>
+            <bullet>b)</bullet>
+            Use a suitable shared library mechanism for linking with the
+            Library. A suitable mechanism is one that (1) uses at run time a
+            copy of the library already present on the user's computer system,
+            rather than copying library functions into the executable, and
+            (2) will operate properly with a modified version of the library,
+            if the user installs one, as long as the modified version is
+            interface-compatible with the version that the work was made with.
+          </item>
+          <item>
+            <bullet>c)</bullet>
+            Accompany the work with a written offer, valid for at
+            least three years, to give the same user the materials
+            specified in Subsection 6a, above, for a charge no
+            more than the cost of performing this distribution.
+          </item>
+          <item>
+            <bullet>d)</bullet>
+            If distribution of the work is made by offering access to
+            copy from a designated place, offer equivalent access to
+            copy the above specified materials from the same place.
+          </item>
+          <item>
+            <bullet>e)</bullet>
+            Verify that the user has already received a copy of these
+            materials or that you have already sent this user a copy.
+          </item>
+        </list>
+        <p>
+          For an executable, the required form of the "work that uses
+          the Library" must include any data and utility programs needed
+          for reproducing the executable from it. However, as a special
+          exception, the materials to be distributed need not include
+          anything that is normally distributed (in either source or
+          binary form) with the major components (compiler, kernel,
+          and so on) of the operating system on which the executable
+          runs, unless that component itself accompanies the executable.
+        </p>
+        <p>
+          It may happen that this requirement contradicts the
+          license restrictions of other proprietary libraries that
+          do not normally accompany the operating system. Such
+          a contradiction means you cannot use both them and the
+          Library together in an executable that you distribute.
+        </p>
+      </item>
+      <item>
+        <bullet>7.</bullet>
+        You may place library facilities that are a work based on the
+        Library side-by-side in a single library together with other library
+        facilities not covered by this License, and distribute such a
+        combined library, provided that the separate distribution of the
+        work based on the Library and of the other library facilities is
+        otherwise permitted, and provided that you do these two things:
+        <list>
+          <item>
+            <bullet>a)</bullet>
+            Accompany the combined library with a copy of the same work based
+            on the Library, uncombined with any other library facilities.
+            This must be distributed under the terms of the Sections above.
+          </item>
+          <item>
+            <bullet>b)</bullet>
+            Give prominent notice with the combined library of the fact
+            that part of it is a work based on the Library, and explaining
+            where to find the accompanying uncombined form of the same work.
+          </item>
+        </list>
+      </item>
+      <item>
+        <bullet>8.</bullet>
+        You may not copy, modify, sublicense, link with, or distribute the
+        Library except as expressly provided under this License. Any attempt
+        otherwise to copy, modify, sublicense, link with, or distribute
+        the Library is void, and will automatically terminate your rights
+        under this License. However, parties who have received copies, or
+        rights, from you under this License will not have their licenses
+        terminated so long as such parties remain in full compliance.
+      </item>
+      <item>
+        <bullet>9.</bullet>
+        You are not required to accept this License, since you have
+        not signed it. However, nothing else grants you permission to
+        modify or distribute the Library or its derivative works. These
+        actions are prohibited by law if you do not accept this License.
+        Therefore, by modifying or distributing the Library (or any
+        work based on the Library), you indicate your acceptance of this
+        License to do so, and all its terms and conditions for copying,
+        distributing or modifying the Library or works based on it.
+      </item>
+      <item>
+        <bullet>10.</bullet>
+        Each time you redistribute the Library (or any work based on
+        the Library), the recipient automatically receives a license
+        from the original licensor to copy, distribute, link with or
+        modify the Library subject to these terms and conditions. You
+        may not impose any further restrictions on the recipients'
+        exercise of the rights granted herein. You are not responsible
+        for enforcing compliance by third parties with this License.
+      </item>
+      <item>
+        <bullet>11.</bullet>
+        If, as a consequence of a court judgment or allegation of patent
+        infringement or for any other reason (not limited to patent issues),
+        conditions are imposed on you (whether by court order, agreement
+        or otherwise) that contradict the conditions of this License,
+        they do not excuse you from the conditions of this License. If you
+        cannot distribute so as to satisfy simultaneously your obligations
+        under this License and any other pertinent obligations, then as a
+        consequence you may not distribute the Library at all. For example,
+        if a patent license would not permit royalty-free redistribution of
+        the Library by all those who receive copies directly or indirectly
+        through you, then the only way you could satisfy both it and this
+        License would be to refrain entirely from distribution of the Library.
+        <p>
+          If any portion of this section is held invalid or
+          unenforceable under any particular circumstance, the
+          balance of the section is intended to apply, and the section
+          as a whole is intended to apply in other circumstances.
+        </p>
+        <p>
+          It is not the purpose of this section to induce you to infringe
+          any patents or other property right claims or to contest
+          validity of any such claims; this section has the sole purpose
+          of protecting the integrity of the free software distribution
+          system which is implemented by public license practices. Many
+          people have made generous contributions to the wide range of
+          software distributed through that system in reliance on consistent
+          application of that system; it is up to the author/donor to
+          decide if he or she is willing to distribute software through
+          any other system and a licensee cannot impose that choice.
+        </p>
+        <p>
+          This section is intended to make thoroughly clear what is
+          believed to be a consequence of the rest of this License.
+        </p>
+      </item>
+      <item>
+        <bullet>12.</bullet>
+        If the distribution and/or use of the Library is restricted in
+        certain countries either by patents or by copyrighted interfaces,
+        the original copyright holder who places the Library under this
+        License may add an explicit geographical distribution limitation
+        excluding those countries, so that distribution is permitted only
+        in or among countries not thus excluded. In such case, this License
+        incorporates the limitation as if written in the body of this License.
+      </item>
+      <item>
+        <bullet>13.</bullet>
+        The Free Software Foundation may publish revised and/or new
+        versions of the Lesser General Public License from time to time.
+        Such new versions will be similar in spirit to the present version,
+        but may differ in detail to address new problems or concerns.
+        <p>
+          Each version is given a distinguishing version number. If
+          the Library specifies a version number of this License which
+          applies to it and "any later version", you have the option of
+          following the terms and conditions either of that version or of
+          any later version published by the Free Software Foundation. If
+          the Library does not specify a license version number, you may
+          choose any version ever published by the Free Software Foundation.
+        </p>
+      </item>
+      <item>
+        <bullet>14.</bullet>
+        If you wish to incorporate parts of the Library into other free programs
+        whose distribution conditions are incompatible with these, write to
+        the author to ask for permission. For software which is copyrighted by
+        the Free Software Foundation, write to the Free Software Foundation; we
+        sometimes make exceptions for this. Our decision will be guided by the
+        two goals of preserving the free status of all derivatives of our free
+        software and of promoting the sharing and reuse of software generally.
+        <p>
+          NO WARRANTY
+        </p>
+      </item>
+      <item>
+        <bullet>15.</bullet>
+        BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+        FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT
+        WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER
+        PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY KIND,
+        EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+        IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+        PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF
+        THE LIBRARY IS WITH YOU. SHOULD THE LIBRARY PROVE DEFECTIVE, YOU
+        ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+      </item>
+      <item>
+        <bullet>16.</bullet>
+        IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+        WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+        REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU FOR
+        DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL
+        DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE LIBRARY
+        (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED
+        INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF
+        THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF SUCH HOLDER
+        OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+      </item>
+    </list>
+    <optional>
+      <p>
+        END OF TERMS AND CONDITIONS
+      </p>
+      <p>
+        How to Apply These Terms to Your New Libraries
+      </p>
+      <p>
+        If you develop a new library, and you want it to be of the greatest
+        possible use to the public, we recommend making it free software
+        that everyone can redistribute and change. You can do so by
+        permitting redistribution under these terms (or, alternatively,
+        under the terms of the ordinary General Public License).
+      </p>
+      <p>
+        To apply these terms, attach the following notices to the
+        library. It is safest to attach them to the start of each
+        source file to most effectively convey the exclusion of
+        warranty; and each file should have at least the "copyright"
+        line and a pointer to where the full notice is found.
+      </p>
+      <p>
+	<optional>&lt;</optional>one line to give the library's name
+	and an idea of what it does.<optional>&gt;</optional>
+        <br></br>
+        Copyright (C)
+        <optional>&lt;</optional>year<optional>&gt;</optional>
+        <optional>&lt;</optional>name of author<optional>&gt;</optional>
+      </p>
+      <p>
+        This library is free software; you can redistribute it and/or
+        modify it under the terms of the GNU Lesser General Public
+        License as published by the Free Software Foundation; either
+        version 2.1 of the License, or (at your option) any later version.
+      </p>
+      <p>
+        This library is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty
+        of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+        See the GNU Lesser General Public License for more details.
+      </p>
+      <p>
+        You should have received a copy of the GNU Lesser General Public License
+        along with this library; if not, write to the Free Software Foundation,
+        Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA Also
+        add information on how to contact you by electronic and paper mail.
+      </p>
+      <p>
+        You should also get your employer (if you work as a programmer)
+        or your school, if any, to sign a "copyright disclaimer" for
+        the library, if necessary. Here is a sample; alter the names:
+      </p>
+      <p>
+        Yoyodyne, Inc., hereby disclaims all copyright interest in<br></br>
+        the library `Frob' (a library for tweaking knobs) written<br></br>
+        by James Random Hacker.
+      </p>
+      <p>
+	<optional>&lt;</optional>signature of Ty Coon<optional>&gt;</optional>,
+	1 April 1990<br></br>
+        Ty Coon, President of Vice<br></br>
+        That's all there is to it!
+      </p>
+    </optional>
+  </license>
+</SPDXLicenseCollection>

--- a/src/LGPL-2.1-or-later.xml
+++ b/src/LGPL-2.1-or-later.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-  <license licenseId="LGPL-2.1" isOsiApproved="true"
-  name="GNU Lesser General Public License v2.1 only">
+  <license licenseId="LGPL-2.1-or-later" isOsiApproved="true"
+  name="GNU Lesser General Public License v2.1 or later">
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</crossRef>
       <crossRef>http://www.opensource.org/licenses/LGPL-2.1</crossRef>

--- a/src/LGPL-2.1-or-later.xml
+++ b/src/LGPL-2.1-or-later.xml
@@ -11,7 +11,8 @@
       <p>
         This library is free software; you can redistribute it and/or
         modify it under the terms of the GNU Lesser General Public
-        License as published by the Free Software Foundation; version 2.1.
+        License as published by the Free Software Foundation; version 2.1
+	or any later version.
       </p>
       <p>
         This library is distributed in the hope that it will be useful,
@@ -26,8 +27,7 @@
       </p>
     </standardLicenseHeader>
     <notes>
-      This license was released: February 1999. This refers to when
-      this LGPL 2.1 only is being used (as opposed to "or later).
+      This license was released: February 1999.
     </notes>
     <titleText>
       <p>

--- a/src/LGPL-2.1-or-later.xml
+++ b/src/LGPL-2.1-or-later.xml
@@ -1,0 +1,659 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SPDXLicenseCollection xmlns="http://www.spdx.org/license">
+  <license licenseId="LGPL-2.1" isOsiApproved="true"
+  name="GNU Lesser General Public License v2.1 only">
+    <crossRefs>
+      <crossRef>http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</crossRef>
+      <crossRef>http://www.opensource.org/licenses/LGPL-2.1</crossRef>
+    </crossRefs>
+    <standardLicenseHeader>
+      Copyright (C)<alt name="copyright" match=".+">year name of author</alt>
+      <p>
+        This library is free software; you can redistribute it and/or
+        modify it under the terms of the GNU Lesser General Public
+        License as published by the Free Software Foundation; version 2.1.
+      </p>
+      <p>
+        This library is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty
+        of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+        See the GNU Lesser General Public License for more details.
+      </p>
+      <p>
+        You should have received a copy of the GNU Lesser General Public License
+        along with this library; if not, write to the Free Software Foundation,
+        Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+      </p>
+    </standardLicenseHeader>
+    <notes>
+      This license was released: February 1999. This refers to when
+      this LGPL 2.1 only is being used (as opposed to "or later).
+    </notes>
+    <titleText>
+      <p>
+        GNU LESSER GENERAL PUBLIC LICENSE
+      </p>
+      <p>
+        Version 2.1, February 1999
+      </p>
+    </titleText>
+    <p>
+      Copyright (C) 1991, 1999 Free Software Foundation, Inc.<br></br>
+      51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+    </p>
+    <p>
+      Everyone is permitted to copy and distribute verbatim copies
+      of this license document, but changing it is not allowed.
+    </p>
+    <p>
+      [This is the first released version of the Lesser GPL.
+      It also counts as the successor of the GNU Library
+      Public License, version 2, hence the version number 2.1.]
+    </p>
+    <p>
+      Preamble
+    </p>
+    <p>
+      The licenses for most software are designed to take away your
+      freedom to share and change it. By contrast, the GNU General Public
+      Licenses are intended to guarantee your freedom to share and change
+      free software--to make sure the software is free for all its users.
+    </p>
+    <p>
+      This license, the Lesser General Public License, applies to some
+      specially designated software packages--typically libraries--of the
+      Free Software Foundation and other authors who decide to use it. You
+      can use it too, but we suggest you first think carefully about whether
+      this license or the ordinary General Public License is the better
+      strategy to use in any particular case, based on the explanations below.
+    </p>
+    <p>
+      When we speak of free software, we are referring to freedom of use, not
+      price. Our General Public Licenses are designed to make sure that you
+      have the freedom to distribute copies of free software (and charge for
+      this service if you wish); that you receive source code or can get it if
+      you want it; that you can change the software and use pieces of it in new
+      free programs; and that you are informed that you can do these things.
+    </p>
+    <p>
+      To protect your rights, we need to make restrictions that forbid
+      distributors to deny you these rights or to ask you to surrender
+      these rights. These restrictions translate to certain responsibilities
+      for you if you distribute copies of the library or if you modify it.
+    </p>
+    <p>
+      For example, if you distribute copies of the library, whether gratis
+      or for a fee, you must give the recipients all the rights that we
+      gave you. You must make sure that they, too, receive or can get the
+      source code. If you link other code with the library, you must provide
+      complete object files to the recipients, so that they can relink them
+      with the library after making changes to the library and recompiling
+      it. And you must show them these terms so they know their rights.
+    </p>
+    <p>
+      We protect your rights with a two-step method: (1) we copyright
+      the library, and (2) we offer you this license, which gives you
+      legal permission to copy, distribute and/or modify the library.
+    </p>
+    <p>
+      To protect each distributor, we want to make it very clear that there
+      is no warranty for the free library. Also, if the library is modified
+      by someone else and passed on, the recipients should know that what they
+      have is not the original version, so that the original author's reputation
+      will not be affected by problems that might be introduced by others.
+    </p>
+    <p>
+      Finally, software patents pose a constant threat to the existence
+      of any free program. We wish to make sure that a company cannot
+      effectively restrict the users of a free program by obtaining a
+      restrictive license from a patent holder. Therefore, we insist that
+      any patent license obtained for a version of the library must be
+      consistent with the full freedom of use specified in this license.
+    </p>
+    <p>
+      Most GNU software, including some libraries, is covered by
+      the ordinary GNU General Public License. This license, the GNU
+      Lesser General Public License, applies to certain designated
+      libraries, and is quite different from the ordinary General
+      Public License. We use this license for certain libraries in
+      order to permit linking those libraries into non-free programs.
+    </p>
+    <p>
+      When a program is linked with a library, whether statically or using
+      a shared library, the combination of the two is legally speaking a
+      combined work, a derivative of the original library. The ordinary
+      General Public License therefore permits such linking only if the entire
+      combination fits its criteria of freedom. The Lesser General Public
+      License permits more lax criteria for linking other code with the library.
+    </p>
+    <p>
+      We call this license the "Lesser" General Public License
+      because it does Less to protect the user's freedom than the
+      ordinary General Public License. It also provides other free
+      software developers Less of an advantage over competing non-free
+      programs. These disadvantages are the reason we use the ordinary
+      General Public License for many libraries. However, the Lesser
+      license provides advantages in certain special circumstances.
+    </p>
+    <p>
+      For example, on rare occasions, there may be a special need to
+      encourage the widest possible use of a certain library, so that
+      it becomes a de-facto standard. To achieve this, non-free programs
+      must be allowed to use the library. A more frequent case is that a
+      free library does the same job as widely used non-free libraries.
+      In this case, there is little to gain by limiting the free library
+      to free software only, so we use the Lesser General Public License.
+    </p>
+    <p>
+      In other cases, permission to use a particular library in non-free
+      programs enables a greater number of people to use a large body of free
+      software. For example, permission to use the GNU C Library in non-free
+      programs enables many more people to use the whole GNU operating
+      system, as well as its variant, the GNU/Linux operating system.
+    </p>
+    <p>
+      Although the Lesser General Public License is Less protective of
+      the users' freedom, it does ensure that the user of a program that
+      is linked with the Library has the freedom and the wherewithal
+      to run that program using a modified version of the Library.
+    </p>
+    <p>
+      The precise terms and conditions for copying, distribution and
+      modification follow. Pay close attention to the difference between
+      a "work based on the library" and a "work that uses the library".
+      The former contains code derived from the library, whereas
+      the latter must be combined with the library in order to run.
+    </p>
+    <p>
+      TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+    </p>
+    <list>
+      <item>
+        <bullet>0.</bullet>
+        This License Agreement applies to any software library or
+        other program which contains a notice placed by the copyright
+        holder or other authorized party saying it may be distributed
+        under the terms of this Lesser General Public License (also
+        called "this License"). Each licensee is addressed as "you".
+        <p>
+          A "library" means a collection of software functions and/or data
+          prepared so as to be conveniently linked with application programs
+          (which use some of those functions and data) to form executables.
+        </p>
+        <p>
+          The "Library", below, refers to any such software library or work
+          which has been distributed under these terms. A "work based on
+          the Library" means either the Library or any derivative work under
+          copyright law: that is to say, a work containing the Library or a
+          portion of it, either verbatim or with modifications and/or translated
+          straightforwardly into another language. (Hereinafter, translation
+          is included without limitation in the term "modification".)
+        </p>
+        <p>
+          "Source code" for a work means the preferred form of the work
+          for making modifications to it. For a library, complete source
+          code means all the source code for all modules it contains,
+          plus any associated interface definition files, plus the scripts
+          used to control compilation and installation of the library.
+        </p>
+        <p>
+          Activities other than copying, distribution and modification are
+          not covered by this License; they are outside its scope. The act of
+          running a program using the Library is not restricted, and output
+          from such a program is covered only if its contents constitute a
+          work based on the Library (independent of the use of the Library
+          in a tool for writing it). Whether that is true depends on what
+          the Library does and what the program that uses the Library does.
+        </p>
+      </item>
+      <item>
+        <bullet>1.</bullet>
+        You may copy and distribute verbatim copies of the Library's complete
+        source code as you receive it, in any medium, provided that you
+        conspicuously and appropriately publish on each copy an appropriate
+        copyright notice and disclaimer of warranty; keep intact all the
+        notices that refer to this License and to the absence of any warranty;
+        and distribute a copy of this License along with the Library.
+        <p>
+          You may charge a fee for the physical act of
+          transferring a copy, and you may at your option
+          offer warranty protection in exchange for a fee.
+        </p>
+      </item>
+      <item>
+        <bullet>2.</bullet>
+        You may modify your copy or copies of the Library or any portion
+        of it, thus forming a work based on the Library, and copy and
+        distribute such modifications or work under the terms of Section
+        1 above, provided that you also meet all of these conditions:
+        <list>
+          <item>
+            <bullet>a)</bullet>
+            The modified work must itself be a software library.
+          </item>
+          <item>
+            <bullet>b)</bullet>
+            You must cause the files modified to carry prominent notices
+            stating that you changed the files and the date of any change.
+          </item>
+          <item>
+            <bullet>c)</bullet>
+            You must cause the whole of the work to be licensed at no
+            charge to all third parties under the terms of this License.
+          </item>
+          <item>
+            <bullet>d)</bullet>
+            If a facility in the modified Library refers to a function
+            or a table of data to be supplied by an application program
+            that uses the facility, other than as an argument passed
+            when the facility is invoked, then you must make a good faith
+            effort to ensure that, in the event an application does not
+            supply such function or table, the facility still operates,
+            and performs whatever part of its purpose remains meaningful.
+          </item>
+        </list>
+        <p>
+          (For example, a function in a library to compute square roots
+          has a purpose that is entirely well-defined independent of
+          the application. Therefore, Subsection 2d requires that any
+          application-supplied function or table used by this function
+          must be optional: if the application does not supply it,
+          the square root function must still compute square roots.)
+        </p>
+        <p>
+          These requirements apply to the modified work as a whole. If
+          identifiable sections of that work are not derived from the
+          Library, and can be reasonably considered independent and separate
+          works in themselves, then this License, and its terms, do not
+          apply to those sections when you distribute them as separate
+          works. But when you distribute the same sections as part of a
+          whole which is a work based on the Library, the distribution
+          of the whole must be on the terms of this License, whose
+          permissions for other licensees extend to the entire whole,
+          and thus to each and every part regardless of who wrote it.
+        </p>
+        <p>
+          Thus, it is not the intent of this section to claim rights or
+          contest your rights to work written entirely by you; rather,
+          the intent is to exercise the right to control the distribution
+          of derivative or collective works based on the Library.
+        </p>
+        <p>
+          In addition, mere aggregation of another work not based on
+          the Library with the Library (or with a work based on the
+          Library) on a volume of a storage or distribution medium does
+          not bring the other work under the scope of this License.
+        </p>
+      </item>
+      <item>
+        <bullet>3.</bullet>
+        You may opt to apply the terms of the ordinary GNU General
+        Public License instead of this License to a given copy of the
+        Library. To do this, you must alter all the notices that refer
+        to this License, so that they refer to the ordinary GNU General
+        Public License, version 2, instead of to this License. (If a
+        newer version than version 2 of the ordinary GNU General Public
+        License has appeared, then you can specify that version instead
+        if you wish.) Do not make any other change in these notices.
+        <p>
+          Once this change is made in a given copy, it is irreversible for
+          that copy, so the ordinary GNU General Public License applies to
+          all subsequent copies and derivative works made from that copy.
+        </p>
+        <p>
+          This option is useful when you wish to copy part of the
+          code of the Library into a program that is not a library.
+        </p>
+      </item>
+      <item>
+        <bullet>4.</bullet>
+        You may copy and distribute the Library (or a portion or derivative
+        of it, under Section 2) in object code or executable form under
+        the terms of Sections 1 and 2 above provided that you accompany
+        it with the complete corresponding machine-readable source code,
+        which must be distributed under the terms of Sections 1 and 2
+        above on a medium customarily used for software interchange.
+        <p>
+          If distribution of object code is made by offering access to copy
+          from a designated place, then offering equivalent access to copy
+          the source code from the same place satisfies the requirement
+          to distribute the source code, even though third parties are
+          not compelled to copy the source along with the object code.
+        </p>
+      </item>
+      <item>
+        <bullet>5.</bullet>
+        A program that contains no derivative of any portion of the
+        Library, but is designed to work with the Library by being compiled
+        or linked with it, is called a "work that uses the Library".
+        Such a work, in isolation, is not a derivative work of the
+        Library, and therefore falls outside the scope of this License.
+        <p>
+          However, linking a "work that uses the Library" with the Library
+          creates an executable that is a derivative of the Library (because
+          it contains portions of the Library), rather than a "work that uses
+          the library". The executable is therefore covered by this License.
+          Section 6 states terms for distribution of such executables.
+        </p>
+        <p>
+          When a "work that uses the Library" uses material from a header
+          file that is part of the Library, the object code for the work may
+          be a derivative work of the Library even though the source code is
+          not. Whether this is true is especially significant if the work can
+          be linked without the Library, or if the work is itself a library.
+          The threshold for this to be true is not precisely defined by law.
+        </p>
+        <p>
+          If such an object file uses only numerical parameters, data
+          structure layouts and accessors, and small macros and small inline
+          functions (ten lines or less in length), then the use of the
+          object file is unrestricted, regardless of whether it is legally
+          a derivative work. (Executables containing this object code
+          plus portions of the Library will still fall under Section 6.)
+        </p>
+        <p>
+          Otherwise, if the work is a derivative of the Library, you may
+          distribute the object code for the work under the terms of Section
+          6. Any executables containing that work also fall under Section 6,
+          whether or not they are linked directly with the Library itself.
+        </p>
+      </item>
+      <item>
+        <bullet>6.</bullet>
+        As an exception to the Sections above, you may also combine or
+        link a "work that uses the Library" with the Library to produce
+        a work containing portions of the Library, and distribute
+        that work under terms of your choice, provided that the terms
+        permit modification of the work for the customer's own use
+        and reverse engineering for debugging such modifications.
+        <p>
+          You must give prominent notice with each copy of the work
+          that the Library is used in it and that the Library and its
+          use are covered by this License. You must supply a copy of
+          this License. If the work during execution displays copyright
+          notices, you must include the copyright notice for the Library
+          among them, as well as a reference directing the user to the
+          copy of this License. Also, you must do one of these things:
+        </p>
+        <list>
+          <item>
+            <bullet>a)</bullet>
+            Accompany the work with the complete corresponding machine-readable
+            source code for the Library including whatever changes were used in
+            the work (which must be distributed under Sections 1 and 2 above);
+            and, if the work is an executable linked with the Library, with the
+            complete machine-readable "work that uses the Library", as object
+            code and/or source code, so that the user can modify the Library
+            and then relink to produce a modified executable containing the
+            modified Library. (It is understood that the user who changes the
+            contents of definitions files in the Library will not necessarily be
+            able to recompile the application to use the modified definitions.)
+          </item>
+          <item>
+            <bullet>b)</bullet>
+            Use a suitable shared library mechanism for linking with the
+            Library. A suitable mechanism is one that (1) uses at run time a
+            copy of the library already present on the user's computer system,
+            rather than copying library functions into the executable, and
+            (2) will operate properly with a modified version of the library,
+            if the user installs one, as long as the modified version is
+            interface-compatible with the version that the work was made with.
+          </item>
+          <item>
+            <bullet>c)</bullet>
+            Accompany the work with a written offer, valid for at
+            least three years, to give the same user the materials
+            specified in Subsection 6a, above, for a charge no
+            more than the cost of performing this distribution.
+          </item>
+          <item>
+            <bullet>d)</bullet>
+            If distribution of the work is made by offering access to
+            copy from a designated place, offer equivalent access to
+            copy the above specified materials from the same place.
+          </item>
+          <item>
+            <bullet>e)</bullet>
+            Verify that the user has already received a copy of these
+            materials or that you have already sent this user a copy.
+          </item>
+        </list>
+        <p>
+          For an executable, the required form of the "work that uses
+          the Library" must include any data and utility programs needed
+          for reproducing the executable from it. However, as a special
+          exception, the materials to be distributed need not include
+          anything that is normally distributed (in either source or
+          binary form) with the major components (compiler, kernel,
+          and so on) of the operating system on which the executable
+          runs, unless that component itself accompanies the executable.
+        </p>
+        <p>
+          It may happen that this requirement contradicts the
+          license restrictions of other proprietary libraries that
+          do not normally accompany the operating system. Such
+          a contradiction means you cannot use both them and the
+          Library together in an executable that you distribute.
+        </p>
+      </item>
+      <item>
+        <bullet>7.</bullet>
+        You may place library facilities that are a work based on the
+        Library side-by-side in a single library together with other library
+        facilities not covered by this License, and distribute such a
+        combined library, provided that the separate distribution of the
+        work based on the Library and of the other library facilities is
+        otherwise permitted, and provided that you do these two things:
+        <list>
+          <item>
+            <bullet>a)</bullet>
+            Accompany the combined library with a copy of the same work based
+            on the Library, uncombined with any other library facilities.
+            This must be distributed under the terms of the Sections above.
+          </item>
+          <item>
+            <bullet>b)</bullet>
+            Give prominent notice with the combined library of the fact
+            that part of it is a work based on the Library, and explaining
+            where to find the accompanying uncombined form of the same work.
+          </item>
+        </list>
+      </item>
+      <item>
+        <bullet>8.</bullet>
+        You may not copy, modify, sublicense, link with, or distribute the
+        Library except as expressly provided under this License. Any attempt
+        otherwise to copy, modify, sublicense, link with, or distribute
+        the Library is void, and will automatically terminate your rights
+        under this License. However, parties who have received copies, or
+        rights, from you under this License will not have their licenses
+        terminated so long as such parties remain in full compliance.
+      </item>
+      <item>
+        <bullet>9.</bullet>
+        You are not required to accept this License, since you have
+        not signed it. However, nothing else grants you permission to
+        modify or distribute the Library or its derivative works. These
+        actions are prohibited by law if you do not accept this License.
+        Therefore, by modifying or distributing the Library (or any
+        work based on the Library), you indicate your acceptance of this
+        License to do so, and all its terms and conditions for copying,
+        distributing or modifying the Library or works based on it.
+      </item>
+      <item>
+        <bullet>10.</bullet>
+        Each time you redistribute the Library (or any work based on
+        the Library), the recipient automatically receives a license
+        from the original licensor to copy, distribute, link with or
+        modify the Library subject to these terms and conditions. You
+        may not impose any further restrictions on the recipients'
+        exercise of the rights granted herein. You are not responsible
+        for enforcing compliance by third parties with this License.
+      </item>
+      <item>
+        <bullet>11.</bullet>
+        If, as a consequence of a court judgment or allegation of patent
+        infringement or for any other reason (not limited to patent issues),
+        conditions are imposed on you (whether by court order, agreement
+        or otherwise) that contradict the conditions of this License,
+        they do not excuse you from the conditions of this License. If you
+        cannot distribute so as to satisfy simultaneously your obligations
+        under this License and any other pertinent obligations, then as a
+        consequence you may not distribute the Library at all. For example,
+        if a patent license would not permit royalty-free redistribution of
+        the Library by all those who receive copies directly or indirectly
+        through you, then the only way you could satisfy both it and this
+        License would be to refrain entirely from distribution of the Library.
+        <p>
+          If any portion of this section is held invalid or
+          unenforceable under any particular circumstance, the
+          balance of the section is intended to apply, and the section
+          as a whole is intended to apply in other circumstances.
+        </p>
+        <p>
+          It is not the purpose of this section to induce you to infringe
+          any patents or other property right claims or to contest
+          validity of any such claims; this section has the sole purpose
+          of protecting the integrity of the free software distribution
+          system which is implemented by public license practices. Many
+          people have made generous contributions to the wide range of
+          software distributed through that system in reliance on consistent
+          application of that system; it is up to the author/donor to
+          decide if he or she is willing to distribute software through
+          any other system and a licensee cannot impose that choice.
+        </p>
+        <p>
+          This section is intended to make thoroughly clear what is
+          believed to be a consequence of the rest of this License.
+        </p>
+      </item>
+      <item>
+        <bullet>12.</bullet>
+        If the distribution and/or use of the Library is restricted in
+        certain countries either by patents or by copyrighted interfaces,
+        the original copyright holder who places the Library under this
+        License may add an explicit geographical distribution limitation
+        excluding those countries, so that distribution is permitted only
+        in or among countries not thus excluded. In such case, this License
+        incorporates the limitation as if written in the body of this License.
+      </item>
+      <item>
+        <bullet>13.</bullet>
+        The Free Software Foundation may publish revised and/or new
+        versions of the Lesser General Public License from time to time.
+        Such new versions will be similar in spirit to the present version,
+        but may differ in detail to address new problems or concerns.
+        <p>
+          Each version is given a distinguishing version number. If
+          the Library specifies a version number of this License which
+          applies to it and "any later version", you have the option of
+          following the terms and conditions either of that version or of
+          any later version published by the Free Software Foundation. If
+          the Library does not specify a license version number, you may
+          choose any version ever published by the Free Software Foundation.
+        </p>
+      </item>
+      <item>
+        <bullet>14.</bullet>
+        If you wish to incorporate parts of the Library into other free programs
+        whose distribution conditions are incompatible with these, write to
+        the author to ask for permission. For software which is copyrighted by
+        the Free Software Foundation, write to the Free Software Foundation; we
+        sometimes make exceptions for this. Our decision will be guided by the
+        two goals of preserving the free status of all derivatives of our free
+        software and of promoting the sharing and reuse of software generally.
+        <p>
+          NO WARRANTY
+        </p>
+      </item>
+      <item>
+        <bullet>15.</bullet>
+        BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+        FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT
+        WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER
+        PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY KIND,
+        EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+        IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+        PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF
+        THE LIBRARY IS WITH YOU. SHOULD THE LIBRARY PROVE DEFECTIVE, YOU
+        ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+      </item>
+      <item>
+        <bullet>16.</bullet>
+        IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+        WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+        REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU FOR
+        DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL
+        DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE LIBRARY
+        (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED
+        INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF
+        THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF SUCH HOLDER
+        OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+      </item>
+    </list>
+    <optional>
+      <p>
+        END OF TERMS AND CONDITIONS
+      </p>
+      <p>
+        How to Apply These Terms to Your New Libraries
+      </p>
+      <p>
+        If you develop a new library, and you want it to be of the greatest
+        possible use to the public, we recommend making it free software
+        that everyone can redistribute and change. You can do so by
+        permitting redistribution under these terms (or, alternatively,
+        under the terms of the ordinary General Public License).
+      </p>
+      <p>
+        To apply these terms, attach the following notices to the
+        library. It is safest to attach them to the start of each
+        source file to most effectively convey the exclusion of
+        warranty; and each file should have at least the "copyright"
+        line and a pointer to where the full notice is found.
+      </p>
+      <p>
+	<optional>&lt;</optional>one line to give the library's name
+	and an idea of what it does.<optional>&gt;</optional>
+        <br></br>
+        Copyright (C)
+        <optional>&lt;</optional>year<optional>&gt;</optional>
+        <optional>&lt;</optional>name of author<optional>&gt;</optional>
+      </p>
+      <p>
+        This library is free software; you can redistribute it and/or
+        modify it under the terms of the GNU Lesser General Public
+        License as published by the Free Software Foundation; either
+        version 2.1 of the License, or (at your option) any later version.
+      </p>
+      <p>
+        This library is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty
+        of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+        See the GNU Lesser General Public License for more details.
+      </p>
+      <p>
+        You should have received a copy of the GNU Lesser General Public License
+        along with this library; if not, write to the Free Software Foundation,
+        Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA Also
+        add information on how to contact you by electronic and paper mail.
+      </p>
+      <p>
+        You should also get your employer (if you work as a programmer)
+        or your school, if any, to sign a "copyright disclaimer" for
+        the library, if necessary. Here is a sample; alter the names:
+      </p>
+      <p>
+        Yoyodyne, Inc., hereby disclaims all copyright interest in<br></br>
+        the library `Frob' (a library for tweaking knobs) written<br></br>
+        by James Random Hacker.
+      </p>
+      <p>
+	<optional>&lt;</optional>signature of Ty Coon<optional>&gt;</optional>,
+	1 April 1990<br></br>
+        Ty Coon, President of Vice<br></br>
+        That's all there is to it!
+      </p>
+    </optional>
+  </license>
+</SPDXLicenseCollection>

--- a/src/LGPL-2.1.xml
+++ b/src/LGPL-2.1.xml
@@ -1,448 +1,659 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isOsiApproved="true" licenseId="LGPL-2.1"
-            name="GNU Lesser General Public License v2.1 only">
-      <crossRefs>
-         <crossRef>http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</crossRef>
-         <crossRef>http://www.opensource.org/licenses/LGPL-2.1</crossRef>
-      </crossRefs>
-      <standardLicenseHeader> Copyright (C)
-    <alt match=".+" name="copyright">year name of author</alt>
-         <p>This library is free software; you can redistribute
-    it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software
-    Foundation; version 2.1.</p>
-         <p>This library is distributed in the hope that it will be useful, but WITHOUT ANY
-    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-    Lesser General Public License for more details.</p>
-         <p>You should have received a copy of the GNU Lesser General Public
-    License along with this library; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth
-    Floor, Boston, MA 02110-1301 USA </p>
-      </standardLicenseHeader>
-      <notes>This license was released: February 1999. This refers to when this LGPL 2.1 only is being used (as opposed to
-         "or later).</notes>
-      <titleText>
-         <p>GNU LESSER GENERAL PUBLIC LICENSE</p>
-         <p>Version 2.1, February 1999</p>
-      </titleText>
-      <p>Copyright (C) 1991, 1999 Free Software Foundation, Inc.
-        <br/>51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+  <license licenseId="LGPL-2.1" isOsiApproved="true"
+  name="GNU Lesser General Public License v2.1 only">
+    <crossRefs>
+      <crossRef>http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</crossRef>
+      <crossRef>http://www.opensource.org/licenses/LGPL-2.1</crossRef>
+    </crossRefs>
+    <standardLicenseHeader>
+      Copyright (C)<alt name="copyright" match=".+">year name of author</alt>
+      <p>
+        This library is free software; you can redistribute it and/or
+        modify it under the terms of the GNU Lesser General Public
+        License as published by the Free Software Foundation; version 2.1.
       </p>
-      <p>Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is
-         not allowed.</p>
-      <p>[This is the first released version of the Lesser GPL. It also counts as the successor of the GNU Library
-         Public License, version 2, hence the version number 2.1.]</p>
-      <p>Preamble</p>
-      <p>The licenses for most software are designed to take away your freedom to share and change it. By
-         contrast, the GNU General Public Licenses are intended to guarantee your freedom to share and change
-         free software--to make sure the software is free for all its users.</p>
-      <p>This license, the Lesser General Public License, applies to some specially designated software
-         packages--typically libraries--of the Free Software Foundation and other authors who decide to use it.
-         You can use it too, but we suggest you first think carefully about whether this license or the
-         ordinary General Public License is the better strategy to use in any particular case, based on the
-         explanations below.</p>
-      <p>When we speak of free software, we are referring to freedom of use, not price. Our General Public
-         Licenses are designed to make sure that you have the freedom to distribute copies of free software
-         (and charge for this service if you wish); that you receive source code or can get it if you want it;
-         that you can change the software and use pieces of it in new free programs; and that you are informed
-         that you can do these things.</p>
-      <p>To protect your rights, we need to make restrictions that forbid distributors to deny you these rights or
-         to ask you to surrender these rights. These restrictions translate to certain responsibilities for you
-         if you distribute copies of the library or if you modify it.</p>
-      <p>For example, if you distribute copies of the library, whether gratis or for a fee, you must give the
-         recipients all the rights that we gave you. You must make sure that they, too, receive or can get the
-         source code. If you link other code with the library, you must provide complete object files to the
-         recipients, so that they can relink them with the library after making changes to the library and
-         recompiling it. And you must show them these terms so they know their rights.</p>
-      <p>We protect your rights with a two-step method: (1) we copyright the library, and (2) we offer you this
-         license, which gives you legal permission to copy, distribute and/or modify the library.</p>
-      <p>To protect each distributor, we want to make it very clear that there is no warranty for the free
-         library. Also, if the library is modified by someone else and passed on, the recipients should know
-         that what they have is not the original version, so that the original author's reputation will
-         not be affected by problems that might be introduced by others.</p>
-      <p>Finally, software patents pose a constant threat to the existence of any free program. We wish to make
-         sure that a company cannot effectively restrict the users of a free program by obtaining a restrictive
-         license from a patent holder. Therefore, we insist that any patent license obtained for a version of
-         the library must be consistent with the full freedom of use specified in this license.</p>
-      <p>Most GNU software, including some libraries, is covered by the ordinary GNU General Public License. This
-         license, the GNU Lesser General Public License, applies to certain designated libraries, and is quite
-         different from the ordinary General Public License. We use this license for certain libraries in order
-         to permit linking those libraries into non-free programs.</p>
-      <p>When a program is linked with a library, whether statically or using a shared library, the combination of
-         the two is legally speaking a combined work, a derivative of the original library. The ordinary
-         General Public License therefore permits such linking only if the entire combination fits its criteria
-         of freedom. The Lesser General Public License permits more lax criteria for linking other code with
-         the library.</p>
-      <p>We call this license the "Lesser" General Public License because it does Less to protect the
-         user's freedom than the ordinary General Public License. It also provides other free software
-         developers Less of an advantage over competing non-free programs. These disadvantages are the reason
-         we use the ordinary General Public License for many libraries. However, the Lesser license provides
-         advantages in certain special circumstances.</p>
-      <p>For example, on rare occasions, there may be a special need to encourage the widest possible use of a
-         certain library, so that it becomes a de-facto standard. To achieve this, non-free programs must be
-         allowed to use the library. A more frequent case is that a free library does the same job as widely
-         used non-free libraries. In this case, there is little to gain by limiting the free library to free
-         software only, so we use the Lesser General Public License.</p>
-      <p>In other cases, permission to use a particular library in non-free programs enables a greater number of
-         people to use a large body of free software. For example, permission to use the GNU C Library in
-         non-free programs enables many more people to use the whole GNU operating system, as well as its
-         variant, the GNU/Linux operating system.</p>
-      <p>Although the Lesser General Public License is Less protective of the users' freedom, it does ensure
-         that the user of a program that is linked with the Library has the freedom and the wherewithal to run
-         that program using a modified version of the Library.</p>
-      <p>The precise terms and conditions for copying, distribution and modification follow. Pay close attention
-         to the difference between a "work based on the library" and a "work that uses the
-         library". The former contains code derived from the library, whereas the latter must be combined
-         with the library in order to run.</p>
-      <p>TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION</p>
-      <list>
-        <item>
-            <bullet>0.</bullet>
-          This License Agreement applies to any software library or other program which contains a notice
-             placed by the copyright holder or other authorized party saying it may be distributed under
-             the terms of this Lesser General Public License (also called "this License"). Each
-             licensee is addressed as "you".
-          <p>A "library" means a collection of software functions and/or data prepared so as to be
-             conveniently linked with application programs (which use some of those functions and data) to
-             form executables.</p>
-            <p>The "Library", below, refers to any such software library or work which has been
-             distributed under these terms. A "work based on the Library" means either the
-             Library or any derivative work under copyright law: that is to say, a work containing the
-             Library or a portion of it, either verbatim or with modifications and/or translated
-             straightforwardly into another language. (Hereinafter, translation is included without
-             limitation in the term "modification".)</p>
-            <p>"Source code" for a work means the preferred form of the work for making modifications
-             to it. For a library, complete source code means all the source code for all modules it
-             contains, plus any associated interface definition files, plus the scripts used to control
-             compilation and installation of the library.</p>
-            <p>Activities other than copying, distribution and modification are not covered by this License;
-             they are outside its scope. The act of running a program using the Library is not restricted,
-             and output from such a program is covered only if its contents constitute a work based on the
-             Library (independent of the use of the Library in a tool for writing it). Whether that is true
-             depends on what the Library does and what the program that uses the Library does.</p>
-        </item>
-        <item>
-            <bullet>1.</bullet>
-          You may copy and distribute verbatim copies of the Library's complete source code as you
-             receive it, in any medium, provided that you conspicuously and appropriately publish on each
-             copy an appropriate copyright notice and disclaimer of warranty; keep intact all the notices
-             that refer to this License and to the absence of any warranty; and distribute a copy of this
-             License along with the Library.
-          <p>You may charge a fee for the physical act of transferring a copy, and you may at your option
-             offer warranty protection in exchange for a fee.</p>
-        </item>
-        <item>
-            <bullet>2.</bullet>
-          You may modify your copy or copies of the Library or any portion of it, thus forming a work based
-             on the Library, and copy and distribute such modifications or work under the terms of Section
-             1 above, provided that you also meet all of these conditions:
+      <p>
+        This library is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty
+        of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+        See the GNU Lesser General Public License for more details.
+      </p>
+      <p>
+        You should have received a copy of the GNU Lesser General Public License
+        along with this library; if not, write to the Free Software Foundation,
+        Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+      </p>
+    </standardLicenseHeader>
+    <notes>
+      This license was released: February 1999. This refers to when
+      this LGPL 2.1 only is being used (as opposed to "or later).
+    </notes>
+    <titleText>
+      <p>
+        GNU LESSER GENERAL PUBLIC LICENSE
+      </p>
+      <p>
+        Version 2.1, February 1999
+      </p>
+    </titleText>
+    <p>
+      Copyright (C) 1991, 1999 Free Software Foundation, Inc.<br></br>
+      51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+    </p>
+    <p>
+      Everyone is permitted to copy and distribute verbatim copies
+      of this license document, but changing it is not allowed.
+    </p>
+    <p>
+      [This is the first released version of the Lesser GPL.
+      It also counts as the successor of the GNU Library
+      Public License, version 2, hence the version number 2.1.]
+    </p>
+    <p>
+      Preamble
+    </p>
+    <p>
+      The licenses for most software are designed to take away your
+      freedom to share and change it. By contrast, the GNU General Public
+      Licenses are intended to guarantee your freedom to share and change
+      free software--to make sure the software is free for all its users.
+    </p>
+    <p>
+      This license, the Lesser General Public License, applies to some
+      specially designated software packages--typically libraries--of the
+      Free Software Foundation and other authors who decide to use it. You
+      can use it too, but we suggest you first think carefully about whether
+      this license or the ordinary General Public License is the better
+      strategy to use in any particular case, based on the explanations below.
+    </p>
+    <p>
+      When we speak of free software, we are referring to freedom of use, not
+      price. Our General Public Licenses are designed to make sure that you
+      have the freedom to distribute copies of free software (and charge for
+      this service if you wish); that you receive source code or can get it if
+      you want it; that you can change the software and use pieces of it in new
+      free programs; and that you are informed that you can do these things.
+    </p>
+    <p>
+      To protect your rights, we need to make restrictions that forbid
+      distributors to deny you these rights or to ask you to surrender
+      these rights. These restrictions translate to certain responsibilities
+      for you if you distribute copies of the library or if you modify it.
+    </p>
+    <p>
+      For example, if you distribute copies of the library, whether gratis
+      or for a fee, you must give the recipients all the rights that we
+      gave you. You must make sure that they, too, receive or can get the
+      source code. If you link other code with the library, you must provide
+      complete object files to the recipients, so that they can relink them
+      with the library after making changes to the library and recompiling
+      it. And you must show them these terms so they know their rights.
+    </p>
+    <p>
+      We protect your rights with a two-step method: (1) we copyright
+      the library, and (2) we offer you this license, which gives you
+      legal permission to copy, distribute and/or modify the library.
+    </p>
+    <p>
+      To protect each distributor, we want to make it very clear that there
+      is no warranty for the free library. Also, if the library is modified
+      by someone else and passed on, the recipients should know that what they
+      have is not the original version, so that the original author's reputation
+      will not be affected by problems that might be introduced by others.
+    </p>
+    <p>
+      Finally, software patents pose a constant threat to the existence
+      of any free program. We wish to make sure that a company cannot
+      effectively restrict the users of a free program by obtaining a
+      restrictive license from a patent holder. Therefore, we insist that
+      any patent license obtained for a version of the library must be
+      consistent with the full freedom of use specified in this license.
+    </p>
+    <p>
+      Most GNU software, including some libraries, is covered by
+      the ordinary GNU General Public License. This license, the GNU
+      Lesser General Public License, applies to certain designated
+      libraries, and is quite different from the ordinary General
+      Public License. We use this license for certain libraries in
+      order to permit linking those libraries into non-free programs.
+    </p>
+    <p>
+      When a program is linked with a library, whether statically or using
+      a shared library, the combination of the two is legally speaking a
+      combined work, a derivative of the original library. The ordinary
+      General Public License therefore permits such linking only if the entire
+      combination fits its criteria of freedom. The Lesser General Public
+      License permits more lax criteria for linking other code with the library.
+    </p>
+    <p>
+      We call this license the "Lesser" General Public License
+      because it does Less to protect the user's freedom than the
+      ordinary General Public License. It also provides other free
+      software developers Less of an advantage over competing non-free
+      programs. These disadvantages are the reason we use the ordinary
+      General Public License for many libraries. However, the Lesser
+      license provides advantages in certain special circumstances.
+    </p>
+    <p>
+      For example, on rare occasions, there may be a special need to
+      encourage the widest possible use of a certain library, so that
+      it becomes a de-facto standard. To achieve this, non-free programs
+      must be allowed to use the library. A more frequent case is that a
+      free library does the same job as widely used non-free libraries.
+      In this case, there is little to gain by limiting the free library
+      to free software only, so we use the Lesser General Public License.
+    </p>
+    <p>
+      In other cases, permission to use a particular library in non-free
+      programs enables a greater number of people to use a large body of free
+      software. For example, permission to use the GNU C Library in non-free
+      programs enables many more people to use the whole GNU operating
+      system, as well as its variant, the GNU/Linux operating system.
+    </p>
+    <p>
+      Although the Lesser General Public License is Less protective of
+      the users' freedom, it does ensure that the user of a program that
+      is linked with the Library has the freedom and the wherewithal
+      to run that program using a modified version of the Library.
+    </p>
+    <p>
+      The precise terms and conditions for copying, distribution and
+      modification follow. Pay close attention to the difference between
+      a "work based on the library" and a "work that uses the library".
+      The former contains code derived from the library, whereas
+      the latter must be combined with the library in order to run.
+    </p>
+    <p>
+      TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+    </p>
+    <list>
+      <item>
+        <bullet>0.</bullet>
+        This License Agreement applies to any software library or
+        other program which contains a notice placed by the copyright
+        holder or other authorized party saying it may be distributed
+        under the terms of this Lesser General Public License (also
+        called "this License"). Each licensee is addressed as "you".
+        <p>
+          A "library" means a collection of software functions and/or data
+          prepared so as to be conveniently linked with application programs
+          (which use some of those functions and data) to form executables.
+        </p>
+        <p>
+          The "Library", below, refers to any such software library or work
+          which has been distributed under these terms. A "work based on
+          the Library" means either the Library or any derivative work under
+          copyright law: that is to say, a work containing the Library or a
+          portion of it, either verbatim or with modifications and/or translated
+          straightforwardly into another language. (Hereinafter, translation
+          is included without limitation in the term "modification".)
+        </p>
+        <p>
+          "Source code" for a work means the preferred form of the work
+          for making modifications to it. For a library, complete source
+          code means all the source code for all modules it contains,
+          plus any associated interface definition files, plus the scripts
+          used to control compilation and installation of the library.
+        </p>
+        <p>
+          Activities other than copying, distribution and modification are
+          not covered by this License; they are outside its scope. The act of
+          running a program using the Library is not restricted, and output
+          from such a program is covered only if its contents constitute a
+          work based on the Library (independent of the use of the Library
+          in a tool for writing it). Whether that is true depends on what
+          the Library does and what the program that uses the Library does.
+        </p>
+      </item>
+      <item>
+        <bullet>1.</bullet>
+        You may copy and distribute verbatim copies of the Library's complete
+        source code as you receive it, in any medium, provided that you
+        conspicuously and appropriately publish on each copy an appropriate
+        copyright notice and disclaimer of warranty; keep intact all the
+        notices that refer to this License and to the absence of any warranty;
+        and distribute a copy of this License along with the Library.
+        <p>
+          You may charge a fee for the physical act of
+          transferring a copy, and you may at your option
+          offer warranty protection in exchange for a fee.
+        </p>
+      </item>
+      <item>
+        <bullet>2.</bullet>
+        You may modify your copy or copies of the Library or any portion
+        of it, thus forming a work based on the Library, and copy and
+        distribute such modifications or work under the terms of Section
+        1 above, provided that you also meet all of these conditions:
         <list>
-               <item>
-                  <bullet>a)</bullet>
+          <item>
+            <bullet>a)</bullet>
             The modified work must itself be a software library.
           </item>
-               <item>
-                  <bullet>b)</bullet>
-            You must cause the files modified to carry prominent notices stating that you changed the
-               files and the date of any change.
+          <item>
+            <bullet>b)</bullet>
+            You must cause the files modified to carry prominent notices
+            stating that you changed the files and the date of any change.
           </item>
-               <item>
-                  <bullet>c)</bullet>
-            You must cause the whole of the work to be licensed at no charge to all third parties under
-               the terms of this License.
+          <item>
+            <bullet>c)</bullet>
+            You must cause the whole of the work to be licensed at no
+            charge to all third parties under the terms of this License.
           </item>
-               <item>
-                  <bullet>d)</bullet>
-            If a facility in the modified Library refers to a function or a table of data to be supplied
-               by an application program that uses the facility, other than as an argument passed when
-               the facility is invoked, then you must make a good faith effort to ensure that, in the
-               event an application does not supply such function or table, the facility still operates,
-               and performs whatever part of its purpose remains meaningful.
-            </item>
-            </list>
-            <p>(For example, a function in a library to compute square roots has a purpose that is entirely
-               well-defined independent of the application. Therefore, Subsection 2d requires that any
-               application-supplied function or table used by this function must be optional: if the
-               application does not supply it, the square root function must still compute square
-               roots.)</p>
-            <p>These requirements apply to the modified work as a whole. If identifiable sections of that
-               work are not derived from the Library, and can be reasonably considered independent and
-               separate works in themselves, then this License, and its terms, do not apply to those
-               sections when you distribute them as separate works. But when you distribute the same
-               sections as part of a whole which is a work based on the Library, the distribution of the
-               whole must be on the terms of this License, whose permissions for other licensees extend
-               to the entire whole, and thus to each and every part regardless of who wrote it.</p>
-            <p>Thus, it is not the intent of this section to claim rights or contest your rights to work
-               written entirely by you; rather, the intent is to exercise the right to control the
-               distribution of derivative or collective works based on the Library.</p>
-            <p>In addition, mere aggregation of another work not based on the Library with the Library (or
-               with a work based on the Library) on a volume of a storage or distribution medium does not
-               bring the other work under the scope of this License.</p>
-        </item>
-        <item>
-            <bullet>3.</bullet>
-          You may opt to apply the terms of the ordinary GNU General Public License instead of this License
-             to a given copy of the Library. To do this, you must alter all the notices that refer to this
-             License, so that they refer to the ordinary GNU General Public License, version 2, instead of
-             to this License. (If a newer version than version 2 of the ordinary GNU General Public License
-             has appeared, then you can specify that version instead if you wish.) Do not make any other
-             change in these notices.
-          <p>Once this change is made in a given copy, it is irreversible for that copy, so the ordinary GNU
-             General Public License applies to all subsequent copies and derivative works made from that
-             copy.</p>
-            <p>This option is useful when you wish to copy part of the code of the Library into a program that
-             is not a library.</p>
-        </item>
-        <item>
-            <bullet>4.</bullet>
-          You may copy and distribute the Library (or a portion or derivative of it, under Section 2) in
-             object code or executable form under the terms of Sections 1 and 2 above provided that you
-             accompany it with the complete corresponding machine-readable source code, which must be
-             distributed under the terms of Sections 1 and 2 above on a medium customarily used for
-             software interchange.
-          <p>If distribution of object code is made by offering access to copy from a designated place, then
-             offering equivalent access to copy the source code from the same place satisfies the
-             requirement to distribute the source code, even though third parties are not compelled to copy
-             the source along with the object code.</p>
-        </item>
-        <item>
-            <bullet>5.</bullet>
-          A program that contains no derivative of any portion of the Library, but is designed to work with
-             the Library by being compiled or linked with it, is called a "work that uses the
-             Library". Such a work, in isolation, is not a derivative work of the Library, and
-             therefore falls outside the scope of this License.
-          <p>However, linking a "work that uses the Library" with the Library creates an executable
-             that is a derivative of the Library (because it contains portions of the Library), rather than
-             a "work that uses the library". The executable is therefore covered by this License.
-             Section 6 states terms for distribution of such executables.</p>
-            <p>When a "work that uses the Library" uses material from a header file that is part of
-             the Library, the object code for the work may be a derivative work of the Library even though
-             the source code is not. Whether this is true is especially significant if the work can be
-             linked without the Library, or if the work is itself a library. The threshold for this to be
-             true is not precisely defined by law.</p>
-            <p>If such an object file uses only numerical parameters, data structure layouts and accessors, and
-             small macros and small inline functions (ten lines or less in length), then the use of the
-             object file is unrestricted, regardless of whether it is legally a derivative work.
-             (Executables containing this object code plus portions of the Library will still fall under
-             Section 6.)</p>
-            <p>Otherwise, if the work is a derivative of the Library, you may distribute the object code for the
-             work under the terms of Section 6. Any executables containing that work also fall under
-             Section 6, whether or not they are linked directly with the Library itself.</p>
-        </item>
-        <item>
-            <bullet>6.</bullet>
-          As an exception to the Sections above, you may also combine or link a "work that uses the
-             Library" with the Library to produce a work containing portions of the Library, and
-             distribute that work under terms of your choice, provided that the terms permit modification
-             of the work for the customer's own use and reverse engineering for debugging such
-             modifications.
-          <p>You must give prominent notice with each copy of the work that the Library is used in it and that
-             the Library and its use are covered by this License. You must supply a copy of this License.
-             If the work during execution displays copyright notices, you must include the copyright notice
-             for the Library among them, as well as a reference directing the user to the copy of this
-             License. Also, you must do one of these things:</p>
-            <list>
-               <item>
-                  <bullet>a)</bullet>
-            Accompany the work with the complete corresponding machine-readable source code for the
-               Library including whatever changes were used in the work (which must be distributed under
-               Sections 1 and 2 above); and, if the work is an executable linked with the Library, with
-               the complete machine-readable "work that uses the Library", as object code
-               and/or source code, so that the user can modify the Library and then relink to produce a
-               modified executable containing the modified Library. (It is understood that the user who
-               changes the contents of definitions files in the Library will not necessarily be able to
-               recompile the application to use the modified definitions.)
+          <item>
+            <bullet>d)</bullet>
+            If a facility in the modified Library refers to a function
+            or a table of data to be supplied by an application program
+            that uses the facility, other than as an argument passed
+            when the facility is invoked, then you must make a good faith
+            effort to ensure that, in the event an application does not
+            supply such function or table, the facility still operates,
+            and performs whatever part of its purpose remains meaningful.
           </item>
-               <item>
-                  <bullet>b)</bullet>
-            Use a suitable shared library mechanism for linking with the Library. A suitable mechanism is
-               one that (1) uses at run time a copy of the library already present on the user's
-               computer system, rather than copying library functions into the executable, and (2) will
-               operate properly with a modified version of the library, if the user installs one, as long
-               as the modified version is interface-compatible with the version that the work was made
-               with.
-          </item>
-               <item>
-                  <bullet>c)</bullet>
-            Accompany the work with a written offer, valid for at least three years, to give the same
-               user the materials specified in Subsection 6a, above, for a charge no more than the cost
-               of performing this distribution.
-          </item>
-               <item>
-                  <bullet>d)</bullet>
-            If distribution of the work is made by offering access to copy from a designated place, offer
-               equivalent access to copy the above specified materials from the same place.
-          </item>
-               <item>
-                  <bullet>e)</bullet>
-            Verify that the user has already received a copy of these materials or that you have already
-               sent this user a copy.
-          </item>
-            </list>
-            <p>For an executable, the required form of the "work that uses the Library" must
-               include any data and utility programs needed for reproducing the executable from it.
-               However, as a special exception, the materials to be distributed need not include anything
-               that is normally distributed (in either source or binary form) with the major components
-               (compiler, kernel, and so on) of the operating system on which the executable runs, unless
-               that component itself accompanies the executable.</p>
-            <p>It may happen that this requirement contradicts the license restrictions of other proprietary
-               libraries that do not normally accompany the operating system. Such a contradiction means
-               you cannot use both them and the Library together in an executable that you
-               distribute.</p>
-        </item>
-        <item>
-            <bullet>7.</bullet>
-          You may place library facilities that are a work based on the Library side-by-side in a single
-             library together with other library facilities not covered by this License, and distribute
-             such a combined library, provided that the separate distribution of the work based on the
-             Library and of the other library facilities is otherwise permitted, and provided that you do
-             these two things:
+        </list>
+        <p>
+          (For example, a function in a library to compute square roots
+          has a purpose that is entirely well-defined independent of
+          the application. Therefore, Subsection 2d requires that any
+          application-supplied function or table used by this function
+          must be optional: if the application does not supply it,
+          the square root function must still compute square roots.)
+        </p>
+        <p>
+          These requirements apply to the modified work as a whole. If
+          identifiable sections of that work are not derived from the
+          Library, and can be reasonably considered independent and separate
+          works in themselves, then this License, and its terms, do not
+          apply to those sections when you distribute them as separate
+          works. But when you distribute the same sections as part of a
+          whole which is a work based on the Library, the distribution
+          of the whole must be on the terms of this License, whose
+          permissions for other licensees extend to the entire whole,
+          and thus to each and every part regardless of who wrote it.
+        </p>
+        <p>
+          Thus, it is not the intent of this section to claim rights or
+          contest your rights to work written entirely by you; rather,
+          the intent is to exercise the right to control the distribution
+          of derivative or collective works based on the Library.
+        </p>
+        <p>
+          In addition, mere aggregation of another work not based on
+          the Library with the Library (or with a work based on the
+          Library) on a volume of a storage or distribution medium does
+          not bring the other work under the scope of this License.
+        </p>
+      </item>
+      <item>
+        <bullet>3.</bullet>
+        You may opt to apply the terms of the ordinary GNU General
+        Public License instead of this License to a given copy of the
+        Library. To do this, you must alter all the notices that refer
+        to this License, so that they refer to the ordinary GNU General
+        Public License, version 2, instead of to this License. (If a
+        newer version than version 2 of the ordinary GNU General Public
+        License has appeared, then you can specify that version instead
+        if you wish.) Do not make any other change in these notices.
+        <p>
+          Once this change is made in a given copy, it is irreversible for
+          that copy, so the ordinary GNU General Public License applies to
+          all subsequent copies and derivative works made from that copy.
+        </p>
+        <p>
+          This option is useful when you wish to copy part of the
+          code of the Library into a program that is not a library.
+        </p>
+      </item>
+      <item>
+        <bullet>4.</bullet>
+        You may copy and distribute the Library (or a portion or derivative
+        of it, under Section 2) in object code or executable form under
+        the terms of Sections 1 and 2 above provided that you accompany
+        it with the complete corresponding machine-readable source code,
+        which must be distributed under the terms of Sections 1 and 2
+        above on a medium customarily used for software interchange.
+        <p>
+          If distribution of object code is made by offering access to copy
+          from a designated place, then offering equivalent access to copy
+          the source code from the same place satisfies the requirement
+          to distribute the source code, even though third parties are
+          not compelled to copy the source along with the object code.
+        </p>
+      </item>
+      <item>
+        <bullet>5.</bullet>
+        A program that contains no derivative of any portion of the
+        Library, but is designed to work with the Library by being compiled
+        or linked with it, is called a "work that uses the Library".
+        Such a work, in isolation, is not a derivative work of the
+        Library, and therefore falls outside the scope of this License.
+        <p>
+          However, linking a "work that uses the Library" with the Library
+          creates an executable that is a derivative of the Library (because
+          it contains portions of the Library), rather than a "work that uses
+          the library". The executable is therefore covered by this License.
+          Section 6 states terms for distribution of such executables.
+        </p>
+        <p>
+          When a "work that uses the Library" uses material from a header
+          file that is part of the Library, the object code for the work may
+          be a derivative work of the Library even though the source code is
+          not. Whether this is true is especially significant if the work can
+          be linked without the Library, or if the work is itself a library.
+          The threshold for this to be true is not precisely defined by law.
+        </p>
+        <p>
+          If such an object file uses only numerical parameters, data
+          structure layouts and accessors, and small macros and small inline
+          functions (ten lines or less in length), then the use of the
+          object file is unrestricted, regardless of whether it is legally
+          a derivative work. (Executables containing this object code
+          plus portions of the Library will still fall under Section 6.)
+        </p>
+        <p>
+          Otherwise, if the work is a derivative of the Library, you may
+          distribute the object code for the work under the terms of Section
+          6. Any executables containing that work also fall under Section 6,
+          whether or not they are linked directly with the Library itself.
+        </p>
+      </item>
+      <item>
+        <bullet>6.</bullet>
+        As an exception to the Sections above, you may also combine or
+        link a "work that uses the Library" with the Library to produce
+        a work containing portions of the Library, and distribute
+        that work under terms of your choice, provided that the terms
+        permit modification of the work for the customer's own use
+        and reverse engineering for debugging such modifications.
+        <p>
+          You must give prominent notice with each copy of the work
+          that the Library is used in it and that the Library and its
+          use are covered by this License. You must supply a copy of
+          this License. If the work during execution displays copyright
+          notices, you must include the copyright notice for the Library
+          among them, as well as a reference directing the user to the
+          copy of this License. Also, you must do one of these things:
+        </p>
         <list>
-               <item>
-                  <bullet>a)</bullet>
-            Accompany the combined library with a copy of the same work based on the Library, uncombined
-               with any other library facilities. This must be distributed under the terms of the
-               Sections above.
+          <item>
+            <bullet>a)</bullet>
+            Accompany the work with the complete corresponding machine-readable
+            source code for the Library including whatever changes were used in
+            the work (which must be distributed under Sections 1 and 2 above);
+            and, if the work is an executable linked with the Library, with the
+            complete machine-readable "work that uses the Library", as object
+            code and/or source code, so that the user can modify the Library
+            and then relink to produce a modified executable containing the
+            modified Library. (It is understood that the user who changes the
+            contents of definitions files in the Library will not necessarily be
+            able to recompile the application to use the modified definitions.)
           </item>
-               <item>
-                  <bullet>b)</bullet>
-            Give prominent notice with the combined library of the fact that part of it is a work based
-               on the Library, and explaining where to find the accompanying uncombined form of the same
-               work.
+          <item>
+            <bullet>b)</bullet>
+            Use a suitable shared library mechanism for linking with the
+            Library. A suitable mechanism is one that (1) uses at run time a
+            copy of the library already present on the user's computer system,
+            rather than copying library functions into the executable, and
+            (2) will operate properly with a modified version of the library,
+            if the user installs one, as long as the modified version is
+            interface-compatible with the version that the work was made with.
           </item>
-            </list>
-        </item>
-        <item>
-            <bullet>8.</bullet>
-          You may not copy, modify, sublicense, link with, or distribute the Library except as expressly
-             provided under this License. Any attempt otherwise to copy, modify, sublicense, link with, or
-             distribute the Library is void, and will automatically terminate your rights under this
-             License. However, parties who have received copies, or rights, from you under this License
-             will not have their licenses terminated so long as such parties remain in full compliance.
-        </item>
-        <item>
-            <bullet>9.</bullet>
-          You are not required to accept this License, since you have not signed it. However, nothing else
-             grants you permission to modify or distribute the Library or its derivative works. These
-             actions are prohibited by law if you do not accept this License. Therefore, by modifying or
-             distributing the Library (or any work based on the Library), you indicate your acceptance of
-             this License to do so, and all its terms and conditions for copying, distributing or modifying
-             the Library or works based on it.
-        </item>
-        <item>
-            <bullet>10.</bullet>
-          Each time you redistribute the Library (or any work based on the Library), the recipient
-             automatically receives a license from the original licensor to copy, distribute, link with or
-             modify the Library subject to these terms and conditions. You may not impose any further
-             restrictions on the recipients' exercise of the rights granted herein. You are not
-             responsible for enforcing compliance by third parties with this License.
-        </item>
-        <item>
-            <bullet>11.</bullet>
-          If, as a consequence of a court judgment or allegation of patent infringement or for any other
-             reason (not limited to patent issues), conditions are imposed on you (whether by court order,
-             agreement or otherwise) that contradict the conditions of this License, they do not excuse you
-             from the conditions of this License. If you cannot distribute so as to satisfy simultaneously
-             your obligations under this License and any other pertinent obligations, then as a consequence
-             you may not distribute the Library at all. For example, if a patent license would not permit
-             royalty-free redistribution of the Library by all those who receive copies directly or
-             indirectly through you, then the only way you could satisfy both it and this License would be
-             to refrain entirely from distribution of the Library.
-          <p>If any portion of this section is held invalid or unenforceable under any particular
-             circumstance, the balance of the section is intended to apply, and the section as a whole is
-             intended to apply in other circumstances.</p>
-            <p>It is not the purpose of this section to induce you to infringe any patents or other property
-             right claims or to contest validity of any such claims; this section has the sole purpose of
-             protecting the integrity of the free software distribution system which is implemented by
-             public license practices. Many people have made generous contributions to the wide range of
-             software distributed through that system in reliance on consistent application of that system;
-             it is up to the author/donor to decide if he or she is willing to distribute software through
-             any other system and a licensee cannot impose that choice.</p>
-            <p>This section is intended to make thoroughly clear what is believed to be a consequence of the
-             rest of this License.</p>
-        </item>
-        <item>
-            <bullet>12.</bullet>
-          If the distribution and/or use of the Library is restricted in certain countries either by
-             patents or by copyrighted interfaces, the original copyright holder who places the Library
-             under this License may add an explicit geographical distribution limitation excluding those
-             countries, so that distribution is permitted only in or among countries not thus excluded. In
-             such case, this License incorporates the limitation as if written in the body of this
-             License.
-        </item>
-        <item>
-            <bullet>13.</bullet>
-          The Free Software Foundation may publish revised and/or new versions of the Lesser General Public
-             License from time to time. Such new versions will be similar in spirit to the present version,
-             but may differ in detail to address new problems or concerns.
-          <p>Each version is given a distinguishing version number. If the Library specifies a version number
-             of this License which applies to it and "any later version", you have the option of
-             following the terms and conditions either of that version or of any later version published by
-             the Free Software Foundation. If the Library does not specify a license version number, you
-             may choose any version ever published by the Free Software Foundation.</p>
-        </item>
-        <item>
-            <bullet>14.</bullet>
-          If you wish to incorporate parts of the Library into other free programs whose distribution
-             conditions are incompatible with these, write to the author to ask for permission. For
-             software which is copyrighted by the Free Software Foundation, write to the Free Software
-             Foundation; we sometimes make exceptions for this. Our decision will be guided by the two
-             goals of preserving the free status of all derivatives of our free software and of promoting
-             the sharing and reuse of software generally.
-          <p>NO WARRANTY</p>
-        </item>
-        <item>
-            <bullet>15.</bullet>
-          BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY FOR THE LIBRARY, TO THE
-             EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
-             HOLDERS AND/OR OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
-             KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-             MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND
-             PERFORMANCE OF THE LIBRARY IS WITH YOU. SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME THE
-             COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
-        </item>
-        <item>
-            <bullet>16.</bullet>
-          IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY COPYRIGHT HOLDER,
-             OR ANY OTHER PARTY WHO MAY MODIFY AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE
-             LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES
-             ARISING OUT OF THE USE OR INABILITY TO USE THE LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF
-             DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
-             FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF SUCH HOLDER OR OTHER PARTY
-             HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
-        </item>
-      </list>
-      <optional>
-         <p>END OF TERMS AND CONDITIONS</p>
-         <p>How to Apply These Terms to Your New Libraries</p>
-         <p>If you develop a new library, and you want it to be of the greatest possible use to the public, we
-         recommend making it free software that everyone can redistribute and change. You can do so by
-         permitting redistribution under these terms (or, alternatively, under the terms of the ordinary
-         General Public License).</p>
-         <p>To apply these terms, attach the following notices to the library. It is safest to attach them to the
-         start of each source file to most effectively convey the exclusion of warranty; and each file should
-         have at least the "copyright" line and a pointer to where the full notice is found.</p>
-         <p><optional>&lt;</optional>one line to give the library's name and an idea of what it does.<optional>&gt;</optional>
-        <br/>Copyright (C) <optional>&lt;</optional>year<optional>&gt;</optional> <optional>&lt;</optional>name of author<optional>&gt;</optional>
+          <item>
+            <bullet>c)</bullet>
+            Accompany the work with a written offer, valid for at
+            least three years, to give the same user the materials
+            specified in Subsection 6a, above, for a charge no
+            more than the cost of performing this distribution.
+          </item>
+          <item>
+            <bullet>d)</bullet>
+            If distribution of the work is made by offering access to
+            copy from a designated place, offer equivalent access to
+            copy the above specified materials from the same place.
+          </item>
+          <item>
+            <bullet>e)</bullet>
+            Verify that the user has already received a copy of these
+            materials or that you have already sent this user a copy.
+          </item>
+        </list>
+        <p>
+          For an executable, the required form of the "work that uses
+          the Library" must include any data and utility programs needed
+          for reproducing the executable from it. However, as a special
+          exception, the materials to be distributed need not include
+          anything that is normally distributed (in either source or
+          binary form) with the major components (compiler, kernel,
+          and so on) of the operating system on which the executable
+          runs, unless that component itself accompanies the executable.
+        </p>
+        <p>
+          It may happen that this requirement contradicts the
+          license restrictions of other proprietary libraries that
+          do not normally accompany the operating system. Such
+          a contradiction means you cannot use both them and the
+          Library together in an executable that you distribute.
+        </p>
+      </item>
+      <item>
+        <bullet>7.</bullet>
+        You may place library facilities that are a work based on the
+        Library side-by-side in a single library together with other library
+        facilities not covered by this License, and distribute such a
+        combined library, provided that the separate distribution of the
+        work based on the Library and of the other library facilities is
+        otherwise permitted, and provided that you do these two things:
+        <list>
+          <item>
+            <bullet>a)</bullet>
+            Accompany the combined library with a copy of the same work based
+            on the Library, uncombined with any other library facilities.
+            This must be distributed under the terms of the Sections above.
+          </item>
+          <item>
+            <bullet>b)</bullet>
+            Give prominent notice with the combined library of the fact
+            that part of it is a work based on the Library, and explaining
+            where to find the accompanying uncombined form of the same work.
+          </item>
+        </list>
+      </item>
+      <item>
+        <bullet>8.</bullet>
+        You may not copy, modify, sublicense, link with, or distribute the
+        Library except as expressly provided under this License. Any attempt
+        otherwise to copy, modify, sublicense, link with, or distribute
+        the Library is void, and will automatically terminate your rights
+        under this License. However, parties who have received copies, or
+        rights, from you under this License will not have their licenses
+        terminated so long as such parties remain in full compliance.
+      </item>
+      <item>
+        <bullet>9.</bullet>
+        You are not required to accept this License, since you have
+        not signed it. However, nothing else grants you permission to
+        modify or distribute the Library or its derivative works. These
+        actions are prohibited by law if you do not accept this License.
+        Therefore, by modifying or distributing the Library (or any
+        work based on the Library), you indicate your acceptance of this
+        License to do so, and all its terms and conditions for copying,
+        distributing or modifying the Library or works based on it.
+      </item>
+      <item>
+        <bullet>10.</bullet>
+        Each time you redistribute the Library (or any work based on
+        the Library), the recipient automatically receives a license
+        from the original licensor to copy, distribute, link with or
+        modify the Library subject to these terms and conditions. You
+        may not impose any further restrictions on the recipients'
+        exercise of the rights granted herein. You are not responsible
+        for enforcing compliance by third parties with this License.
+      </item>
+      <item>
+        <bullet>11.</bullet>
+        If, as a consequence of a court judgment or allegation of patent
+        infringement or for any other reason (not limited to patent issues),
+        conditions are imposed on you (whether by court order, agreement
+        or otherwise) that contradict the conditions of this License,
+        they do not excuse you from the conditions of this License. If you
+        cannot distribute so as to satisfy simultaneously your obligations
+        under this License and any other pertinent obligations, then as a
+        consequence you may not distribute the Library at all. For example,
+        if a patent license would not permit royalty-free redistribution of
+        the Library by all those who receive copies directly or indirectly
+        through you, then the only way you could satisfy both it and this
+        License would be to refrain entirely from distribution of the Library.
+        <p>
+          If any portion of this section is held invalid or
+          unenforceable under any particular circumstance, the
+          balance of the section is intended to apply, and the section
+          as a whole is intended to apply in other circumstances.
+        </p>
+        <p>
+          It is not the purpose of this section to induce you to infringe
+          any patents or other property right claims or to contest
+          validity of any such claims; this section has the sole purpose
+          of protecting the integrity of the free software distribution
+          system which is implemented by public license practices. Many
+          people have made generous contributions to the wide range of
+          software distributed through that system in reliance on consistent
+          application of that system; it is up to the author/donor to
+          decide if he or she is willing to distribute software through
+          any other system and a licensee cannot impose that choice.
+        </p>
+        <p>
+          This section is intended to make thoroughly clear what is
+          believed to be a consequence of the rest of this License.
+        </p>
+      </item>
+      <item>
+        <bullet>12.</bullet>
+        If the distribution and/or use of the Library is restricted in
+        certain countries either by patents or by copyrighted interfaces,
+        the original copyright holder who places the Library under this
+        License may add an explicit geographical distribution limitation
+        excluding those countries, so that distribution is permitted only
+        in or among countries not thus excluded. In such case, this License
+        incorporates the limitation as if written in the body of this License.
+      </item>
+      <item>
+        <bullet>13.</bullet>
+        The Free Software Foundation may publish revised and/or new
+        versions of the Lesser General Public License from time to time.
+        Such new versions will be similar in spirit to the present version,
+        but may differ in detail to address new problems or concerns.
+        <p>
+          Each version is given a distinguishing version number. If
+          the Library specifies a version number of this License which
+          applies to it and "any later version", you have the option of
+          following the terms and conditions either of that version or of
+          any later version published by the Free Software Foundation. If
+          the Library does not specify a license version number, you may
+          choose any version ever published by the Free Software Foundation.
+        </p>
+      </item>
+      <item>
+        <bullet>14.</bullet>
+        If you wish to incorporate parts of the Library into other free programs
+        whose distribution conditions are incompatible with these, write to
+        the author to ask for permission. For software which is copyrighted by
+        the Free Software Foundation, write to the Free Software Foundation; we
+        sometimes make exceptions for this. Our decision will be guided by the
+        two goals of preserving the free status of all derivatives of our free
+        software and of promoting the sharing and reuse of software generally.
+        <p>
+          NO WARRANTY
+        </p>
+      </item>
+      <item>
+        <bullet>15.</bullet>
+        BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+        FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT
+        WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER
+        PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY KIND,
+        EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+        IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+        PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF
+        THE LIBRARY IS WITH YOU. SHOULD THE LIBRARY PROVE DEFECTIVE, YOU
+        ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+      </item>
+      <item>
+        <bullet>16.</bullet>
+        IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+        WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+        REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU FOR
+        DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL
+        DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE LIBRARY
+        (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED
+        INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF
+        THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF SUCH HOLDER
+        OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+      </item>
+    </list>
+    <optional>
+      <p>
+        END OF TERMS AND CONDITIONS
       </p>
-         <p>This library is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser
-         General Public License as published by the Free Software Foundation; either version 2.1 of the
-         License, or (at your option) any later version.</p>
-         <p>This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
-         the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
-         General Public License for more details.</p>
-         <p>You should have received a copy of the GNU Lesser General Public License along with this library; if not,
-         write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301
-         USA Also add information on how to contact you by electronic and paper mail.</p>
-         <p>You should also get your employer (if you work as a programmer) or your school, if any, to sign a
-         "copyright disclaimer" for the library, if necessary. Here is a sample; alter the names:</p>
-         <p>Yoyodyne, Inc., hereby disclaims all copyright interest in
-        <br/>the library `Frob' (a library for tweaking knobs) written
-        <br/>by James Random Hacker.
+      <p>
+        How to Apply These Terms to Your New Libraries
       </p>
-         <p><optional>&lt;</optional>signature of Ty Coon<optional>&gt;</optional>, 1 April 1990 
-        <br/>Ty Coon, President of Vice
-        <br/>That's all there is to it!
+      <p>
+        If you develop a new library, and you want it to be of the greatest
+        possible use to the public, we recommend making it free software
+        that everyone can redistribute and change. You can do so by
+        permitting redistribution under these terms (or, alternatively,
+        under the terms of the ordinary General Public License).
       </p>
-      </optional>
+      <p>
+        To apply these terms, attach the following notices to the
+        library. It is safest to attach them to the start of each
+        source file to most effectively convey the exclusion of
+        warranty; and each file should have at least the "copyright"
+        line and a pointer to where the full notice is found.
+      </p>
+      <p>
+	<optional>&lt;</optional>one line to give the library's name
+	and an idea of what it does.<optional>&gt;</optional>
+        <br></br>
+        Copyright (C)
+        <optional>&lt;</optional>year<optional>&gt;</optional>
+        <optional>&lt;</optional>name of author<optional>&gt;</optional>
+      </p>
+      <p>
+        This library is free software; you can redistribute it and/or
+        modify it under the terms of the GNU Lesser General Public
+        License as published by the Free Software Foundation; either
+        version 2.1 of the License, or (at your option) any later version.
+      </p>
+      <p>
+        This library is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty
+        of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+        See the GNU Lesser General Public License for more details.
+      </p>
+      <p>
+        You should have received a copy of the GNU Lesser General Public License
+        along with this library; if not, write to the Free Software Foundation,
+        Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA Also
+        add information on how to contact you by electronic and paper mail.
+      </p>
+      <p>
+        You should also get your employer (if you work as a programmer)
+        or your school, if any, to sign a "copyright disclaimer" for
+        the library, if necessary. Here is a sample; alter the names:
+      </p>
+      <p>
+        Yoyodyne, Inc., hereby disclaims all copyright interest in<br></br>
+        the library `Frob' (a library for tweaking knobs) written<br></br>
+        by James Random Hacker.
+      </p>
+      <p>
+	<optional>&lt;</optional>signature of Ty Coon<optional>&gt;</optional>,
+	1 April 1990<br></br>
+        Ty Coon, President of Vice<br></br>
+        That's all there is to it!
+      </p>
+    </optional>
   </license>
 </SPDXLicenseCollection>

--- a/src/LGPL-2.1.xml
+++ b/src/LGPL-2.1.xml
@@ -1,11 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
   <license licenseId="LGPL-2.1" isOsiApproved="true"
-  name="GNU Lesser General Public License v2.1 only">
+  name="GNU Lesser General Public License v2.1 only"
+  isDeprecated="true" deprecatedVersion="3.0">
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</crossRef>
       <crossRef>http://www.opensource.org/licenses/LGPL-2.1</crossRef>
     </crossRefs>
+    <notes>
+      DEPRECATED: Deprecated in lieu of more
+      explicit license identifier of LGPL-2.1-only
+    </notes>
     <standardLicenseHeader>
       Copyright (C)<alt name="copyright" match=".+">year name of author</alt>
       <p>

--- a/src/LGPL-3.0-only.xml
+++ b/src/LGPL-3.0-only.xml
@@ -1,0 +1,257 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SPDXLicenseCollection xmlns="http://www.spdx.org/license">
+  <license licenseId="LGPL-3.0" isOsiApproved="true"
+  name="GNU Lesser General Public License v3.0 only">
+    <crossRefs>
+      <crossRef>http://www.gnu.org/licenses/lgpl-3.0-standalone.html</crossRef>
+      <crossRef>http://www.opensource.org/licenses/LGPL-3.0</crossRef>
+    </crossRefs>
+    <notes>
+      This license was released: 29 June 2007. This refers to when
+      this LGPL 3.0 only is being used (as opposed to "or later).
+    </notes>
+    <titleText>
+      <p>
+        GNU LESSER GENERAL PUBLIC LICENSE<br></br>
+        Version 3, 29 June 2007
+      </p>
+    </titleText>
+    <p>
+      Copyright (C) 2007 Free Software Foundation, Inc.
+      &lt;http<optional>s</optional>://fsf.org/&gt;
+    </p>
+    <p>
+      Everyone is permitted to copy and distribute verbatim copies
+      of this license document, but changing it is not allowed.
+    </p>
+    <p>
+      This version of the GNU Lesser General Public License incorporates
+      the terms and conditions of version 3 of the GNU General Public
+      License, supplemented by the additional permissions listed below.
+    </p>
+    <list>
+      <item>
+        <bullet>0.</bullet>
+        Additional Definitions.
+        <list>
+          <item>
+            <p>
+              As used herein, "this License" refers to version 3 of
+              the GNU Lesser General Public License, and the "GNU GPL"
+              refers to version 3 of the GNU General Public License.
+            </p>
+          </item>
+          <item>
+            <p>
+              "The Library" refers to a covered work governed by this License,
+              other than an Application or a Combined Work as defined below.
+            </p>
+          </item>
+          <item>
+            <p>
+              An "Application" is any work that makes use of an interface
+              provided by the Library, but which is not otherwise based on the
+              Library. Defining a subclass of a class defined by the Library
+              is deemed a mode of using an interface provided by the Library.
+            </p>
+          </item>
+          <item>
+            <p>
+              A "Combined Work" is a work produced by combining or
+              linking an Application with the Library. The particular
+              version of the Library with which the Combined
+              Work was made is also called the "Linked Version".
+            </p>
+          </item>
+          <item>
+            <p>
+              The "Minimal Corresponding Source" for a Combined
+              Work means the Corresponding Source for the Combined
+              Work, excluding any source code for portions of the
+              Combined Work that, considered in isolation, are based
+              on the Application, and not on the Linked Version.
+            </p>
+          </item>
+          <item>
+            <p>
+              The "Corresponding Application Code" for a Combined
+              Work means the object code and/or source code for the
+              Application, including any data and utility programs needed
+              for reproducing the Combined Work from the Application,
+              but excluding the System Libraries of the Combined Work.
+            </p>
+          </item>
+        </list>
+      </item>
+      <item>
+        <bullet>1.</bullet>
+        Exception to Section 3 of the GNU GPL.<br></br>
+        You may convey a covered work under sections 3 and 4 of this
+        License without being bound by section 3 of the GNU GPL.
+      </item>
+      <item>
+        <bullet>2.</bullet>
+        Conveying Modified Versions.<br></br>
+        If you modify a copy of the Library, and, in your
+        modifications, a facility refers to a function or data
+        to be supplied by an Application that uses the facility
+        (other than as an argument passed when the facility is
+        invoked), then you may convey a copy of the modified version:
+        <list>
+          <item>
+            <bullet>a)</bullet>
+            under this License, provided that you make a good faith
+            effort to ensure that, in the event an Application does not
+            supply the function or data, the facility still operates, and
+            performs whatever part of its purpose remains meaningful, or
+          </item>
+          <item>
+            <bullet>b)</bullet>
+            under the GNU GPL, with none of the additional
+            permissions of this License applicable to that copy.
+          </item>
+        </list>
+      </item>
+      <item>
+        <bullet>3.</bullet>
+        Object Code Incorporating Material from Library Header Files.<br></br>
+        The object code form of an Application may incorporate material from
+        a header file that is part of the Library. You may convey such object
+        code under terms of your choice, provided that, if the incorporated
+        material is not limited to numerical parameters, data structure
+        layouts and accessors, or small macros, inline functions and templates
+        (ten or fewer lines in length), you do both of the following:
+        <list>
+          <item>
+            <bullet>a)</bullet>
+            Give prominent notice with each copy of the object
+            code that the Library is used in it and that the
+            Library and its use are covered by this License.
+          </item>
+          <item>
+            <bullet>b)</bullet>
+            Accompany the object code with a copy of
+            the GNU GPL and this license document.
+          </item>
+        </list>
+      </item>
+      <item>
+        <bullet>4.</bullet>
+        Combined Works.<br></br>
+        You may convey a Combined Work under terms of your choice that, taken
+        together, effectively do not restrict modification of the portions of
+        the Library contained in the Combined Work and reverse engineering for
+        debugging such modifications, if you also do each of the following:
+        <list>
+          <item>
+            <bullet>a)</bullet>
+            Give prominent notice with each copy of the Combined
+            Work that the Library is used in it and that the
+            Library and its use are covered by this License.
+          </item>
+          <item>
+            <bullet>b)</bullet>
+            Accompany the Combined Work with a copy
+            of the GNU GPL and this license document.
+          </item>
+          <item>
+            <bullet>c)</bullet>
+            For a Combined Work that displays copyright notices during
+            execution, include the copyright notice for the Library
+            among these notices, as well as a reference directing the
+            user to the copies of the GNU GPL and this license document.
+          </item>
+          <item>
+            <bullet>d)</bullet>
+            Do one of the following:
+            <list>
+              <item>
+                <bullet>0)</bullet>
+                Convey the Minimal Corresponding Source under the terms
+                of this License, and the Corresponding Application Code
+                in a form suitable for, and under terms that permit,
+                the user to recombine or relink the Application with
+                a modified version of the Linked Version to produce a
+                modified Combined Work, in the manner specified by section
+                6 of the GNU GPL for conveying Corresponding Source.
+              </item>
+              <item>
+                <bullet>1)</bullet>
+                Use a suitable shared library mechanism for linking
+                with the Library. A suitable mechanism is one that
+                (a) uses at run time a copy of the Library already
+                present on the user's computer system, and (b) will
+                operate properly with a modified version of the Library
+                that is interface-compatible with the Linked Version.
+              </item>
+            </list>
+          </item>
+          <item>
+            <bullet>e)</bullet>
+            Provide Installation Information, but only if you would otherwise
+            be required to provide such information under section 6 of the GNU
+            GPL, and only to the extent that such information is necessary to
+            install and execute a modified version of the Combined Work produced
+            by recombining or relinking the Application with a modified version
+            of the Linked Version. (If you use option 4d0, the Installation
+            Information must accompany the Minimal Corresponding Source and
+            Corresponding Application Code. If you use option 4d1, you must
+            provide the Installation Information in the manner specified by
+            section 6 of the GNU GPL for conveying Corresponding Source.)
+          </item>
+        </list>
+      </item>
+      <item>
+        <bullet>5.</bullet>
+        Combined Libraries.<br></br>
+        You may place library facilities that are a work based on
+        the Library side by side in a single library together with
+        other library facilities that are not Applications and are not
+        covered by this License, and convey such a combined library
+        under terms of your choice, if you do both of the following:
+        <list>
+          <item>
+            <bullet>a)</bullet>
+            Accompany the combined library with a copy of the same work
+            based on the Library, uncombined with any other library
+            facilities, conveyed under the terms of this License.
+          </item>
+          <item>
+            <bullet>b)</bullet>
+            Give prominent notice with the combined library that part
+            of it is a work based on the Library, and explaining where
+            to find the accompanying uncombined form of the same work.
+          </item>
+        </list>
+      </item>
+      <item>
+        <bullet>6.</bullet>
+        Revised Versions of the GNU Lesser General Public License.
+        <p>
+          The Free Software Foundation may publish revised and/or new versions
+          of the GNU Lesser General Public License from time to time. Such
+          new versions will be similar in spirit to the present version,
+          but may differ in detail to address new problems or concerns.
+        </p>
+        <p>
+          Each version is given a distinguishing version number. If the Library
+          as you received it specifies that a certain numbered version of the
+          GNU Lesser General Public License "or any later version" applies
+          to it, you have the option of following the terms and conditions
+          either of that published version or of any later version published
+          by the Free Software Foundation. If the Library as you received it
+          does not specify a version number of the GNU Lesser General Public
+          License, you may choose any version of the GNU Lesser General
+          Public License ever published by the Free Software Foundation.
+        </p>
+        <p>
+          If the Library as you received it specifies that a proxy
+          can decide whether future versions of the GNU Lesser
+          General Public License shall apply, that proxy's public
+          statement of acceptance of any version is permanent
+          authorization for you to choose that version for the Library.
+        </p>
+      </item>
+    </list>
+  </license>
+</SPDXLicenseCollection>

--- a/src/LGPL-3.0-only.xml
+++ b/src/LGPL-3.0-only.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-  <license licenseId="LGPL-3.0" isOsiApproved="true"
+  <license licenseId="LGPL-3.0-only" isOsiApproved="true"
   name="GNU Lesser General Public License v3.0 only">
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/lgpl-3.0-standalone.html</crossRef>

--- a/src/LGPL-3.0-or-later.xml
+++ b/src/LGPL-3.0-or-later.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-  <license licenseId="LGPL-3.0" isOsiApproved="true"
-  name="GNU Lesser General Public License v3.0 only">
+  <license licenseId="LGPL-3.0-or-later" isOsiApproved="true"
+  name="GNU Lesser General Public License v3.0 or later">
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/lgpl-3.0-standalone.html</crossRef>
       <crossRef>http://www.opensource.org/licenses/LGPL-3.0</crossRef>

--- a/src/LGPL-3.0-or-later.xml
+++ b/src/LGPL-3.0-or-later.xml
@@ -1,0 +1,257 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SPDXLicenseCollection xmlns="http://www.spdx.org/license">
+  <license licenseId="LGPL-3.0" isOsiApproved="true"
+  name="GNU Lesser General Public License v3.0 only">
+    <crossRefs>
+      <crossRef>http://www.gnu.org/licenses/lgpl-3.0-standalone.html</crossRef>
+      <crossRef>http://www.opensource.org/licenses/LGPL-3.0</crossRef>
+    </crossRefs>
+    <notes>
+      This license was released: 29 June 2007. This refers to when
+      this LGPL 3.0 only is being used (as opposed to "or later).
+    </notes>
+    <titleText>
+      <p>
+        GNU LESSER GENERAL PUBLIC LICENSE<br></br>
+        Version 3, 29 June 2007
+      </p>
+    </titleText>
+    <p>
+      Copyright (C) 2007 Free Software Foundation, Inc.
+      &lt;http<optional>s</optional>://fsf.org/&gt;
+    </p>
+    <p>
+      Everyone is permitted to copy and distribute verbatim copies
+      of this license document, but changing it is not allowed.
+    </p>
+    <p>
+      This version of the GNU Lesser General Public License incorporates
+      the terms and conditions of version 3 of the GNU General Public
+      License, supplemented by the additional permissions listed below.
+    </p>
+    <list>
+      <item>
+        <bullet>0.</bullet>
+        Additional Definitions.
+        <list>
+          <item>
+            <p>
+              As used herein, "this License" refers to version 3 of
+              the GNU Lesser General Public License, and the "GNU GPL"
+              refers to version 3 of the GNU General Public License.
+            </p>
+          </item>
+          <item>
+            <p>
+              "The Library" refers to a covered work governed by this License,
+              other than an Application or a Combined Work as defined below.
+            </p>
+          </item>
+          <item>
+            <p>
+              An "Application" is any work that makes use of an interface
+              provided by the Library, but which is not otherwise based on the
+              Library. Defining a subclass of a class defined by the Library
+              is deemed a mode of using an interface provided by the Library.
+            </p>
+          </item>
+          <item>
+            <p>
+              A "Combined Work" is a work produced by combining or
+              linking an Application with the Library. The particular
+              version of the Library with which the Combined
+              Work was made is also called the "Linked Version".
+            </p>
+          </item>
+          <item>
+            <p>
+              The "Minimal Corresponding Source" for a Combined
+              Work means the Corresponding Source for the Combined
+              Work, excluding any source code for portions of the
+              Combined Work that, considered in isolation, are based
+              on the Application, and not on the Linked Version.
+            </p>
+          </item>
+          <item>
+            <p>
+              The "Corresponding Application Code" for a Combined
+              Work means the object code and/or source code for the
+              Application, including any data and utility programs needed
+              for reproducing the Combined Work from the Application,
+              but excluding the System Libraries of the Combined Work.
+            </p>
+          </item>
+        </list>
+      </item>
+      <item>
+        <bullet>1.</bullet>
+        Exception to Section 3 of the GNU GPL.<br></br>
+        You may convey a covered work under sections 3 and 4 of this
+        License without being bound by section 3 of the GNU GPL.
+      </item>
+      <item>
+        <bullet>2.</bullet>
+        Conveying Modified Versions.<br></br>
+        If you modify a copy of the Library, and, in your
+        modifications, a facility refers to a function or data
+        to be supplied by an Application that uses the facility
+        (other than as an argument passed when the facility is
+        invoked), then you may convey a copy of the modified version:
+        <list>
+          <item>
+            <bullet>a)</bullet>
+            under this License, provided that you make a good faith
+            effort to ensure that, in the event an Application does not
+            supply the function or data, the facility still operates, and
+            performs whatever part of its purpose remains meaningful, or
+          </item>
+          <item>
+            <bullet>b)</bullet>
+            under the GNU GPL, with none of the additional
+            permissions of this License applicable to that copy.
+          </item>
+        </list>
+      </item>
+      <item>
+        <bullet>3.</bullet>
+        Object Code Incorporating Material from Library Header Files.<br></br>
+        The object code form of an Application may incorporate material from
+        a header file that is part of the Library. You may convey such object
+        code under terms of your choice, provided that, if the incorporated
+        material is not limited to numerical parameters, data structure
+        layouts and accessors, or small macros, inline functions and templates
+        (ten or fewer lines in length), you do both of the following:
+        <list>
+          <item>
+            <bullet>a)</bullet>
+            Give prominent notice with each copy of the object
+            code that the Library is used in it and that the
+            Library and its use are covered by this License.
+          </item>
+          <item>
+            <bullet>b)</bullet>
+            Accompany the object code with a copy of
+            the GNU GPL and this license document.
+          </item>
+        </list>
+      </item>
+      <item>
+        <bullet>4.</bullet>
+        Combined Works.<br></br>
+        You may convey a Combined Work under terms of your choice that, taken
+        together, effectively do not restrict modification of the portions of
+        the Library contained in the Combined Work and reverse engineering for
+        debugging such modifications, if you also do each of the following:
+        <list>
+          <item>
+            <bullet>a)</bullet>
+            Give prominent notice with each copy of the Combined
+            Work that the Library is used in it and that the
+            Library and its use are covered by this License.
+          </item>
+          <item>
+            <bullet>b)</bullet>
+            Accompany the Combined Work with a copy
+            of the GNU GPL and this license document.
+          </item>
+          <item>
+            <bullet>c)</bullet>
+            For a Combined Work that displays copyright notices during
+            execution, include the copyright notice for the Library
+            among these notices, as well as a reference directing the
+            user to the copies of the GNU GPL and this license document.
+          </item>
+          <item>
+            <bullet>d)</bullet>
+            Do one of the following:
+            <list>
+              <item>
+                <bullet>0)</bullet>
+                Convey the Minimal Corresponding Source under the terms
+                of this License, and the Corresponding Application Code
+                in a form suitable for, and under terms that permit,
+                the user to recombine or relink the Application with
+                a modified version of the Linked Version to produce a
+                modified Combined Work, in the manner specified by section
+                6 of the GNU GPL for conveying Corresponding Source.
+              </item>
+              <item>
+                <bullet>1)</bullet>
+                Use a suitable shared library mechanism for linking
+                with the Library. A suitable mechanism is one that
+                (a) uses at run time a copy of the Library already
+                present on the user's computer system, and (b) will
+                operate properly with a modified version of the Library
+                that is interface-compatible with the Linked Version.
+              </item>
+            </list>
+          </item>
+          <item>
+            <bullet>e)</bullet>
+            Provide Installation Information, but only if you would otherwise
+            be required to provide such information under section 6 of the GNU
+            GPL, and only to the extent that such information is necessary to
+            install and execute a modified version of the Combined Work produced
+            by recombining or relinking the Application with a modified version
+            of the Linked Version. (If you use option 4d0, the Installation
+            Information must accompany the Minimal Corresponding Source and
+            Corresponding Application Code. If you use option 4d1, you must
+            provide the Installation Information in the manner specified by
+            section 6 of the GNU GPL for conveying Corresponding Source.)
+          </item>
+        </list>
+      </item>
+      <item>
+        <bullet>5.</bullet>
+        Combined Libraries.<br></br>
+        You may place library facilities that are a work based on
+        the Library side by side in a single library together with
+        other library facilities that are not Applications and are not
+        covered by this License, and convey such a combined library
+        under terms of your choice, if you do both of the following:
+        <list>
+          <item>
+            <bullet>a)</bullet>
+            Accompany the combined library with a copy of the same work
+            based on the Library, uncombined with any other library
+            facilities, conveyed under the terms of this License.
+          </item>
+          <item>
+            <bullet>b)</bullet>
+            Give prominent notice with the combined library that part
+            of it is a work based on the Library, and explaining where
+            to find the accompanying uncombined form of the same work.
+          </item>
+        </list>
+      </item>
+      <item>
+        <bullet>6.</bullet>
+        Revised Versions of the GNU Lesser General Public License.
+        <p>
+          The Free Software Foundation may publish revised and/or new versions
+          of the GNU Lesser General Public License from time to time. Such
+          new versions will be similar in spirit to the present version,
+          but may differ in detail to address new problems or concerns.
+        </p>
+        <p>
+          Each version is given a distinguishing version number. If the Library
+          as you received it specifies that a certain numbered version of the
+          GNU Lesser General Public License "or any later version" applies
+          to it, you have the option of following the terms and conditions
+          either of that published version or of any later version published
+          by the Free Software Foundation. If the Library as you received it
+          does not specify a version number of the GNU Lesser General Public
+          License, you may choose any version of the GNU Lesser General
+          Public License ever published by the Free Software Foundation.
+        </p>
+        <p>
+          If the Library as you received it specifies that a proxy
+          can decide whether future versions of the GNU Lesser
+          General Public License shall apply, that proxy's public
+          statement of acceptance of any version is permanent
+          authorization for you to choose that version for the Library.
+        </p>
+      </item>
+    </list>
+  </license>
+</SPDXLicenseCollection>

--- a/src/LGPL-3.0-or-later.xml
+++ b/src/LGPL-3.0-or-later.xml
@@ -7,8 +7,7 @@
       <crossRef>http://www.opensource.org/licenses/LGPL-3.0</crossRef>
     </crossRefs>
     <notes>
-      This license was released: 29 June 2007. This refers to when
-      this LGPL 3.0 only is being used (as opposed to "or later).
+      This license was released: 29 June 2007.
     </notes>
     <titleText>
       <p>

--- a/src/LGPL-3.0.xml
+++ b/src/LGPL-3.0.xml
@@ -1,11 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
   <license licenseId="LGPL-3.0" isOsiApproved="true"
-  name="GNU Lesser General Public License v3.0 only">
+  name="GNU Lesser General Public License v3.0 only"
+  isDeprecated="true" deprecatedVersion="3.0">
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/lgpl-3.0-standalone.html</crossRef>
       <crossRef>http://www.opensource.org/licenses/LGPL-3.0</crossRef>
     </crossRefs>
+    <notes>
+      DEPRECATED: Deprecated in lieu of more
+      explicit license identifier of LGPL-3.0-only
+    </notes>
     <notes>
       This license was released: 29 June 2007. This refers to when
       this LGPL 3.0 only is being used (as opposed to "or later).

--- a/src/LGPL-3.0.xml
+++ b/src/LGPL-3.0.xml
@@ -1,206 +1,257 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isOsiApproved="true" licenseId="LGPL-3.0"
-            name="GNU Lesser General Public License v3.0 only">
-      <crossRefs>
-         <crossRef>http://www.gnu.org/licenses/lgpl-3.0-standalone.html</crossRef>
-         <crossRef>http://www.opensource.org/licenses/LGPL-3.0</crossRef>
-      </crossRefs>
-      <notes>This license was released: 29 June 2007. This refers to when this LGPL 3.0 only is being used (as opposed to
-         "or later).</notes>
-      <titleText>
-         <p>GNU LESSER GENERAL PUBLIC LICENSE 
-        <br/>Version 3, 29 June 2007 
+  <license licenseId="LGPL-3.0" isOsiApproved="true"
+  name="GNU Lesser General Public License v3.0 only">
+    <crossRefs>
+      <crossRef>http://www.gnu.org/licenses/lgpl-3.0-standalone.html</crossRef>
+      <crossRef>http://www.opensource.org/licenses/LGPL-3.0</crossRef>
+    </crossRefs>
+    <notes>
+      This license was released: 29 June 2007. This refers to when
+      this LGPL 3.0 only is being used (as opposed to "or later).
+    </notes>
+    <titleText>
+      <p>
+        GNU LESSER GENERAL PUBLIC LICENSE<br></br>
+        Version 3, 29 June 2007
       </p>
-      </titleText>
-      <p>Copyright (C) 2007 Free Software Foundation, Inc. &lt;http<optional>s</optional>://fsf.org/&gt;</p>
-      <p>Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is
-         not allowed.</p>
-      <p>This version of the GNU Lesser General Public License incorporates the terms and conditions of version 3
-         of the GNU General Public License, supplemented by the additional permissions listed below.</p>
-      <list>
-        <item>
-            <bullet>0.</bullet>
-          Additional Definitions.
-          <list>
-               <item>
-                  <p>As used herein, "this License" refers to version 3 of the GNU Lesser General Public
-                 License, and the "GNU GPL" refers to version 3 of the GNU General Public
-                 License.</p>
-               </item>
-               <item>
-                  <p>"The Library" refers to a covered work governed by this License, other than an
-                 Application or a Combined Work as defined below.</p>
-               </item>
-               <item>
-                  <p>An "Application" is any work that makes use of an interface provided by the Library,
-                 but which is not otherwise based on the Library. Defining a subclass of a class defined by the
-                 Library is deemed a mode of using an interface provided by the Library.</p>
-               </item>
-               <item>
-                  <p>A "Combined Work" is a work produced by combining or linking an Application with the
-                 Library. The particular version of the Library with which the Combined Work was made is also
-                 called the "Linked Version".</p>
-               </item>
-               <item>
-                  <p>The "Minimal Corresponding Source" for a Combined Work means the Corresponding Source
-                 for the Combined Work, excluding any source code for portions of the Combined Work that,
-                 considered in isolation, are based on the Application, and not on the Linked Version.</p>
-               </item>
-               <item>
-                  <p>The "Corresponding Application Code" for a Combined Work means the object code and/or
-                 source code for the Application, including any data and utility programs needed for
-                 reproducing the Combined Work from the Application, but excluding the System Libraries of the
-                 Combined Work.</p>
-               </item>
+    </titleText>
+    <p>
+      Copyright (C) 2007 Free Software Foundation, Inc.
+      &lt;http<optional>s</optional>://fsf.org/&gt;
+    </p>
+    <p>
+      Everyone is permitted to copy and distribute verbatim copies
+      of this license document, but changing it is not allowed.
+    </p>
+    <p>
+      This version of the GNU Lesser General Public License incorporates
+      the terms and conditions of version 3 of the GNU General Public
+      License, supplemented by the additional permissions listed below.
+    </p>
+    <list>
+      <item>
+        <bullet>0.</bullet>
+        Additional Definitions.
+        <list>
+          <item>
+            <p>
+              As used herein, "this License" refers to version 3 of
+              the GNU Lesser General Public License, and the "GNU GPL"
+              refers to version 3 of the GNU General Public License.
+            </p>
+          </item>
+          <item>
+            <p>
+              "The Library" refers to a covered work governed by this License,
+              other than an Application or a Combined Work as defined below.
+            </p>
+          </item>
+          <item>
+            <p>
+              An "Application" is any work that makes use of an interface
+              provided by the Library, but which is not otherwise based on the
+              Library. Defining a subclass of a class defined by the Library
+              is deemed a mode of using an interface provided by the Library.
+            </p>
+          </item>
+          <item>
+            <p>
+              A "Combined Work" is a work produced by combining or
+              linking an Application with the Library. The particular
+              version of the Library with which the Combined
+              Work was made is also called the "Linked Version".
+            </p>
+          </item>
+          <item>
+            <p>
+              The "Minimal Corresponding Source" for a Combined
+              Work means the Corresponding Source for the Combined
+              Work, excluding any source code for portions of the
+              Combined Work that, considered in isolation, are based
+              on the Application, and not on the Linked Version.
+            </p>
+          </item>
+          <item>
+            <p>
+              The "Corresponding Application Code" for a Combined
+              Work means the object code and/or source code for the
+              Application, including any data and utility programs needed
+              for reproducing the Combined Work from the Application,
+              but excluding the System Libraries of the Combined Work.
+            </p>
+          </item>
+        </list>
+      </item>
+      <item>
+        <bullet>1.</bullet>
+        Exception to Section 3 of the GNU GPL.<br></br>
+        You may convey a covered work under sections 3 and 4 of this
+        License without being bound by section 3 of the GNU GPL.
+      </item>
+      <item>
+        <bullet>2.</bullet>
+        Conveying Modified Versions.<br></br>
+        If you modify a copy of the Library, and, in your
+        modifications, a facility refers to a function or data
+        to be supplied by an Application that uses the facility
+        (other than as an argument passed when the facility is
+        invoked), then you may convey a copy of the modified version:
+        <list>
+          <item>
+            <bullet>a)</bullet>
+            under this License, provided that you make a good faith
+            effort to ensure that, in the event an Application does not
+            supply the function or data, the facility still operates, and
+            performs whatever part of its purpose remains meaningful, or
+          </item>
+          <item>
+            <bullet>b)</bullet>
+            under the GNU GPL, with none of the additional
+            permissions of this License applicable to that copy.
+          </item>
+        </list>
+      </item>
+      <item>
+        <bullet>3.</bullet>
+        Object Code Incorporating Material from Library Header Files.<br></br>
+        The object code form of an Application may incorporate material from
+        a header file that is part of the Library. You may convey such object
+        code under terms of your choice, provided that, if the incorporated
+        material is not limited to numerical parameters, data structure
+        layouts and accessors, or small macros, inline functions and templates
+        (ten or fewer lines in length), you do both of the following:
+        <list>
+          <item>
+            <bullet>a)</bullet>
+            Give prominent notice with each copy of the object
+            code that the Library is used in it and that the
+            Library and its use are covered by this License.
+          </item>
+          <item>
+            <bullet>b)</bullet>
+            Accompany the object code with a copy of
+            the GNU GPL and this license document.
+          </item>
+        </list>
+      </item>
+      <item>
+        <bullet>4.</bullet>
+        Combined Works.<br></br>
+        You may convey a Combined Work under terms of your choice that, taken
+        together, effectively do not restrict modification of the portions of
+        the Library contained in the Combined Work and reverse engineering for
+        debugging such modifications, if you also do each of the following:
+        <list>
+          <item>
+            <bullet>a)</bullet>
+            Give prominent notice with each copy of the Combined
+            Work that the Library is used in it and that the
+            Library and its use are covered by this License.
+          </item>
+          <item>
+            <bullet>b)</bullet>
+            Accompany the Combined Work with a copy
+            of the GNU GPL and this license document.
+          </item>
+          <item>
+            <bullet>c)</bullet>
+            For a Combined Work that displays copyright notices during
+            execution, include the copyright notice for the Library
+            among these notices, as well as a reference directing the
+            user to the copies of the GNU GPL and this license document.
+          </item>
+          <item>
+            <bullet>d)</bullet>
+            Do one of the following:
+            <list>
+              <item>
+                <bullet>0)</bullet>
+                Convey the Minimal Corresponding Source under the terms
+                of this License, and the Corresponding Application Code
+                in a form suitable for, and under terms that permit,
+                the user to recombine or relink the Application with
+                a modified version of the Linked Version to produce a
+                modified Combined Work, in the manner specified by section
+                6 of the GNU GPL for conveying Corresponding Source.
+              </item>
+              <item>
+                <bullet>1)</bullet>
+                Use a suitable shared library mechanism for linking
+                with the Library. A suitable mechanism is one that
+                (a) uses at run time a copy of the Library already
+                present on the user's computer system, and (b) will
+                operate properly with a modified version of the Library
+                that is interface-compatible with the Linked Version.
+              </item>
             </list>
-        </item>
-        <item>
-            <bullet>1.</bullet>
-          Exception to Section 3 of the GNU GPL. 
-            <br/>You may convey a covered work under sections 3 and 4 of this License without being bound by
-                 section 3 of the GNU GPL.
-        </item>
-        <item>
-            <bullet>2.</bullet>
-          Conveying Modified Versions. 
-            <br/>If you modify a copy of the Library, and, in your modifications, a facility refers to a
-                 function or data to be supplied by an Application that uses the facility (other than
-                 as an argument passed when the facility is invoked), then you may convey a copy of the
-                 modified version:
-          
-          <list>
-               <item>
-                  <bullet>a)</bullet>
-              under this License, provided that you make a good faith effort to ensure that, in the event
-                 an Application does not supply the function or data, the facility still operates, and
-                 performs whatever part of its purpose remains meaningful, or
-            </item>
-               <item>
-                  <bullet>b)</bullet>
-              under the GNU GPL, with none of the additional permissions of this License applicable to that copy.
-            </item>
-            </list>
-        </item>
-        <item>
-            <bullet>3.</bullet>
-          Object Code Incorporating Material from Library Header Files. 
-            <br/>The object code form of an Application may incorporate material from a header file that is
-                 part of the Library. You may convey such object code under terms of your choice,
-                 provided that, if the incorporated material is not limited to numerical parameters,
-                 data structure layouts and accessors, or small macros, inline functions and templates
-                 (ten or fewer lines in length), you do both of the following: 
-          
-          <list>
-               <item>
-                  <bullet>a)</bullet>
-              Give prominent notice with each copy of the object code that the Library is used in it and
-                 that the Library and its use are covered by this License.
-            </item>
-               <item>
-                  <bullet>b)</bullet>
-              Accompany the object code with a copy of the GNU GPL and this license document.
-            </item>
-            </list>
-        </item>
-        <item>
-            <bullet>4.</bullet>
-          Combined Works. 
-            <br/>You may convey a Combined Work under terms of your choice that, taken together, effectively
-                 do not restrict modification of the portions of the Library contained in the Combined
-                 Work and reverse engineering for debugging such modifications, if you also do each of
-                 the following: 
-          
-          <list>
-               <item>
-                  <bullet>a)</bullet>
-              Give prominent notice with each copy of the Combined Work that the Library is used in it and
-                 that the Library and its use are covered by this License.
-            </item>
-               <item>
-                  <bullet>b)</bullet>
-              Accompany the Combined Work with a copy of the GNU GPL and this license document.
-            </item>
-               <item>
-                  <bullet>c)</bullet>
-              For a Combined Work that displays copyright notices during execution, include the copyright
-                 notice for the Library among these notices, as well as a reference directing the user to
-                 the copies of the GNU GPL and this license document.
-            </item>
-               <item>
-                  <bullet>d)</bullet>
-              Do one of the following:
-              <list>
-                     <item>
-                        <bullet>0)</bullet>
-                  Convey the Minimal Corresponding Source under the terms of this License, and the
-                     Corresponding Application Code in a form suitable for, and under terms that permit,
-                     the user to recombine or relink the Application with a modified version of the Linked
-                     Version to produce a modified Combined Work, in the manner specified by section 6 of
-                     the GNU GPL for conveying Corresponding Source.
-                </item>
-                     <item>
-                        <bullet>1)</bullet>
-                  Use a suitable shared library mechanism for linking with the Library. A suitable
-                     mechanism is one that (a) uses at run time a copy of the Library already present on
-                     the user's computer system, and (b) will operate properly with a modified version
-                     of the Library that is interface-compatible with the Linked Version.
-                </item>
-                  </list>
-               </item>
-               <item>
-                  <bullet>e)</bullet>
-              Provide Installation Information, but only if you would otherwise be required to provide such
-                 information under section 6 of the GNU GPL, and only to the extent that such information
-                 is necessary to install and execute a modified version of the Combined Work produced by
-                 recombining or relinking the Application with a modified version of the Linked Version.
-                 (If you use option 4d0, the Installation Information must accompany the Minimal
-                 Corresponding Source and Corresponding Application Code. If you use option 4d1, you must
-                 provide the Installation Information in the manner specified by section 6 of the GNU GPL
-                 for conveying Corresponding Source.)
-            </item>
-            </list>
-        </item>
-        <item>
-            <bullet>5.</bullet>
-          Combined Libraries. 
-            <br/>You may place library facilities that are a work based on the Library side by side in a
-                 single library together with other library facilities that are not Applications and
-                 are not covered by this License, and convey such a combined library under terms of
-                 your choice, if you do both of the following: 
-          
-          <list>
-               <item>
-                  <bullet>a)</bullet>
-              Accompany the combined library with a copy of the same work based on the Library, uncombined
-                 with any other library facilities, conveyed under the terms of this License.
-            </item>
-               <item>
-                  <bullet>b)</bullet>
-              Give prominent notice with the combined library that part of it is a work based on the
-                 Library, and explaining where to find the accompanying uncombined form of the same
-                 work.
-            </item>
-            </list>
-        </item>
-        <item>
-            <bullet>6.</bullet>
-          Revised Versions of the GNU Lesser General Public License.
-          <p>The Free Software Foundation may publish revised and/or new versions of the GNU Lesser General Public
-             License from time to time. Such new versions will be similar in spirit to the present version, but may
-             differ in detail to address new problems or concerns.</p>
-            <p>Each version is given a distinguishing version number. If the Library as you received it specifies that a
-             certain numbered version of the GNU Lesser General Public License "or any later version"
-             applies to it, you have the option of following the terms and conditions either of that published
-             version or of any later version published by the Free Software Foundation. If the Library as you
-             received it does not specify a version number of the GNU Lesser General Public License, you may choose
-             any version of the GNU Lesser General Public License ever published by the Free Software
-             Foundation.</p>
-            <p>If the Library as you received it specifies that a proxy can decide whether future versions of the GNU
-             Lesser General Public License shall apply, that proxy's public statement of acceptance of any version 
-             is permanent authorization for you to choose that version for the Library. 
-          </p>
-        </item>
-      </list>
+          </item>
+          <item>
+            <bullet>e)</bullet>
+            Provide Installation Information, but only if you would otherwise
+            be required to provide such information under section 6 of the GNU
+            GPL, and only to the extent that such information is necessary to
+            install and execute a modified version of the Combined Work produced
+            by recombining or relinking the Application with a modified version
+            of the Linked Version. (If you use option 4d0, the Installation
+            Information must accompany the Minimal Corresponding Source and
+            Corresponding Application Code. If you use option 4d1, you must
+            provide the Installation Information in the manner specified by
+            section 6 of the GNU GPL for conveying Corresponding Source.)
+          </item>
+        </list>
+      </item>
+      <item>
+        <bullet>5.</bullet>
+        Combined Libraries.<br></br>
+        You may place library facilities that are a work based on
+        the Library side by side in a single library together with
+        other library facilities that are not Applications and are not
+        covered by this License, and convey such a combined library
+        under terms of your choice, if you do both of the following:
+        <list>
+          <item>
+            <bullet>a)</bullet>
+            Accompany the combined library with a copy of the same work
+            based on the Library, uncombined with any other library
+            facilities, conveyed under the terms of this License.
+          </item>
+          <item>
+            <bullet>b)</bullet>
+            Give prominent notice with the combined library that part
+            of it is a work based on the Library, and explaining where
+            to find the accompanying uncombined form of the same work.
+          </item>
+        </list>
+      </item>
+      <item>
+        <bullet>6.</bullet>
+        Revised Versions of the GNU Lesser General Public License.
+        <p>
+          The Free Software Foundation may publish revised and/or new versions
+          of the GNU Lesser General Public License from time to time. Such
+          new versions will be similar in spirit to the present version,
+          but may differ in detail to address new problems or concerns.
+        </p>
+        <p>
+          Each version is given a distinguishing version number. If the Library
+          as you received it specifies that a certain numbered version of the
+          GNU Lesser General Public License "or any later version" applies
+          to it, you have the option of following the terms and conditions
+          either of that published version or of any later version published
+          by the Free Software Foundation. If the Library as you received it
+          does not specify a version number of the GNU Lesser General Public
+          License, you may choose any version of the GNU Lesser General
+          Public License ever published by the Free Software Foundation.
+        </p>
+        <p>
+          If the Library as you received it specifies that a proxy
+          can decide whether future versions of the GNU Lesser
+          General Public License shall apply, that proxy's public
+          statement of acceptance of any version is permanent
+          authorization for you to choose that version for the Library.
+        </p>
+      </item>
+    </list>
   </license>
 </SPDXLicenseCollection>


### PR DESCRIPTION
Here are the new GNU licenses, taking care of #542 and #543.

- reformatted (pretty-printed) the 10 GNU licenses
- copies of the 10 GNU licenses as -only and -or-later
- added deprecation attrs and note to 10 GNU licenses
- updated licenseId and name for 10 GNU -only licenses
- updated licenseId and name for the 10 GNU -or-later licenses
- fixing standardLicenseHeader in GNU -only licenses
- fixing StandardLicenseHeader and note for the -or-later licenses
