### PR TITLE
Giftware|SMLNJ: Update URLs to avoid double-slashes

### DIFF
--- a/src/Giftware.xml
+++ b/src/Giftware.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="false" licenseId="Giftware" name="Giftware License">
       <crossRefs>
-         <crossRef>http://alleg.sourceforge.net//license.html</crossRef>
+         <crossRef>http://liballeg.org/license.html#allegro-4-the-giftware-license</crossRef>
       </crossRefs>
       <notes>This license may also be known as Allegro 4. The Allegro 5 license shown at the alleg.sourceforge.net URL is
          the same as zlib</notes>

--- a/src/SMLNJ.xml
+++ b/src/SMLNJ.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="false" licenseId="SMLNJ"
             name="Standard ML of New Jersey License">
       <crossRefs>
-         <crossRef>http://www.smlnj.org//license.html</crossRef>
+         <crossRef>https://www.smlnj.org/license.html</crossRef>
       </crossRefs>
       <titleText>
          <p>STANDARD ML OF NEW JERSEY COPYRIGHT NOTICE, LICENSE AND DISCLAIMER.</p>


### PR DESCRIPTION
I turned up these two double-slash URLs while looking for more issues like the one fixed by #540.