### PR TITLE
Remove GPL paragraph from LLVM-exception

### DIFF
--- a/src/exceptions/LLVM-exception
+++ b/src/exceptions/LLVM-exception
@@ -5,10 +5,6 @@
          <crossRef>http://lists.llvm.org/pipermail/llvm-dev/2017-August/116266.html</crossRef>
       </crossRefs>
       <notes>This exception was created specifically to be used with Apache-2.0</notes>
-      <p>This Program is free software; you can redistribute it and/or
-       modify it under the terms of the GNU General Public License as
-       published by the Free Software Foundation; version 2 of the
-       License.</p>
       <p> As an exception, if, as a result of your compiling your source 
       code, portions of this Software are embedded into an Object form of 
       such source code, you may redistribute such embedded portions in such 


### PR DESCRIPTION
This paragraph relating to GPL does not appear coherent with the rest of the exception and I also don't see it in the draft LLVM developer docs mentioned in thread (http://lists.llvm.org/pipermail/llvm-dev/2017-August/116266.html). This patch removes the GPL paragraph.