### PR TITLE
NCSA: List group before institution

### DIFF
--- a/src/NCSA.xml
+++ b/src/NCSA.xml
@@ -17,8 +17,8 @@
 
       <p>Developed by: 
         <alt match=".+" name="organization">
-		<br/>&lt;Name of Institution&gt;
 		<br/>&lt;Name of Development Group&gt; 
+		<br/>&lt;Name of Institution&gt;
         <br/>&lt;URL for Development Group/Institution&gt;</alt>
       </p>
     


### PR DESCRIPTION
Both upstream:

```console
$ curl -s http://otm.illinois.edu/disclose-protect/illinois-open-source-license | grep 'Name of Institution'
…Developed by:<br /><em><span …>&lt;Name of Development Group&gt;</span><br /><span …>&lt;Name of Institution&gt;</span><br /><span …>&lt;URL for Development Group/Institution&gt;</span>…
```

and the OSI:

```console
$ curl -s https://opensource.org/licenses/NCSA | grep -1 'Name of Institution'
Developed by:           &lt;Name of Development Group&gt;
                        &lt;Name of Institution&gt;
                        &lt;URL for Development Group/Institution&gt;
```

list the group before the institution.  We did too, until the recent 68711a7 (#550), so we can flip this back to match upstream without worrying about breaking consumers.