### PR TITLE
*: Fix missing space between (c) and <alt>

### DIFF
--- a/src/AGPL-3.0-only.xml
+++ b/src/AGPL-3.0-only.xml
@@ -7,7 +7,7 @@
       <crossRef>http://www.opensource.org/licenses/AGPL-3.0</crossRef>
     </crossRefs>
     <standardLicenseHeader>
-      Copyright (C)<alt name="copyright" match=".+">[year] [name of author]</alt>
+      Copyright (C) <alt name="copyright" match=".+">[year] [name of author]</alt>
       <p>
 	This program is free software: you can redistribute it and/or modify it
         under the terms of the GNU Affero General Public License as published

--- a/src/AGPL-3.0-or-later.xml
+++ b/src/AGPL-3.0-or-later.xml
@@ -7,7 +7,7 @@
       <crossRef>http://www.opensource.org/licenses/AGPL-3.0</crossRef>
     </crossRefs>
     <standardLicenseHeader>
-      Copyright (C)<alt name="copyright" match=".+">[year] [name of author]</alt>
+      Copyright (C) <alt name="copyright" match=".+">[year] [name of author]</alt>
       <p>This program is free software: you can redistribute it and/or modify it
       under the terms of the GNU Affero General Public License as published
       by the Free Software Foundation, either version 3 of the License, or 

--- a/src/AGPL-3.0.xml
+++ b/src/AGPL-3.0.xml
@@ -12,7 +12,7 @@
       explicit license identifier of AGPL-3.0-only
     </notes>
     <standardLicenseHeader>
-      Copyright (C)<alt name="copyright" match=".+">[year] [name of author]</alt>
+      Copyright (C) <alt name="copyright" match=".+">[year] [name of author]</alt>
       This program is free software: you can redistribute it and/or modify it
       under the terms of the GNU Affero General Public License as published
       by the Free Software Foundation, version 3. This program is distributed

--- a/src/BSD-2-Clause-Patent.xml
+++ b/src/BSD-2-Clause-Patent.xml
@@ -16,7 +16,7 @@
     </notes>
     <copyrightText>
       <p>
-        Copyright (c)<alt name="copyright"
+        Copyright (c) <alt name="copyright"
         match=".+">&lt;YEAR&gt; &lt;COPYRIGHT HOLDERS&gt;</alt>
       </p>
     </copyrightText>

--- a/src/GFDL-1.2-only.xml
+++ b/src/GFDL-1.2-only.xml
@@ -6,7 +6,7 @@
       <crossRef>http://www.gnu.org/licenses/old-licenses/fdl-1.2.txt</crossRef>
     </crossRefs>
     <standardLicenseHeader>
-      Copyright (c)<alt name="copyright" match=".+">YEAR YOUR NAME</alt>
+      Copyright (c) <alt name="copyright" match=".+">YEAR YOUR NAME</alt>
       . Permission is granted to copy, distribute and/or modify this
       document under the terms of the GNU Free Documentation License,
       Version 1.2; with no Invariant Sections, no Front-Cover Texts,

--- a/src/GFDL-1.2-or-later.xml
+++ b/src/GFDL-1.2-or-later.xml
@@ -6,7 +6,7 @@
       <crossRef>http://www.gnu.org/licenses/old-licenses/fdl-1.2.txt</crossRef>
     </crossRefs>
     <standardLicenseHeader>
-      Copyright (c)<alt name="copyright" match=".+">YEAR YOUR NAME</alt>
+      Copyright (c) <alt name="copyright" match=".+">YEAR YOUR NAME</alt>
       Permission is granted to copy, distribute and/or modify this
       document under the terms of the GNU Free Documentation License,
       Version 1.2 or any later version published by the Free Software

--- a/src/GFDL-1.2.xml
+++ b/src/GFDL-1.2.xml
@@ -11,7 +11,7 @@
       explicit license identifier of GFDL-1.2-only
     </notes>
     <standardLicenseHeader>
-      Copyright (c)<alt name="copyright" match=".+">YEAR YOUR NAME</alt>
+      Copyright (c) <alt name="copyright" match=".+">YEAR YOUR NAME</alt>
       . Permission is granted to copy, distribute and/or modify this
       document under the terms of the GNU Free Documentation License,
       Version 1.2 or any later version published by the Free Software

--- a/src/GFDL-1.3-only.xml
+++ b/src/GFDL-1.3-only.xml
@@ -6,7 +6,7 @@
       <crossRef>http://www.gnu.org/licenses/fdl-1.3.txt</crossRef>
     </crossRefs>
     <standardLicenseHeader>
-      Copyright (c)<alt name="copyright" match=".+">YEAR YOUR NAME</alt>
+      Copyright (c) <alt name="copyright" match=".+">YEAR YOUR NAME</alt>
       Permission is granted to copy, distribute and/or modify this
       document under the terms of the GNU Free Documentation License,
       Version 1.3; with no Invariant Sections, no Front-Cover Texts,

--- a/src/GFDL-1.3-or-later.xml
+++ b/src/GFDL-1.3-or-later.xml
@@ -6,7 +6,7 @@
       <crossRef>http://www.gnu.org/licenses/fdl-1.3.txt</crossRef>
     </crossRefs>
     <standardLicenseHeader>
-      Copyright (c)<alt name="copyright" match=".+">YEAR YOUR NAME</alt>
+      Copyright (c) <alt name="copyright" match=".+">YEAR YOUR NAME</alt>
       Permission is granted to copy, distribute and/or modify this
       document under the terms of the GNU Free Documentation License,
       Version 1.3 or any later version published by the Free Software

--- a/src/GFDL-1.3.xml
+++ b/src/GFDL-1.3.xml
@@ -11,7 +11,7 @@
       explicit license identifier of GFDL-1.3-only
     </notes>
     <standardLicenseHeader>
-      Copyright (c)<alt name="copyright" match=".+">YEAR YOUR NAME</alt>
+      Copyright (c) <alt name="copyright" match=".+">YEAR YOUR NAME</alt>
       Permission is granted to copy, distribute and/or modify this
       document under the terms of the GNU Free Documentation License,
       Version 1.3 or any later version published by the Free Software

--- a/src/GPL-1.0-only.xml
+++ b/src/GPL-1.0-only.xml
@@ -6,7 +6,7 @@
       <crossRef>http://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html</crossRef>
     </crossRefs>
     <standardLicenseHeader>
-      Copyright (C)<alt name="copyright" match=".+">19xx name of author</alt>
+      Copyright (C) <alt name="copyright" match=".+">19xx name of author</alt>
       <p>
         This program is free software; you can redistribute it and/or
         modify it under the terms of the GNU General Public License

--- a/src/GPL-1.0-or-later.xml
+++ b/src/GPL-1.0-or-later.xml
@@ -6,7 +6,7 @@
       <crossRef>http://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html</crossRef>
     </crossRefs>
     <standardLicenseHeader>
-      Copyright (C)<alt name="copyright" match=".+">19xx name of author</alt>
+      Copyright (C) <alt name="copyright" match=".+">19xx name of author</alt>
       <p>
         This program is free software; you can redistribute it and/or
         modify it under the terms of the GNU General Public License

--- a/src/GPL-1.0.xml
+++ b/src/GPL-1.0.xml
@@ -11,7 +11,7 @@
       explicit license identifier of GPL-1.0-only
     </notes>
     <standardLicenseHeader>
-      Copyright (C)<alt name="copyright" match=".+">19xx name of author</alt>
+      Copyright (C) <alt name="copyright" match=".+">19xx name of author</alt>
       <p>
         This program is free software; you can redistribute it and/or
         modify it under the terms of the GNU General Public License

--- a/src/GPL-2.0-only.xml
+++ b/src/GPL-2.0-only.xml
@@ -7,7 +7,7 @@
       <crossRef>http://www.opensource.org/licenses/GPL-2.0</crossRef>
     </crossRefs>
     <standardLicenseHeader>
-      Copyright (C)<alt name="copyright" match=".+">yyyy name of author</alt>
+      Copyright (C) <alt name="copyright" match=".+">yyyy name of author</alt>
       <p>
         This program is free software; you can redistribute it and/or
         modify it under the terms of the GNU General Public License

--- a/src/GPL-2.0-or-later.xml
+++ b/src/GPL-2.0-or-later.xml
@@ -7,7 +7,7 @@
       <crossRef>http://www.opensource.org/licenses/GPL-2.0</crossRef>
     </crossRefs>
     <standardLicenseHeader>
-      Copyright (C)<alt name="copyright" match=".+">yyyy name of author</alt>
+      Copyright (C) <alt name="copyright" match=".+">yyyy name of author</alt>
       <p>
         This program is free software; you can redistribute it and/or
         modify it under the terms of the GNU General Public License

--- a/src/GPL-2.0.xml
+++ b/src/GPL-2.0.xml
@@ -12,7 +12,7 @@
       explicit license identifier of GPL-2.0-only
     </notes>
     <standardLicenseHeader>
-      Copyright (C)<alt name="copyright" match=".+">yyyy name of author</alt>
+      Copyright (C) <alt name="copyright" match=".+">yyyy name of author</alt>
       <p>
         This program is free software; you can redistribute it and/or
         modify it under the terms of the GNU General Public License

--- a/src/GPL-3.0-only.xml
+++ b/src/GPL-3.0-only.xml
@@ -7,7 +7,7 @@
       <crossRef>http://www.opensource.org/licenses/GPL-3.0</crossRef>
     </crossRefs>
     <standardLicenseHeader>
-      Copyright (C)<alt name="copyright"
+      Copyright (C) <alt name="copyright"
       match=".+">&lt;year&gt; &lt;name of author&gt;</alt>
 	<p>This program is free software: you can redistribute it and/or
       	modify it under the terms of the GNU General Public License as

--- a/src/GPL-3.0-or-later.xml
+++ b/src/GPL-3.0-or-later.xml
@@ -7,7 +7,7 @@
       <crossRef>http://www.opensource.org/licenses/GPL-3.0</crossRef>
     </crossRefs>
     <standardLicenseHeader>
-      Copyright (C)<alt name="copyright"
+      Copyright (C) <alt name="copyright"
       match=".+">&lt;year&gt; &lt;name of author&gt;</alt>
 	<p>This program is free software: you can redistribute it and/or
       	modify it under the terms of the GNU General Public License as

--- a/src/GPL-3.0.xml
+++ b/src/GPL-3.0.xml
@@ -12,7 +12,7 @@
       explicit license identifier of GPL-3.0-only
     </notes>
     <standardLicenseHeader>
-      Copyright (C)<alt name="copyright"
+      Copyright (C) <alt name="copyright"
       match=".+">&lt;year&gt; &lt;name of author&gt;</alt>
       This program is free software: you can redistribute it and/or
       modify it under the terms of the GNU General Public License as

--- a/src/LGPL-2.0-only.xml
+++ b/src/LGPL-2.0-only.xml
@@ -6,7 +6,7 @@
       <crossRef>http://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html</crossRef>
     </crossRefs>
     <standardLicenseHeader>
-      Copyright (C)<alt name="copyright" match=".+">year name of author</alt>
+      Copyright (C) <alt name="copyright" match=".+">year name of author</alt>
       <p>This library is free software; you can redistribute it and/or modify it
       under the terms of the GNU Library General Public License as published
         by the Free Software Foundation; version 2.</p> 

--- a/src/LGPL-2.0-or-later.xml
+++ b/src/LGPL-2.0-or-later.xml
@@ -6,7 +6,7 @@
       <crossRef>http://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html</crossRef>
     </crossRefs>
     <standardLicenseHeader>
-      Copyright (C)<alt name="copyright" match=".+">year name of author</alt>
+      Copyright (C) <alt name="copyright" match=".+">year name of author</alt>
       <p>This library is free software; you can redistribute it and/or modify it
       under the terms of the GNU Library General Public License as published
         by the Free Software Foundation; version 2 or any later version.</p> 

--- a/src/LGPL-2.0.xml
+++ b/src/LGPL-2.0.xml
@@ -11,7 +11,7 @@
       explicit license identifier of LGPL-2.0-only
     </notes>
     <standardLicenseHeader>
-      Copyright (C)<alt name="copyright" match=".+">year name of author</alt>
+      Copyright (C) <alt name="copyright" match=".+">year name of author</alt>
       This library is free software; you can redistribute it and/or modify it
       under the terms of the GNU Library General Public License as published
       by the Free Software Foundation; version 2. This library is distributed

--- a/src/LGPL-2.1-only.xml
+++ b/src/LGPL-2.1-only.xml
@@ -7,7 +7,7 @@
       <crossRef>http://www.opensource.org/licenses/LGPL-2.1</crossRef>
     </crossRefs>
     <standardLicenseHeader>
-      Copyright (C)<alt name="copyright" match=".+">year name of author</alt>
+      Copyright (C) <alt name="copyright" match=".+">year name of author</alt>
       <p>
         This library is free software; you can redistribute it and/or
         modify it under the terms of the GNU Lesser General Public

--- a/src/LGPL-2.1-or-later.xml
+++ b/src/LGPL-2.1-or-later.xml
@@ -7,7 +7,7 @@
       <crossRef>http://www.opensource.org/licenses/LGPL-2.1</crossRef>
     </crossRefs>
     <standardLicenseHeader>
-      Copyright (C)<alt name="copyright" match=".+">year name of author</alt>
+      Copyright (C) <alt name="copyright" match=".+">year name of author</alt>
       <p>
         This library is free software; you can redistribute it and/or
         modify it under the terms of the GNU Lesser General Public

--- a/src/LGPL-2.1.xml
+++ b/src/LGPL-2.1.xml
@@ -12,7 +12,7 @@
       explicit license identifier of LGPL-2.1-only
     </notes>
     <standardLicenseHeader>
-      Copyright (C)<alt name="copyright" match=".+">year name of author</alt>
+      Copyright (C) <alt name="copyright" match=".+">year name of author</alt>
       <p>
         This library is free software; you can redistribute it and/or
         modify it under the terms of the GNU Lesser General Public


### PR DESCRIPTION
Generated with:

    $ sed -i 's/\(([cC])\)<alt/\1 <alt/' $(git grep -l '[cC])<alt')

Like 7af2b40 (#526), but with more licenses.  The ones I'm fixing here were mostly broken by a0879e6e (#553).