### PR TITLE
GPL-2.0*: More alt/optional entries to match FSF's canonical text/plain

### DIFF
--- a/src/GPL-2.0-only.xml
+++ b/src/GPL-2.0-only.xml
@@ -38,7 +38,7 @@
       </p>
     </titleText>
     <p>
-      Copyright (C) 1989, 1991 Free Software Foundation, Inc.<br></br>
+      Copyright (C) 1989, 1991 Free Software Foundation, Inc.<alt name="incComma" match="|,"/><br/>
       51 Franklin Street, Fifth Floor, Boston, MA 02110-1301<optional>,</optional>
       USA
     </p>
@@ -104,6 +104,7 @@
       distribution and modification follow.
     </p>
     <p>
+      <alt name="termsTitle" match="|GNU GENERAL PUBLIC LICENSE"/>
       TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
     </p>
     <list>
@@ -400,10 +401,10 @@
         the "copyright" line and a pointer to where the full notice is found.
       </p>
       <p>
-        <optional>&lt;</optional>one line to give the program's name and an idea of what it does.<optional>&gt;</optional>
+        <optional>&lt;</optional>one line to give the program's name and <alt name="ideaArticle" match="an|a brief">an</alt> idea of what it does.<optional>&gt;</optional>
         <br></br>
         Copyright (C)
-        <optional>&lt;</optional>yyyy<optional>&gt;</optional>
+        <optional>&lt;</optional><alt name="templateYear" match="yyyy|year">yyyy</alt><optional>&gt;</optional>
         <optional>&lt;</optional>name of author<optional>&gt;</optional>
       </p>
       <p>
@@ -453,6 +454,15 @@
       <p>
 	<optional>&lt;</optional>signature of Ty Coon<optional>&gt;</optional>,
 	1 April 1989 Ty Coon, President of Vice
+      </p>
+    </optional>
+    <optional>
+      <p>
+        This General Public License does not permit incorporating your program into
+        proprietary programs.  If your program is a subroutine library, you may
+        consider it more useful to permit linking proprietary applications with the
+        library.  If this is what you want to do, use the GNU Lesser General
+        Public License instead of this License.
       </p>
     </optional>
     </text>

--- a/src/GPL-2.0-or-later.xml
+++ b/src/GPL-2.0-or-later.xml
@@ -17,7 +17,7 @@
       </p>
     </titleText>
     <p>
-      Copyright (C) 1989, 1991 Free Software Foundation, Inc.<br></br>
+      Copyright (C) 1989, 1991 Free Software Foundation, Inc.<alt name="incComma" match="|,"/><br/>
       51 Franklin Street, Fifth Floor, Boston, MA 02110-1301<optional>,</optional>
       USA
     </p>
@@ -83,6 +83,7 @@
       distribution and modification follow.
     </p>
     <p>
+      <alt name="termsTitle" match="|GNU GENERAL PUBLIC LICENSE"/>
       TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
     </p>
     <list>
@@ -434,6 +435,15 @@
       <p>
 	<optional>&lt;</optional>signature of Ty Coon<optional>&gt;</optional>,
 	1 April 1989 Ty Coon, President of Vice
+      </p>
+    </optional>
+    <optional>
+      <p>
+        This General Public License does not permit incorporating your program into
+        proprietary programs.  If your program is a subroutine library, you may
+        consider it more useful to permit linking proprietary applications with the
+        library.  If this is what you want to do, use the GNU Lesser General
+        Public License instead of this License.
       </p>
     </optional>
     </text>

--- a/src/GPL-2.0.xml
+++ b/src/GPL-2.0.xml
@@ -39,7 +39,7 @@
       </p>
     </titleText>
     <p>
-      Copyright (C) 1989, 1991 Free Software Foundation, Inc.<br></br>
+      Copyright (C) 1989, 1991 Free Software Foundation, Inc.<alt name="incComma" match="|,"/><br/>
       51 Franklin Street, Fifth Floor, Boston, MA 02110-1301<optional>,</optional>
       USA
     </p>
@@ -105,6 +105,7 @@
       distribution and modification follow.
     </p>
     <p>
+      <alt name="termsTitle" match="|GNU GENERAL PUBLIC LICENSE"/>
       TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
     </p>
     <list>
@@ -401,10 +402,10 @@
         the "copyright" line and a pointer to where the full notice is found.
       </p>
       <p>
-        <optional>&lt;</optional>one line to give the program's name and an idea of what it does.<optional>&gt;</optional>
+        <optional>&lt;</optional>one line to give the program's name and <alt name="ideaArticle" match="an|a brief">an</alt> idea of what it does.<optional>&gt;</optional>
         <br></br>
         Copyright (C)
-        <optional>&lt;</optional>yyyy<optional>&gt;</optional>
+        <optional>&lt;</optional><alt name="templateYear" match="yyyy|year">yyyy</alt><optional>&gt;</optional>
         <optional>&lt;</optional>name of author<optional>&gt;</optional>
       </p>
       <p>
@@ -454,6 +455,15 @@
       <p>
 	<optional>&lt;</optional>signature of Ty Coon<optional>&gt;</optional>,
 	1 April 1989 Ty Coon, President of Vice
+      </p>
+    </optional>
+    <optional>
+      <p>
+        This General Public License does not permit incorporating your program into
+        proprietary programs.  If your program is a subroutine library, you may
+        consider it more useful to permit linking proprietary applications with the
+        library.  If this is what you want to do, use the GNU Lesser General
+        Public License instead of this License.
       </p>
     </optional>
     </text>


### PR DESCRIPTION
These changes address additional differences between [the FSF's text/plain version][1] (unchanged since 2007-07-16 [according to the Internet Archive][2]) and [the FSF's HTML version][3].  There has been previous work in this direction in #496 and #514.

The final paragraph (“This General Public License does not permit…”) is in both the text/plain and HTML FSF versions.  I'm not clear on why it wasn't included in our template (our GPL-3.0 template does include a similar paragraph).  I've put it in a new `<optional>` block to cover folks who were using the text we previously recommended (which lacked the paragraph).

The WIP tag is because this will conflict with #571, which I think is more important (or at least, easier to review), and because I haven't touched GPL-2.0-only or GPL-2.0-or-later (which share the same license content as GPL-2.0).

[1]: https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt
[2]: https://web.archive.org/web/20070716031727/https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt
[3]: https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html