### PR TITLE
wxWindows: Collapse to a single <notes> element

### DIFF
--- a/src/wxWindows.xml
+++ b/src/wxWindows.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license licenseId="wxWindows" name="wxWindows Library License"  isDeprecated="true" deprecatedVersion="2.0rc2">
-   <notes>DEPRECATED: Use License Expression Syntax and Exceptions list to create equivalent license.</notes>
       <crossRefs>
          <crossRef>http://www.opensource.org/licenses/WXwindows</crossRef>
       </crossRefs>
-      <notes>Typically used with GPL-2.0+
+   <notes>
+     <p>DEPRECATED: Use License Expression Syntax and Exceptions list to create equivalent license.</p>
+     <p>Typically used with GPL-2.0+.</p>
   </notes>
       <p>EXCEPTION NOTICE</p>
       <list>


### PR DESCRIPTION
The XSD schema is currently buggy on this point, but the plural element name (`<notes>` vs. `<note>`) and `maxOccurs` in the XSD entry:

```xml
<element name="notes" type="tns:formattedFixedTextType" minOccurs="0" maxOccurs="1"/>
```

suggest that we expect only a single note entry.

Spun off from #566.