### PR TITLE
Add back LLVM exception for release 3.1

### DIFF
--- a/src/exceptions/LLVM-exception.xml
+++ b/src/exceptions/LLVM-exception.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SPDXLicenseCollection xmlns="http://www.spdx.org/license">
+   <exception licenseId="LLVM-exception" name="LLVM Exceptions to the Apache 2.0">
+      <crossRefs>
+         <crossRef>http://lists.llvm.org/pipermail/llvm-dev/2017-August/116266.html</crossRef>
+      </crossRefs>
+      <notes>This exception was created specifically to be used with Apache-2.0</notes>
+	  <titleText>
+		<p>
+		<optional>---- </optional>LLVM Exceptions to the Apache 2.0 License<optional> ----</optional>
+		</p>
+	  </titleText>
+      <p> As an exception, if, as a result of your compiling your source 
+      code, portions of this Software are embedded into an Object form of 
+      such source code, you may redistribute such embedded portions in such 
+      Object form without complying with the conditions of Sections 4(a), 
+      4(b) and 4(d) of the License.</p>
+
+      <p>In addition, if you combine or link compiled forms of this Software 
+      with software that is licensed under the GPLv2 ("Combined Software") 
+      and if a court of competent jurisdiction determines that the patent 
+      provision (Section 3), the indemnity provision (Section 9) or other 
+      Section of the License conflicts with the conditions of the GPLv2, 
+      you may retroactively and prospectively choose to deem waived or 
+      otherwise exclude such Section(s) of the License, but only in their 
+      entirety and only with respect to the Combined Software.</p>
+  </exception>
+</SPDXLicenseCollection>

--- a/src/exceptions/LLVM-exception.xml
+++ b/src/exceptions/LLVM-exception.xml
@@ -5,6 +5,7 @@
          <crossRef>http://lists.llvm.org/pipermail/llvm-dev/2017-August/116266.html</crossRef>
       </crossRefs>
       <notes>This exception was created specifically to be used with Apache-2.0</notes>
+	  <text>
 	  <titleText>
 		<p>
 		<optional>---- </optional>LLVM Exceptions to the Apache 2.0 License<optional> ----</optional>
@@ -24,5 +25,6 @@
       you may retroactively and prospectively choose to deem waived or 
       otherwise exclude such Section(s) of the License, but only in their 
       entirety and only with respect to the Combined Software.</p>
+	  </text>
   </exception>
 </SPDXLicenseCollection>

--- a/src/exceptions/LLVM-exception.xml
+++ b/src/exceptions/LLVM-exception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <exception licenseId="LLVM-exception" name="LLVM Exceptions to the Apache 2.0">
+   <exception licenseId="LLVM-exception" name="LLVM Exception">
       <crossRefs>
          <crossRef>http://lists.llvm.org/pipermail/llvm-dev/2017-August/116266.html</crossRef>
       </crossRefs>


### PR DESCRIPTION
This was temporarily removed from the 3.0 release.  To be added once issue #541 is resolved.

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>