### PR TITLE
GPL-3.0: Remove extra '[year]' from standardLicenseHeader

### DIFF
--- a/src/GPL-3.0+.xml
+++ b/src/GPL-3.0+.xml
@@ -8,7 +8,8 @@
       </crossRefs>
 	  <notes>DEPRECATED: Use the license identifier GPL-3.0-or-later</notes>
       <standardLicenseHeader> Copyright (C) 
-    <alt match=".+" name="copyright">&lt;year&gt; &lt;name of author&gt;</alt>[year] This program is free software:
+    <alt match=".+" name="copyright">&lt;year&gt; &lt;name of author&gt;</alt>
+    This program is free software:
     you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the
     Free Software Foundation, version. This program is distributed in the hope that it will be useful, but WITHOUT
     ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the

--- a/src/GPL-3.0-only.xml
+++ b/src/GPL-3.0-only.xml
@@ -9,7 +9,6 @@
     <standardLicenseHeader>
       Copyright (C)<alt name="copyright"
       match=".+">&lt;year&gt; &lt;name of author&gt;</alt>
-      [year] 
 	<p>This program is free software: you can redistribute it and/or
       	modify it under the terms of the GNU General Public License as
  	published by the Free Software Foundation, version 3.</p> 

--- a/src/GPL-3.0-or-later.xml
+++ b/src/GPL-3.0-or-later.xml
@@ -9,7 +9,6 @@
     <standardLicenseHeader>
       Copyright (C)<alt name="copyright"
       match=".+">&lt;year&gt; &lt;name of author&gt;</alt>
-      [year] 
 	<p>This program is free software: you can redistribute it and/or
       	modify it under the terms of the GNU General Public License as
 	published by the Free Software Foundation, version 3 or any later version.</p>

--- a/src/GPL-3.0.xml
+++ b/src/GPL-3.0.xml
@@ -14,7 +14,7 @@
     <standardLicenseHeader>
       Copyright (C)<alt name="copyright"
       match=".+">&lt;year&gt; &lt;name of author&gt;</alt>
-      [year] This program is free software: you can redistribute it and/or
+      This program is free software: you can redistribute it and/or
       modify it under the terms of the GNU General Public License as
       published by the Free Software Foundation, version. This program is
       distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;


### PR DESCRIPTION
These are from back in f6c34536 (#85) and similar, and we've just been dragging them along.