### PR TITLE
Fix the match pattern in cc-by-xx-4.0 such that 'Moreconsiderations' is not matched

### DIFF
--- a/src/CC-BY-4.0.xml
+++ b/src/CC-BY-4.0.xml
@@ -35,7 +35,7 @@
          the licensed material may still be restricted for other reasons, including because others have
          copyright or other rights in the material. A licensor may make special requests, such as asking that
          all changes be marked or described. Although not required by our licenses, you are encouraged to
-         respect those requests where reasonable. More<alt match=" ?|_" name="spaceUnderscore"> </alt>considerations for the public<alt match=": wiki.creativecommons.org/Considerations_for_licensees|\." name="considerationsLicensees">: wiki.creativecommons.org/Considerations_for_licensees</alt></p>
+         respect those requests where reasonable. <alt match="More considerations|More_considerations" name="spaceUnderscore">More considerations</alt> for the public<alt match=": wiki.creativecommons.org/Considerations_for_licensees|\." name="considerationsLicensees">: wiki.creativecommons.org/Considerations_for_licensees</alt></p>
       </optional>
 
       <titleText>

--- a/src/CC-BY-NC-4.0.xml
+++ b/src/CC-BY-NC-4.0.xml
@@ -39,7 +39,7 @@
                     the licensed material may still be restricted for other reasons, including because others have
                     copyright or other rights in the material. A licensor may make special requests, such as asking that
                     all changes be marked or described. Although not required by our licenses, you are encouraged to
-                    respect those requests where reasonable. More<alt match=" ?|_" name="spaceUnderscore"> </alt>considerations for the public<alt match=": wiki.creativecommons.org/Considerations_for_licensees|\." name="considerationsLicensees">: wiki.creativecommons.org/Considerations_for_licensees</alt></p>
+                    respect those requests where reasonable. <alt match="More considerations|More_considerations" name="spaceUnderscore">More considerations</alt> for the public<alt match=": wiki.creativecommons.org/Considerations_for_licensees|\." name="considerationsLicensees">: wiki.creativecommons.org/Considerations_for_licensees</alt></p>
             </item>
         </list>
       </optional>

--- a/src/CC-BY-NC-ND-4.0.xml
+++ b/src/CC-BY-NC-ND-4.0.xml
@@ -35,7 +35,7 @@
          the licensed material may still be restricted for other reasons, including because others have
          copyright or other rights in the material. A licensor may make special requests, such as asking that
          all changes be marked or described. Although not required by our licenses, you are encouraged to
-         respect those requests where reasonable. More<alt match=" ?|_" name="spaceUnderscore"> </alt>considerations for the public<alt match=": wiki.creativecommons.org/Considerations_for_licensees|\." name="considerationsLicensees">: wiki.creativecommons.org/Considerations_for_licensees</alt></p>
+         respect those requests where reasonable. <alt match="More considerations|More_considerations" name="spaceUnderscore">More considerations</alt> for the public<alt match=": wiki.creativecommons.org/Considerations_for_licensees|\." name="considerationsLicensees">: wiki.creativecommons.org/Considerations_for_licensees</alt></p>
          <p>Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License</p>
          <p>By exercising the Licensed Rights (defined below), You accept and agree to be bound by the terms and
          conditions of this Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public

--- a/src/CC-BY-NC-SA-4.0.xml
+++ b/src/CC-BY-NC-SA-4.0.xml
@@ -35,7 +35,7 @@
          the licensed material may still be restricted for other reasons, including because others have
          copyright or other rights in the material. A licensor may make special requests, such as asking that
          all changes be marked or described. Although not required by our licenses, you are encouraged to
-         respect those requests where reasonable. More<alt match=" ?|_" name="spaceUnderscore"> </alt>considerations for the public<alt match=": wiki.creativecommons.org/Considerations_for_licensees|\." name="considerationsLicensees">: wiki.creativecommons.org/Considerations_for_licensees</alt></p>
+         respect those requests where reasonable. <alt match="More considerations|More_considerations" name="spaceUnderscore">More considerations</alt> for the public<alt match=": wiki.creativecommons.org/Considerations_for_licensees|\." name="considerationsLicensees">: wiki.creativecommons.org/Considerations_for_licensees</alt></p>
       </optional>
 
         <p>Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International Public License</p>

--- a/src/CC-BY-ND-4.0.xml
+++ b/src/CC-BY-ND-4.0.xml
@@ -36,7 +36,7 @@
          the licensed material may still be restricted for other reasons, including because others have
          copyright or other rights in the material. A licensor may make special requests, such as asking that
          all changes be marked or described. Although not required by our licenses, you are encouraged to
-         respect those requests where reasonable. More<alt match=" ?|_" name="spaceUnderscore"> </alt>considerations for the public<alt match=": wiki.creativecommons.org/Considerations_for_licensees|\." name="considerationsLicensees">: wiki.creativecommons.org/Considerations_for_licensees</alt></p>
+         respect those requests where reasonable. <alt match="More considerations|More_considerations" name="spaceUnderscore">More considerations</alt> for the public<alt match=": wiki.creativecommons.org/Considerations_for_licensees|\." name="considerationsLicensees">: wiki.creativecommons.org/Considerations_for_licensees</alt></p>
       <p>Creative Commons Attribution-NoDerivatives 4.0 International Public License</p>
       <p>By exercising the Licensed Rights (defined below), You accept and agree to be bound by the terms and
          conditions of this Creative Commons Attribution-NoDerivatives 4.0 International Public License

--- a/src/CC-BY-SA-4.0.xml
+++ b/src/CC-BY-SA-4.0.xml
@@ -37,7 +37,7 @@
          copyright or other rights in the material. A licensor may make special requests, such as asking that
          all changes be marked or described.</p>
       <p>Although not required by our licenses, you are encouraged to respect those requests where reasonable.
-         More<alt match=" ?|_" name="spaceUnderscore"> </alt>considerations for the public<alt match=": wiki.creativecommons.org/Considerations_for_licensees|\." name="considerationsLicensees">: wiki.creativecommons.org/Considerations_for_licensees</alt></p>
+         <alt match="More considerations|More_considerations" name="spaceUnderscore">More considerations</alt> for the public<alt match=": wiki.creativecommons.org/Considerations_for_licensees|\." name="considerationsLicensees">: wiki.creativecommons.org/Considerations_for_licensees</alt></p>
       <p>Creative Commons Attribution-ShareAlike 4.0 International Public License</p>
       <p>By exercising the Licensed Rights (defined below), You accept and agree to be bound by the terms and
          conditions of this Creative Commons Attribution-ShareAlike 4.0 International Public License ("Public


### PR DESCRIPTION
As discussed in the PR #549
Signed-off-by: Gary O'Neall <gary@sourceauditor.com>