### PR TITLE
.github/issue_template: Add an issue template

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,26 @@
+*This template is designed to help with requesting new license/exceptions.  If you are reporting an issue with an *existing* license/exception, you can skip the template.*
+
+New License/Exception Request: *license/exception name*
+
+* Full name: *e.g. Apache License 2.0*
+* Short identifier: *e.g. Apache-2.0*
+* URL for the license/exception (optional): *e.g. http://www.apache.org/licenses/LICENSE-2.0*
+* URL showing a project using the license/exception: *e.g. https://svn.apache.org/viewvc/httpd/httpd/trunk/LICENSE?view=markup*
+
+# Motivation
+
+*Provide a short explanation regarding the need for this license/exception to be included on the SPDX License List.*
+
+# Is the license/exception approved by the Open Source Initiative?
+
+*Provide one of:*
+
+* *An OSI URL like https://opensource.org/licenses/Apache-2.0*,
+* *Pointers to ongoing OSI discussion like http://lists.opensource.org/pipermail/license-review_lists.opensource.org/2017-October/003247.html*, or
+* *A comment explaining that the license/exception has not been discussed by the OSI.*
+
+# Full text
+
+*Provide the full text of the license, either here in the issue or as [a `.txt` attachment][attachment].*
+
+[attachment]: https://help.github.com/articles/file-attachments-on-issues-and-pull-requests/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
-.DS_Store
-# Ignore all hidden files/dirs except .gitignore and .travis.yml
+# Ignore all hidden files/dirs except the ones we whitelist
 .*
+!/.github
 !/.gitignore
 !/.travis.yml
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Please familiarize yourself with the SPDX License List and its supporting docume
 * [SPDX License List Matching Guidelines](https://spdx.org/spdx-license-list/matching-guidelines) provides guidelines to be used for the purposes of matching licenses and license exceptions against those included on the SPDX License List. 
 * [SPDX Specification](https://spdx.org/specifications): It is helpful to be familiar with certain sections of the SPDX Specification thatuse or deal with the SPDX License List. In particular: sub-sections related to license information in Section 3, 4, and 6; Appendices II, IV, and V.  
 
-# How to contribute/participate: general
+# General contributions and participation
 The SPDX License List is maintained by the SPDX Legal Team. Work and discussion is primarily done via the mailing list and bi-weekly calls. In particular, the bi-weekly calls are used to discuss topics and issues that may be difficult to only discuss via email.
 You can join the mailing list and otherwise manage your subscription [via spdx-legal mailman](https://lists.spdx.org/mailman/listinfo/spdx-legal). Information on the bi-weekly calls and the working area for the SPDX Legal Team, can be found on the [SPDX legal team wiki](https://wiki.spdx.org/view/Legal_Team)
 
@@ -15,16 +15,7 @@ The SPDX Legal Team appreciates proposals for new free and open source licenses 
 
 2.  Check the historical license and exceptions [tracking page](https://docs.google.com/spreadsheets/d/11AKxLBoN_VXM32OmDTk2hKeYExKzsnPjAVM7rLstQ8s/edit?pli=1#gid=695212681) and issues labeled [new license/exception request](https://github.com/spdx/license-list-XML/labels/new%20license%2Fexception%20request) to ensure this license or exception has not been previously requested. 
 
-3. Submit your request with all of the following information either via a new Issue or via the SPDX-legal mailing list
-(If you are not on the SPDX-legal mailing list, please join first, see above. If you send your license request without joining the mailing list, this will greatly slow down correspondance in both directions.)
-
-* Issue name or email subject line: "New License/Exception Request: <license/exception name>" 
-* Provide a proposed Full Name for the license or exception.
-* Provide a proposed Short Identifier.
-* Provide a functioning URL reference to the license or exception text.
-* Indicate whether the license is OSI-approved or is currently under review. (If the latter, please provide some information as to where in the process.) 
-* Provide a short explanation regarding the need for this license or exception to be included on the SPDX License List, and identify at least one program that uses it.
-* Provide the text of the license. 
+3. Submit your request [as a new issue][new-issue], or fill out the [issue template][issue-template] and submit it via the [SPDX-legal mailing list](#general-contributions-and-participation).
 
 ### Review Process
 1. The SPDX Legal Team will discuss any submissions for new licenses or exceptions on the bi-weekly calls. If further information or clarification is required, the Team will reach out to the requestor accordingly.
@@ -32,10 +23,13 @@ The SPDX Legal Team appreciates proposals for new free and open source licenses 
 3. Upon acceptance, the new license or exception will be prepared by a member of the SPDX Legal Team in the proper XML format and plain text via a Pull Request and reviewed as appropriate. 
 4. The new license/exception will be officially added for the next release of the SPDX License List.
 
-## Other Contributions to the SPDX License List
-If you find an error or have a suggested update to an existing license, please open a [new issue](https://github.com/spdx/license-list-XML/issues/new). Depending on the nature of the Issue, it may be referred for further discussion on the mailing list or bi-weekly calls. 
+## Updating existing licenses and exceptions
+If you find an error or have a suggested update to an existing license, please open a [new issue][new-issue]. Depending on the nature of the Issue, it may be referred for further discussion on the mailing list or bi-weekly calls.
 Examples of things that should be logged via an issue (versus raised on the mailing list/discussed on calls) may include:
 * update an URL for a license
 * recommend additional markup for matching purposes (usually requires legal review)
 
 Please do not raise general questions via issues in this Github repository, but use the appropriate workgroup mailing list. 
+
+[issue-template]: .github/issue_template.md
+[new-issue]: https://github.com/spdx/license-list-XML/issues/new


### PR DESCRIPTION
The old docs for this process are [here][1].  This template pulls out the subset of information required by the initial request, as discussed [here][1.1] and [here][1.2].

Docs for the filename are [here][2].  I've used a `.github` subdirectory to keep this peripheral workflow information out of the root directory.

GitHub also supports [pull-request templates][3], but most of this information will be included in the pull-request payload, and doesn't need to be repeated in the pull-request's opening comment.  The exception is the short motivation, but I'm comfortable assuming folks who file pull requests know enough to provide that without prompting.

[1]: https://spdx.org/spdx-license-list/request-new-license
[1.1]: https://github.com/spdx/license-list-XML/pull/538#commitcomment-26393643
[1.2]: https://github.com/spdx/license-list-XML/pull/546#discussion_r158738634
[2]: https://help.github.com/articles/creating-an-issue-template-for-your-repository/
[3]: https://help.github.com/articles/creating-a-pull-request-template-for-your-repository/