### PR TITLE
GPL-3.0*: Copy the standard header from the license body

### DIFF
--- a/src/GPL-3.0+.xml
+++ b/src/GPL-3.0+.xml
@@ -9,12 +9,23 @@
 	  <notes>DEPRECATED: Use the license identifier GPL-3.0-or-later</notes>
       <standardLicenseHeader> Copyright (C) 
     <alt match=".+" name="copyright">&lt;year&gt; &lt;name of author&gt;</alt>
-    This program is free software:
-    you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the
-    Free Software Foundation, version. This program is distributed in the hope that it will be useful, but WITHOUT
-    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-    GNU General Public License for more details. You should have received a copy of the GNU General Public License
-    along with this program. If not, see http://www.gnu.org/licenses/
+      <p>
+        This program is free software: you can redistribute it and/or
+        modify it under the terms of the GNU General Public License
+        as published by the Free Software Foundation, either version
+        3 of the License, or (at your option) any later version.
+      </p>
+      <p>
+        This program is distributed in the hope that it will be
+        useful, but WITHOUT ANY WARRANTY; without even the implied
+        warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+        PURPOSE. See the GNU General Public License for more details.
+      </p>
+      <p>
+        You should have received a copy of the GNU General
+        Public License along with this program. If not, see
+        &lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.
+      </p>
   </standardLicenseHeader>
       <notes>This license was released: 29 June 2007 This refers to when this GPL 3.0 only is being used (as opposed to
          "or later).</notes>

--- a/src/GPL-3.0-only.xml
+++ b/src/GPL-3.0-only.xml
@@ -9,15 +9,22 @@
     <standardLicenseHeader>
       Copyright (C)<alt name="copyright"
       match=".+">&lt;year&gt; &lt;name of author&gt;</alt>
-	<p>This program is free software: you can redistribute it and/or
-      	modify it under the terms of the GNU General Public License as
- 	published by the Free Software Foundation, version 3.</p> 
-	<p>This program is
-      	distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-      	without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
-	PARTICULAR PURPOSE. See the GNU General Public License for more details.</p>
-      <p>You should have received a copy of the GNU General Public License
-      along with this program. If not, see http://www.gnu.org/licenses/</p>
+      <p>
+        This program is free software: you can redistribute it and/or
+        modify it under the terms of the GNU General Public License
+        as published by the Free Software Foundation, version 3.
+      </p>
+      <p>
+        This program is distributed in the hope that it will be
+        useful, but WITHOUT ANY WARRANTY; without even the implied
+        warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+        PURPOSE. See the GNU General Public License for more details.
+      </p>
+      <p>
+        You should have received a copy of the GNU General
+        Public License along with this program. If not, see
+        &lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.
+      </p>
     </standardLicenseHeader>
     <notes>
       This license was released: 29 June 2007 This refers to when

--- a/src/GPL-3.0-or-later.xml
+++ b/src/GPL-3.0-or-later.xml
@@ -9,15 +9,23 @@
     <standardLicenseHeader>
       Copyright (C)<alt name="copyright"
       match=".+">&lt;year&gt; &lt;name of author&gt;</alt>
-	<p>This program is free software: you can redistribute it and/or
-      	modify it under the terms of the GNU General Public License as
-	published by the Free Software Foundation, version 3 or any later version.</p>
-      	<p>This program is distributed in the hope that it will be useful, but
-      	WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
-      	or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
-	for more details.</p>  
-    	<p>You should have received a copy of the GNU General
-	Public License along with this program. If not, see http://www.gnu.org/licenses/</p>
+      <p>
+        This program is free software: you can redistribute it and/or
+        modify it under the terms of the GNU General Public License
+        as published by the Free Software Foundation, either version
+        3 of the License, or (at your option) any later version.
+      </p>
+      <p>
+        This program is distributed in the hope that it will be
+        useful, but WITHOUT ANY WARRANTY; without even the implied
+        warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+        PURPOSE. See the GNU General Public License for more details.
+      </p>
+      <p>
+        You should have received a copy of the GNU General
+        Public License along with this program. If not, see
+        &lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.
+      </p>
     </standardLicenseHeader>
     <notes>
       This license was released: 29 June 2007

--- a/src/GPL-3.0.xml
+++ b/src/GPL-3.0.xml
@@ -14,14 +14,22 @@
     <standardLicenseHeader>
       Copyright (C)<alt name="copyright"
       match=".+">&lt;year&gt; &lt;name of author&gt;</alt>
-      This program is free software: you can redistribute it and/or
-      modify it under the terms of the GNU General Public License as
-      published by the Free Software Foundation, version. This program is
-      distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-      without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
-      PARTICULAR PURPOSE. See the GNU General Public License for more details.
-      You should have received a copy of the GNU General Public License
-      along with this program. If not, see http://www.gnu.org/licenses/
+      <p>
+        This program is free software: you can redistribute it and/or
+        modify it under the terms of the GNU General Public License
+        as published by the Free Software Foundation, version 3.
+      </p>
+      <p>
+        This program is distributed in the hope that it will be
+        useful, but WITHOUT ANY WARRANTY; without even the implied
+        warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+        PURPOSE. See the GNU General Public License for more details.
+      </p>
+      <p>
+        You should have received a copy of the GNU General
+        Public License along with this program. If not, see
+        &lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.
+      </p>
     </standardLicenseHeader>
     <notes>
       This license was released: 29 June 2007 This refers to when


### PR DESCRIPTION
I've copy/pasted exactly from the license body, except for:

* Some tab → space replacements for consistent indenting.
* Adjusting the version text for the `-only` forms.  I think the version text we use is pretty strange, but I'll deal with that in follow-up work.

Semantic changes due to this standardization:

* GPL-3.0 gets “version.” → “version 3.”.

* GPL-3.0+ gets “either version 3 of the License, or (at your option) any later” where it previously had nothing.

* GPL-3.0-or-later gets “version 3 or any later version” → “either version 3 of the License, or (at your option) any later version”.

* Every license I touch gets `<…>` around its URL, which has been in the license templates since f6c34536 (#85) and similar.

* Every license I touch gets the optional HTTPS from df182a1a (#450) and similar.

I haven't bothered adding alt/optional to support our old forms, because I'm expecting folks in the wild to be copy/pasting from the FSF license text instead of our `<standardLicenseHeader>`s.  But I can work up alt/optional entries if folks feel they are needed.