### PR TITLE
*: Collapse to a single note entry

### DIFF
--- a/src/AGPL-3.0.xml
+++ b/src/AGPL-3.0.xml
@@ -23,9 +23,6 @@
       along with this program. If not, see
       &lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;
     </standardLicenseHeader>
-    <notes>
-      This version was released: 19 November 2007
-    </notes>
     <titleText>
       <p>
         GNU AFFERO GENERAL PUBLIC LICENSE<br></br>

--- a/src/GFDL-1.1.xml
+++ b/src/GFDL-1.1.xml
@@ -20,9 +20,6 @@
       Back-Cover Texts being LIST. A copy of the license is included
       in the section entitled "GNU Free Documentation License".
     </standardLicenseHeader>
-    <notes>
-      This license was released March 2000
-    </notes>
     <titleText>
       <p>
         GNU Free Documentation License<br></br>

--- a/src/GFDL-1.2.xml
+++ b/src/GFDL-1.2.xml
@@ -19,9 +19,6 @@
       and no Back-Cover Texts. A copy of the license is included
       in the section entitled "GNU Free Documentation License".
     </standardLicenseHeader>
-    <notes>
-      This license was released November 2002
-    </notes>
     <titleText>
       <p>
         GNU Free Documentation License<br></br>

--- a/src/GFDL-1.3.xml
+++ b/src/GFDL-1.3.xml
@@ -19,9 +19,6 @@
       and no Back-Cover Texts. A copy of the license is included
       in the section entitled "GNU Free Documentation License".
     </standardLicenseHeader>
-    <notes>
-      This license was released 3 November 2008.
-    </notes>
     <titleText>
       <p>
         GNU Free Documentation License<br></br>

--- a/src/GPL-1.0+.xml
+++ b/src/GPL-1.0+.xml
@@ -15,8 +15,6 @@
          <p>You should have received a copy of the GNU General Public License along with
     this program; if not, write to the Free Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA. </p>
       </standardLicenseHeader>
-      <notes>This license was released: February 1989. This license has been deprecated. This refers to when this GPL 1.0
-         only is being used (as opposed to "or later).</notes>
       <titleText>
          <p>GNU GENERAL PUBLIC LICENSE 
         <br/>Version 1, February 1989 

--- a/src/GPL-1.0.xml
+++ b/src/GPL-1.0.xml
@@ -29,11 +29,6 @@
         Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
       </p>
     </standardLicenseHeader>
-    <notes>
-      This license was released: February 1989. This license
-      has been deprecated. This refers to when this GPL
-      1.0 only is being used (as opposed to "or later).
-    </notes>
     <titleText>
       <p>
         GNU GENERAL PUBLIC LICENSE<br></br>

--- a/src/GPL-2.0+.xml
+++ b/src/GPL-2.0+.xml
@@ -19,8 +19,6 @@
     this program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
     02110-1301<optional>,</optional> USA.</p>
       </standardLicenseHeader>
-      <notes>This license was released: June 1991 This refers to when this GPL 2.0 only is being used (as opposed to GPLv2
-         or later).</notes>
       <titleText>
          <p>GNU GENERAL PUBLIC LICENSE
         <br/>Version 2, June 1991

--- a/src/GPL-2.0.xml
+++ b/src/GPL-2.0.xml
@@ -32,10 +32,6 @@
         USA.
       </p>
     </standardLicenseHeader>
-    <notes>
-      This license was released: June 1991 This refers to when this
-      GPL 2.0 only is being used (as opposed to GPLv2 or later).
-    </notes>
     <titleText>
       <p>
         GNU GENERAL PUBLIC LICENSE<br></br>

--- a/src/GPL-3.0+.xml
+++ b/src/GPL-3.0+.xml
@@ -16,8 +16,6 @@
     GNU General Public License for more details. You should have received a copy of the GNU General Public License
     along with this program. If not, see http://www.gnu.org/licenses/
   </standardLicenseHeader>
-      <notes>This license was released: 29 June 2007 This refers to when this GPL 3.0 only is being used (as opposed to
-         "or later).</notes>
       <titleText>
          <p>GNU GENERAL PUBLIC LICENSE 
         <br/>Version 3, 29 June 2007 

--- a/src/GPL-3.0.xml
+++ b/src/GPL-3.0.xml
@@ -23,10 +23,6 @@
       You should have received a copy of the GNU General Public License
       along with this program. If not, see http://www.gnu.org/licenses/
     </standardLicenseHeader>
-    <notes>
-      This license was released: 29 June 2007 This refers to when
-      this GPL 3.0 only is being used (as opposed to "or later).
-    </notes>
     <titleText>
       <p>
         GNU GENERAL PUBLIC LICENSE<br></br>

--- a/src/LGPL-2.0+.xml
+++ b/src/LGPL-2.0+.xml
@@ -15,8 +15,6 @@
     License along with this library; if not, write to the Free Software Foundation, Inc., 51 Franklin St, Fifth
     Floor, Boston, MA 02110-1301, USA. 
   </standardLicenseHeader>
-      <notes>This license was released: June 1991. This license has been superseded by LGPL v2.1 This refers to when this
-         LGPL 2.0 only is being used (as opposed to "or later).</notes>
       <titleText>
          <p>GNU LIBRARY GENERAL PUBLIC LICENSE</p>
          <p>Version 2, June 1991</p>

--- a/src/LGPL-2.0.xml
+++ b/src/LGPL-2.0.xml
@@ -22,11 +22,6 @@
       License along with this library; if not, write to the Free Software
       Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
     </standardLicenseHeader>
-    <notes>
-      This license was released: June 1991. This license has
-      been superseded by LGPL v2.1 This refers to when this
-      LGPL 2.0 only is being used (as opposed to "or later).
-    </notes>
     <titleText>
       <p>
         GNU LIBRARY GENERAL PUBLIC LICENSE

--- a/src/LGPL-2.1+.xml
+++ b/src/LGPL-2.1+.xml
@@ -19,8 +19,6 @@
     License along with this library; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth
     Floor, Boston, MA 02110-1301 USA </p>
       </standardLicenseHeader>
-      <notes>This license was released: February 1999. This refers to when this LGPL 2.1 only is being used (as opposed to
-         "or later).</notes>
       <titleText>
          <p>GNU LESSER GENERAL PUBLIC LICENSE</p>
          <p>Version 2.1, February 1999</p>

--- a/src/LGPL-2.1.xml
+++ b/src/LGPL-2.1.xml
@@ -30,10 +30,6 @@
         Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
       </p>
     </standardLicenseHeader>
-    <notes>
-      This license was released: February 1999. This refers to when
-      this LGPL 2.1 only is being used (as opposed to "or later).
-    </notes>
     <titleText>
       <p>
         GNU LESSER GENERAL PUBLIC LICENSE

--- a/src/LGPL-3.0+.xml
+++ b/src/LGPL-3.0+.xml
@@ -7,8 +7,6 @@
          <crossRef>http://www.gnu.org/licenses/lgpl-3.0-standalone.html</crossRef>
          <crossRef>http://www.opensource.org/licenses/LGPL-3.0</crossRef>
       </crossRefs>
-      <notes>This license was released: 29 June 2007. This refers to when this LGPL 3.0 only is being used (as opposed to
-         "or later).</notes>
       <titleText>
          <p>GNU LESSER GENERAL PUBLIC LICENSE 
         <br/>Version 3, 29 June 2007 

--- a/src/LGPL-3.0.xml
+++ b/src/LGPL-3.0.xml
@@ -11,10 +11,6 @@
       DEPRECATED: Deprecated in lieu of more
       explicit license identifier of LGPL-3.0-only
     </notes>
-    <notes>
-      This license was released: 29 June 2007. This refers to when
-      this LGPL 3.0 only is being used (as opposed to "or later).
-    </notes>
     <titleText>
       <p>
         GNU LESSER GENERAL PUBLIC LICENSE<br></br>


### PR DESCRIPTION
The XSD schema is currently buggy on this point, but the plural element name (`<notes>` vs. `<note>`) and `maxOccurs` in the XSD entry:

```xml
<element name="notes" type="tns:formattedFixedTextType" minOccurs="0" maxOccurs="1"/>
```

suggest that we expect only a single note entry (see also discussion [here][1]).  This PR brings us back to a single `<notes>` entry for our licenses, preparing us for #452, which fixes the XSD schema.

The wxWindows change, I created paragraphs for the previously separate `<notes>` content.

For the GPL-family changes, I dropped the release-date/version `<notes>`, because:

* Licenses with a release date in their `<notes>` entry had that same release date in the license title.  I don't see a need to include that release date as unstrucutured information in two places, and the license title is clearly the more important location.

* Whether the license is only or or-later is covered explicitly in the long name and implicitly in the new deprecation notice (e.g. as added in #552).  Once we get explicit obsoleted-by markup (#392), those deprecation notices will become machine readable.  So I don't think we need to call out the versioning again in the notes.

[1]: https://github.com/spdx/license-list-XML/pull/553#discussion_r158600187