### PR TITLE
Allow standardLicenseHeader under text

### DIFF
--- a/schema/ListedLicense.xsd
+++ b/schema/ListedLicense.xsd
@@ -32,8 +32,7 @@
 		<all>
 			<element name="crossRefs" type="tns:crossRefsType" minOccurs="0" maxOccurs="1"/>
 			<element name="notes" type="tns:formattedFixedTextType" minOccurs="0" maxOccurs="1"/>
-			<element name="standardLicenseHeader" type="tns:formattedAltTextType" minOccurs="0" maxOccurs="1"/>
-			<element name="text" type="tns:formattedAltTextType" minOccurs="0" maxOccurs="1"/>
+			<element name="text" type="tns:formattedAltFileGrantTextType" minOccurs="0" maxOccurs="1"/>
 		</all>
 		<attribute name="licenseId" type="string" use="required" />
 		<attribute name="isOsiApproved" type="boolean"/>
@@ -55,10 +54,19 @@
 	<complexType name="optionalType" mixed="true">
 		<group ref="tns:formattedAltTextGroup" minOccurs="0" maxOccurs="unbounded"/>
 	</complexType>
+	<complexType name="optionalFileGrantType" mixed="true">
+		<group ref="tns:formattedAltFileGrantTextGroup" minOccurs="0" maxOccurs="unbounded"/>
+	</complexType>
 	<complexType name="listType">
 		<choice minOccurs="1" maxOccurs="unbounded">
 			<element name="item" type="tns:formattedAltTextType"/>
 			<element name="list" type="tns:listType"/>
+		</choice>
+	</complexType>
+	<complexType name="listFileGrantType">
+		<choice minOccurs="1" maxOccurs="unbounded">
+			<element name="item" type="tns:formattedAltFileGrantTextType"/>
+			<element name="list" type="tns:listFileGrantType"/>
 		</choice>
 	</complexType>
 	<complexType name="emptyType"/>
@@ -67,6 +75,9 @@
 	</complexType>
 	<complexType name="formattedAltTextType" mixed="true">
 		<group ref="tns:formattedAltTextGroup" minOccurs="0" maxOccurs="unbounded"/>
+	</complexType>
+	<complexType name="formattedAltFileGrantTextType" mixed="true">
+		<group ref="tns:formattedAltFileGrantTextGroup" minOccurs="0" maxOccurs="unbounded"/>
 	</complexType>
 	<group name="formattedFixedTextGroup">
 		<choice>
@@ -88,6 +99,19 @@
 			<element name="br" type="tns:emptyType" minOccurs="0" maxOccurs="unbounded"/>
 			<element name="titleText" type="tns:formattedAltTextType" minOccurs="0" maxOccurs="1"/>
 			<element name="copyrightText" type="tns:formattedAltTextType" minOccurs="0" maxOccurs="1"/>
+		</choice>
+	</group>
+	<group name="formattedAltFileGrantTextGroup">
+		<choice>
+			<element name="p" type="tns:formattedAltFileGrantTextType" minOccurs="0" maxOccurs="unbounded"/>
+			<element name="bullet" type="string" minOccurs="0" maxOccurs="unbounded"/>
+			<element name="list" type="tns:listFileGrantType" minOccurs="0" maxOccurs="unbounded"/>
+			<element name="optional" type="tns:optionalFileGrantType" minOccurs="0" maxOccurs="unbounded"/>
+			<element name="alt" type="tns:altType" minOccurs="0" maxOccurs="unbounded"/>
+			<element name="br" type="tns:emptyType" minOccurs="0" maxOccurs="unbounded"/>
+			<element name="titleText" type="tns:formattedAltTextType" minOccurs="0" maxOccurs="1"/>
+			<element name="copyrightText" type="tns:formattedAltTextType" minOccurs="0" maxOccurs="1"/>
+			<element name="fileGrant" type="tns:formattedAltTextType" minOccurs="0" maxOccurs="1"/>
 		</choice>
 	</group>
 </schema>

--- a/schema/ListedLicense.xsd
+++ b/schema/ListedLicense.xsd
@@ -32,7 +32,7 @@
 		<all>
 			<element name="crossRefs" type="tns:crossRefsType" minOccurs="0" maxOccurs="1"/>
 			<element name="notes" type="tns:formattedFixedTextType" minOccurs="0" maxOccurs="1"/>
-			<element name="text" type="tns:formattedAltFileGrantTextType" minOccurs="0" maxOccurs="1"/>
+			<element name="text" type="tns:formattedAltStandardLicenseHeaderTextType" minOccurs="0" maxOccurs="1"/>
 		</all>
 		<attribute name="licenseId" type="string" use="required" />
 		<attribute name="isOsiApproved" type="boolean"/>
@@ -54,8 +54,8 @@
 	<complexType name="optionalType" mixed="true">
 		<group ref="tns:formattedAltTextGroup" minOccurs="0" maxOccurs="unbounded"/>
 	</complexType>
-	<complexType name="optionalFileGrantType" mixed="true">
-		<group ref="tns:formattedAltFileGrantTextGroup" minOccurs="0" maxOccurs="unbounded"/>
+	<complexType name="optionalStandardLicenseHeaderType" mixed="true">
+		<group ref="tns:formattedAltStandardLicenseHeaderTextGroup" minOccurs="0" maxOccurs="unbounded"/>
 	</complexType>
 	<complexType name="listType">
 		<choice minOccurs="1" maxOccurs="unbounded">
@@ -63,10 +63,10 @@
 			<element name="list" type="tns:listType"/>
 		</choice>
 	</complexType>
-	<complexType name="listFileGrantType">
+	<complexType name="listStandardLicenseHeaderType">
 		<choice minOccurs="1" maxOccurs="unbounded">
-			<element name="item" type="tns:formattedAltFileGrantTextType"/>
-			<element name="list" type="tns:listFileGrantType"/>
+			<element name="item" type="tns:formattedAltStandardLicenseHeaderTextType"/>
+			<element name="list" type="tns:listStandardLicenseHeaderType"/>
 		</choice>
 	</complexType>
 	<complexType name="emptyType"/>
@@ -76,8 +76,8 @@
 	<complexType name="formattedAltTextType" mixed="true">
 		<group ref="tns:formattedAltTextGroup" minOccurs="0" maxOccurs="unbounded"/>
 	</complexType>
-	<complexType name="formattedAltFileGrantTextType" mixed="true">
-		<group ref="tns:formattedAltFileGrantTextGroup" minOccurs="0" maxOccurs="unbounded"/>
+	<complexType name="formattedAltStandardLicenseHeaderTextType" mixed="true">
+		<group ref="tns:formattedAltStandardLicenseHeaderTextGroup" minOccurs="0" maxOccurs="unbounded"/>
 	</complexType>
 	<group name="formattedFixedTextGroup">
 		<choice>
@@ -101,17 +101,17 @@
 			<element name="copyrightText" type="tns:formattedAltTextType" minOccurs="0" maxOccurs="1"/>
 		</choice>
 	</group>
-	<group name="formattedAltFileGrantTextGroup">
+	<group name="formattedAltStandardLicenseHeaderTextGroup">
 		<choice>
-			<element name="p" type="tns:formattedAltFileGrantTextType" minOccurs="0" maxOccurs="unbounded"/>
+			<element name="p" type="tns:formattedAltStandardLicenseHeaderTextType" minOccurs="0" maxOccurs="unbounded"/>
 			<element name="bullet" type="string" minOccurs="0" maxOccurs="unbounded"/>
-			<element name="list" type="tns:listFileGrantType" minOccurs="0" maxOccurs="unbounded"/>
-			<element name="optional" type="tns:optionalFileGrantType" minOccurs="0" maxOccurs="unbounded"/>
+			<element name="list" type="tns:listStandardLicenseHeaderType" minOccurs="0" maxOccurs="unbounded"/>
+			<element name="optional" type="tns:optionalStandardLicenseHeaderType" minOccurs="0" maxOccurs="unbounded"/>
 			<element name="alt" type="tns:altType" minOccurs="0" maxOccurs="unbounded"/>
 			<element name="br" type="tns:emptyType" minOccurs="0" maxOccurs="unbounded"/>
 			<element name="titleText" type="tns:formattedAltTextType" minOccurs="0" maxOccurs="1"/>
 			<element name="copyrightText" type="tns:formattedAltTextType" minOccurs="0" maxOccurs="1"/>
-			<element name="fileGrant" type="tns:formattedAltTextType" minOccurs="0" maxOccurs="1"/>
+			<element name="standardLicenseHeader" type="tns:formattedAltTextType" minOccurs="0" maxOccurs="1"/>
 		</choice>
 	</group>
 </schema>

--- a/schema/ListedLicense.xsd
+++ b/schema/ListedLicense.xsd
@@ -32,6 +32,7 @@
 		<all>
 			<element name="crossRefs" type="tns:crossRefsType" minOccurs="0" maxOccurs="1"/>
 			<element name="notes" type="tns:formattedFixedTextType" minOccurs="0" maxOccurs="1"/>
+			<element name="standardLicenseHeader" type="tns:formattedAltTextType" minOccurs="0" maxOccurs="1"/>
 			<element name="text" type="tns:formattedAltStandardLicenseHeaderTextType" minOccurs="0" maxOccurs="1"/>
 		</all>
 		<attribute name="licenseId" type="string" use="required" />

--- a/src/AFL-1.1.xml
+++ b/src/AFL-1.1.xml
@@ -5,9 +5,6 @@
          <crossRef>http://opensource.linux-mirror.org/licenses/afl-1.1.txt</crossRef>
          <crossRef>http://wayback.archive.org/web/20021004124254/http://www.opensource.org/licenses/academic.php</crossRef>
       </crossRefs>
-      <standardLicenseHeader>
-         Licensed under the Academic Free License version 1.1.
-      </standardLicenseHeader>  
       <notes>This license has been superseded by later versions.</notes>
     <text>
       <titleText>
@@ -18,7 +15,9 @@
          <p>The Academic Free License applies to any original work of authorship (the "Original Work") whose owner
          (the "Licensor") has placed the following notice immediately following the copyright notice for the
          Original Work:</p>
-         <p>"Licensed under the Academic Free License version 1.1."</p>
+         <standardLicenseHeader>
+         <p><optional>"</optional>Licensed under the Academic Free License version 1.1.<optional>"</optional></p>
+         </standardLicenseHeader>
       </optional>
     
       <p>Grant of License. Licensor hereby grants to any person obtaining a copy of the Original Work ("You") a

--- a/src/AFL-1.2.xml
+++ b/src/AFL-1.2.xml
@@ -5,9 +5,6 @@
          <crossRef>http://opensource.linux-mirror.org/licenses/afl-1.2.txt</crossRef>
          <crossRef>http://wayback.archive.org/web/20021204204652/http://www.opensource.org/licenses/academic.php</crossRef>
       </crossRefs>
-      <standardLicenseHeader>
-        Licensed under the Academic Free License version 1.2
-      </standardLicenseHeader>
       <notes>This license has been superseded by later versions.
   
     We found these notes here: https://web.archive.org/web/20100828113909/http://opensource.linux-mirror.org/licenses/afl-1.2.txt
@@ -30,7 +27,9 @@
          <p>This Academic Free License applies to any original work of authorship (the "Original Work") whose owner
          (the "Licensor") has placed the following notice immediately following the copyright notice for the 
          Original Work:</p>
+         <standardLicenseHeader>
          <p>Licensed under the Academic Free License version 1.2</p>
+         </standardLicenseHeader>
       </optional>
     
       <p>Grant of License. Licensor hereby grants to any person obtaining a copy of the Original Work ("You") a

--- a/src/AFL-2.0.xml
+++ b/src/AFL-2.0.xml
@@ -5,9 +5,6 @@
          <crossRef>http://opensource.linux-mirror.org/licenses/afl-2.0.txt</crossRef>
          <crossRef>http://wayback.archive.org/web/20060924134533/http://www.opensource.org/licenses/afl-2.0.txt</crossRef>
       </crossRefs>
-      <standardLicenseHeader>
-         <p>Licensed under the Academic Free License version 2.0</p>
-      </standardLicenseHeader>
     <text>
       <titleText>
          <p>The Academic Free License 
@@ -18,7 +15,9 @@
          <p>This Academic Free License (the "License") applies to any original work of authorship (the "Original
          Work") whose owner (the "Licensor") has placed the following notice immediately following the
          copyright notice for the Original Work:</p>
+         <standardLicenseHeader>
          <p>Licensed under the Academic Free License version 2.0</p>
+         </standardLicenseHeader>
       </optional>
       <list>
         <item>

--- a/src/AFL-2.1.xml
+++ b/src/AFL-2.1.xml
@@ -4,9 +4,6 @@
       <crossRefs>
          <crossRef>http://opensource.linux-mirror.org/licenses/afl-2.1.txt</crossRef>
       </crossRefs>
-      <standardLicenseHeader>
-         Licensed under the Academic Free License version 2.1
-      </standardLicenseHeader>
     <text>
       <titleText>
          <p>The Academic Free License 
@@ -17,7 +14,9 @@
          <p>This Academic Free License (the "License") applies to any original work of authorship (the
          "Original Work") whose owner (the "Licensor") has placed the following notice
          immediately following the copyright notice for the Original Work:</p>
+         <standardLicenseHeader>
          <p>Licensed under the Academic Free License version 2.1</p>
+         </standardLicenseHeader>
       </optional>
     
       <list>

--- a/src/AFL-3.0.xml
+++ b/src/AFL-3.0.xml
@@ -5,9 +5,6 @@
          <crossRef>http://www.rosenlaw.com/AFL3.0.htm</crossRef>
          <crossRef>http://www.opensource.org/licenses/afl-3.0</crossRef>
       </crossRefs>
-      <standardLicenseHeader>
-         Licensed under the Academic Free License version 3.0
-      </standardLicenseHeader>
     <text>
       <titleText>
          <p>Academic Free License ("AFL") v. 3.0</p>
@@ -16,7 +13,9 @@
          <p>This Academic Free License (the "License") applies to any original work of authorship (the
          "Original Work") whose owner (the "Licensor") has placed the following licensing
          notice adjacent to the copyright notice for the Original Work:</p>
+         <standardLicenseHeader>
          <p>Licensed under the Academic Free License version 3.0</p>
+         </standardLicenseHeader>
       </optional>
     
       <list>

--- a/src/AGPL-3.0-or-later.xml
+++ b/src/AGPL-3.0-or-later.xml
@@ -6,20 +6,6 @@
       <crossRef>http://www.gnu.org/licenses/agpl.txt</crossRef>
       <crossRef>http://www.opensource.org/licenses/AGPL-3.0</crossRef>
     </crossRefs>
-    <standardLicenseHeader>
-      Copyright (C) <alt name="copyright" match=".+">[year] [name of author]</alt>
-      <p>This program is free software: you can redistribute it and/or modify it
-      under the terms of the GNU Affero General Public License as published
-      by the Free Software Foundation, either version 3 of the License, or 
-	      <optional>(at your option)</optional> any later version. </p>
-      <p>This program is distributed
-      in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
-      even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-      PURPOSE. See the GNU Affero General Public License for more details.</p>
-      <p>You should have received a copy of the GNU Affero General Public License
-      along with this program. If not, see
-	      &lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;</p>
-    </standardLicenseHeader>
     <notes>
       This version was released: 19 November 2007
     </notes>
@@ -805,16 +791,17 @@
         state the exclusion of warranty; and each file should have at least
         the "copyright" line and a pointer to where the full notice is found.
       </p>
+      <standardLicenseHeader>
       <p>
-        &lt;one line to give the program's name and
-        a brief idea of what it does.&gt;<br></br>
-        Copyright (C) &lt;year&gt; &lt;name of author&gt;
+        <alt name="description" match=".+">&lt;one line to give the program's name and
+        a brief idea of what it does.&gt;</alt><br/>
+        Copyright (C) <alt name="copyright" match=".+">&lt;year&gt; &lt;name of author&gt;</alt>
       </p>
       <p>
         This program is free software: you can redistribute it and/or
         modify it under the terms of the GNU Affero General Public
         License as published by the Free Software Foundation, either
-        version 3 of the License, or (at your option) any later version.
+        version 3 of the License, or <optional>(at your option)</optional> any later version.
       </p>
       <p>
         This program is distributed in the hope that it will be useful,
@@ -827,6 +814,7 @@
 	Public License along with this program. If not, see
 	&lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.
       </p>
+      </standardLicenseHeader>
       <p>
         Also add information on how to contact you by electronic and paper mail.
       </p>

--- a/src/Apache-2.0.xml
+++ b/src/Apache-2.0.xml
@@ -5,24 +5,6 @@
          <crossRef>http://www.apache.org/licenses/LICENSE-2.0</crossRef>
          <crossRef>http://www.opensource.org/licenses/Apache-2.0</crossRef>
       </crossRefs>
-      <standardLicenseHeader> Copyright 
-    <alt match=".+" name="copyright">[yyyy] [name of copyright owner]</alt> 
-       <p>
-          Licensed under the Apache License, Version 2.0 (the "License"); you may 
-          not use this file except in compliance with the License. You may
-          obtain a copy of the License at
-       </p>
-       <p>
-          http://www.apache.org/licenses/LICENSE-2.0
-       </p>
-       <p>
-          Unless required by applicable law or agreed to in writing, software 
-          distributed under the License is distributed on an "AS IS" BASIS,
-          WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
-          implied. See the License for the specific language governing permissions
-          and limitations under the License. 
-       </p>
-  </standardLicenseHeader>
       <notes>This license was released January 2004</notes>
     <text>
       <titleText>
@@ -221,7 +203,8 @@
          format. We also recommend that a file or class name and description of purpose be included on the same
          "printed page" as the copyright notice for easier identification within third-party
          archives.</p>
-         <p>Copyright [yyyy] [name of copyright owner]</p>
+         <standardLicenseHeader>
+         <p>Copyright <alt name="copyright" match=".+">[yyyy] [name of copyright owner]</alt></p>
          <p>Licensed under the Apache License, Version 2.0 (the "License"); 
         <br/>you may not use this file except in compliance with the License. 
         <br/>You may obtain a copy of the License at 
@@ -233,6 +216,7 @@
         <br/>See the License for the specific language governing permissions and 
         <br/>limitations under the License. 
       </p>
+        </standardLicenseHeader>
       </optional>
     </text>
   </license>

--- a/src/BitTorrent-1.0.xml
+++ b/src/BitTorrent-1.0.xml
@@ -5,14 +5,6 @@
       <crossRefs>
          <crossRef>http://sources.gentoo.org/cgi-bin/viewvc.cgi/gentoo-x86/licenses/BitTorrent?r1=1.1&amp;r2=1.1.1.1&amp;diff_format=s</crossRef>
       </crossRefs>
-      <standardLicenseHeader>
-         <p>The contents of this file are subject to the BitTorrent Open Source License Version 1.0 (the License). 
-      You may not copy or use this file, in either source code or executable form, except in compliance with 
-      the License. You may obtain a copy of the License at http://www.bittorrent.com/license/.</p>
-         <p>Software distributed under the License is distributed on an AS IS basis, WITHOUT WARRANTY OF ANY KIND, 
-      either express or implied. See the License for the specific language governing rights and limitations under 
-      the License.</p>
-      </standardLicenseHeader>
     <text>
       <titleText>
          <p>BitTorrent Open Source License 
@@ -461,12 +453,14 @@
          Product or any hereto. Contributors to any Modifications may add their own copyright notices to
          identify their own contributions.</p>
          <p>License:</p>
+         <standardLicenseHeader>
          <p>The contents of this file are subject to the BitTorrent Open Source License Version 1.0 (the License).
          You may not copy or use this file, in either source code or executable form, except in compliance with
          the License. You may obtain a copy of the License at http://www.bittorrent.com/license/.</p>
          <p>Software distributed under the License is distributed on an AS IS basis, WITHOUT WARRANTY OF ANY KIND,
          either express or implied. See the License for the specific language governing rights and limitations
          under the License.</p>
+         </standardLicenseHeader>
       </optional>
     </text>
   </license>

--- a/src/CPAL-1.0.xml
+++ b/src/CPAL-1.0.xml
@@ -5,38 +5,6 @@
       <crossRefs>
          <crossRef>http://www.opensource.org/licenses/CPAL-1.0</crossRef>
       </crossRefs>
-      <standardLicenseHeader> The contents of this file are subject to the Common Public Attribution License Version 1.0 (the
-          "License"); you may not use this file except in compliance with the License. You may
-          obtain a copy of the License at _____. The License is based on the Mozilla Public License Version
-          1.1 but Sections 14 and 15 have been added to cover use of software over a computer network and
-          provide for limited attribution for the Original Developer. In addition, Exhibit A has been modified
-          to be consistent with Exhibit B. Software distributed under the License is distributed on an
-          "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
-          License for the specific language governing rights and limitations under the License. 
-         <p>The Original
-          Code is 
-            <alt match=".+" name="code">_____</alt>.</p> 
-         <p>The Original Developer is not the Initial Developer and is 
-    <alt match=".+" name="developer">_____</alt>. If left blank, the Original Developer is the Initial Developer.</p>
-    <p>The Initial Developer of the Original Code is 
-    <alt match=".+" name="InitialDeveloper">_____</alt>. All portions of the code written by 
-    <alt match=".+" name="createdby">_____</alt> are Copyright (c) 
-       <alt match=".+" name="copyright">_____</alt>. All Rights Reserved.</p> 
-         <p>Contributor 
-            <alt match=".+" name="contributor">_____</alt>.</p> 
-         <p>Alternatively, the contents of this file may be used under the
-    terms of the 
-    <alt match=".+" name="AltLicense">_____</alt> license (the 
-    <alt match=".+" name="licenseName">[____]</alt> License), in which case the provisions of 
-    <alt match=".+" name="licenseName">[____]</alt> License are applicable instead of those above. If you wish to
-    allow use of your version of this file only under the terms of the 
-    <alt match=".+" name="licenseName">[____]</alt> License and not to allow others to use your version of this file
-    under the CPAL, indicate your decision by deleting the provisions above and replace them with the notice and
-    other provisions required by the 
-    <alt match=".+" name="licenseName">[____]</alt> License. If you do not delete the provisions above, a recipient
-    may use your version of this file under either the CPAL or the 
-            <alt match=".+" name="licenseName">[____]</alt> License. </p>
-  </standardLicenseHeader>
     <text>
       <titleText>
          <p>Common Public Attribution License Version 1.0 (CPAL)</p>
@@ -629,31 +597,33 @@
     
       <optional>
          <p>EXHIBIT A. Common Public Attribution License Version 1.0.</p>
+         <standardLicenseHeader>
          <p>"The contents of this file are subject to the Common Public Attribution License Version 1.0 (the
          "License"); you may not use this file except in compliance with the License. You may
-         obtain a copy of the License at _____________. The License is based on the Mozilla Public License
+         obtain a copy of the License at <alt name="source" match=".+">_____________</alt>. The License is based on the Mozilla Public License
          Version 1.1 but Sections 14 and 15 have been added to cover use of software over a computer network
          and provide for limited attribution for the Original Developer. In addition, Exhibit A has been
          modified to be consistent with Exhibit B. 
         <br/>Software distributed under the License is distributed on an "AS IS" basis, WITHOUT
              WARRANTY OF ANY KIND, either express or implied. See the License for the specific language
              governing rights and limitations under the License. 
-        <br/>The Original Code is______________________. 
-        <br/>The Original Developer is not the Initial Developer and is __________. If left blank, the Original
+        <br/>The Original Code is <alt name="code" match=".+">______________________</alt>.
+        <br/>The Original Developer is not the Initial Developer and is <alt name="originalDeveloper" match=".+">__________</alt>. If left blank, the Original
              Developer is the Initial Developer. 
-        <br/>The Initial Developer of the Original Code is ____________. All portions of the code written by
-             ___________ are Copyright (c) _____. All Rights Reserved. 
-        <br/>Contributor ______________________. 
-        <br/>Alternatively, the contents of this file may be used under the terms of the _____ license (the
-             [___] License), in which case the provisions of [______] License are applicable instead of
+        <br/>The Initial Developer of the Original Code is <alt name="initialDeveloper" match=".+">____________</alt>. All portions of the code written by
+             <alt name="initialDeveloper2" match=".+">___________</alt> are Copyright (c) <alt name="copyright" match=".+">_____</alt>. All Rights Reserved.
+        <br/>Contributor <alt name="contributor" match=".+">______________________</alt>.
+        <br/>Alternatively, the contents of this file may be used under the terms of the <alt name="altLicense" match=".+">_____</alt> license (the
+             <alt name="altLicenseShort1" match=".+">[___]</alt> License), in which case the provisions of <alt name="altLicenseShort2" match=".+">[______]</alt> License are applicable instead of
              those above. 
-        <br/>If you wish to allow use of your version of this file only under the terms of the [____] License
+        <br/>If you wish to allow use of your version of this file only under the terms of the <alt name="altLicenseShort3" match=".+">[____]</alt> License
              and not to allow others to use your version of this file under the CPAL, indicate your
              decision by deleting the provisions above and replace them with the notice and other
-             provisions required by the [___] License. If you do not delete the provisions above, a
-             recipient may use your version of this file under either the CPAL or the [___]
+             provisions required by the <alt name="altLicenseShort4" match=".+">[___]</alt> License. If you do not delete the provisions above, a
+             recipient may use your version of this file under either the CPAL or the <alt name="altLicenseShort5" match=".+">[___]</alt>
              License." 
       </p>
+         </standardLicenseHeader>
          <p>[NOTE: The text of this Exhibit A may differ slightly from the text of the notices in the Source Code
          files of the Original Code. You should use the text of this Exhibit A rather than the text found in
          the Original Code Source Code for Your Modifications.]</p>

--- a/src/CUA-OPL-1.0.xml
+++ b/src/CUA-OPL-1.0.xml
@@ -5,29 +5,6 @@
       <crossRefs>
          <crossRef>http://opensource.org/licenses/CUA-OPL-1.0</crossRef>
       </crossRefs>
-      <standardLicenseHeader> 
-        <p>The contents of this file are subject to the CUA Office Public License Version 1.0 (the
-          "License"); you may not use this file except in compliance with the License. You may
-          obtain a copy of the License at http://cuaoffice.sourceforge.net/ Software distributed under the
-          License is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express
-          or implied. See the License for the specific language governing rights and limitations under the
-          License. </p>
-          <p>The Original Code is <alt match=".+" name="OriginalCodeCopyrightNotice">_____</alt>.</p> 
-          <p>The Initial Developer of the Original Code is <alt match=".+" name="InitialDeveloperName">_____</alt>. </p>
-          <p>Portions created by <alt match=".+" name="OtherContributorName">_____</alt> are Copyright (C) 
-          <alt match=".+" name="OtherContributorCopyrightNotice">_____</alt>. All Rights Reserved. </p>
-          <p>Contributor(s): <alt match=".+" name="AdditionalContributors">_____</alt>. </p>
-            
-        <p>Alternatively, the contents of this file may be used under the terms of the 
-        <alt match=".+" name="AltLicenseName">_____</alt> license (the "<alt match=".+" name="AltLicenseName">[____]</alt> License"), 
-        in which case the provisions of <alt match=".+" name="AltLicenseName">[____]</alt> License are applicable 
-        instead of those above. If you wish to allow use of your version of this file only under the terms of 
-        the <alt match=".+" name="AltLicenseName">[____]</alt> License and not to allow others to use your version 
-        of this file under the CUAPL, indicate your decision by deleting the provisions above and replace 
-        them with the notice and other provisions required by the <alt match=".+" name="AltLicenseName">[____]</alt> 
-        License. If you do not delete the provisions above, a recipient may use your version of this file 
-        under either the CUAPL or the <alt match=".+" name="AltLicenseName">[____]</alt> License. </p>
-      </standardLicenseHeader>
     <text>
       <titleText>
          <p>CUA Office Public License Version 1.0</p>
@@ -520,23 +497,25 @@
       </list>
       <optional>
          <p>EXHIBIT A - CUA Office Public License.</p>
-         <p>"The contents of this file are subject to the CUA Office Public License Version 1.0 (the
+         <standardLicenseHeader>
+         <p><optional>"</optional>The contents of this file are subject to the CUA Office Public License Version 1.0 (the
          "License"); you may not use this file except in compliance with the License. You may obtain
          a copy of the License at http://cuaoffice.sourceforge.net/</p>
          <p>Software distributed under the License is distributed on an "AS IS" basis, WITHOUT WARRANTY OF
          ANY KIND, either express or implied. See the License for the specific language governing rights and
          limitations under the License.</p>
-         <p>The Original Code is ______________________________________.</p>
-         <p>The Initial Developer of the Original Code is ________________________. Portions created by
-         ______________________ are Copyright (C) ______ _______________________. All Rights Reserved.</p>
-         <p>Contributor(s): ______________________________________.</p>
-         <p>Alternatively, the contents of this file may be used under the terms of the _____ license (the
-         "[___] License"), in which case the provisions of [______] License are applicable instead of
-         those above. If you wish to allow use of your version of this file only under the terms of the [____]
+         <p>The Original Code is <alt name="code" match=".+">______________________________________</alt>.</p>
+         <p>The Initial Developer of the Original Code is <alt name="initialDeveloper" match=".+">________________________</alt>. Portions created by
+         <alt name="creator" match=".+">______________________</alt> are Copyright (C) <alt name="copyright" match=".+">______ _______________________</alt>. All Rights Reserved.</p>
+         <p>Contributor(s): <alt name="contributor" match=".+">______________________________________</alt>.</p>
+         <p>Alternatively, the contents of this file may be used under the terms of the <alt name="altLicense" match=".+">_____</alt> license (the
+         "<alt name="altLicenseShort1" match=".+">[___]</alt> License"), in which case the provisions of <alt name="altLicenseShort2" match=".+">[______]</alt> License are applicable instead of
+         those above. If you wish to allow use of your version of this file only under the terms of the <alt name="altLicenseShort3" match=".+">[____]</alt>
          License and not to allow others to use your version of this file under the CUAPL, indicate your
          decision by deleting the provisions above and replace them with the notice and other provisions
-         required by the [___] License. If you do not delete the provisions above, a recipient may use your
-         version of this file under either the CUAPL or the [___] License."</p>
+         required by the <alt name="altLicenseShort4" match=".+">[___]</alt> License. If you do not delete the provisions above, a recipient may use your
+         version of this file under either the CUAPL or the <alt name="altLicenseShort5" match=".+">[___]</alt> License.<optional>"</optional></p>
+         </standardLicenseHeader>
          <p>[NOTE: The text of this Exhibit A may differ slightly from the text of the notices in the Source Code
          files of the Original Code. You should use the text of this Exhibit A rather than the text found in
          the Original Code Source Code for Your Modifications.]</p>

--- a/src/ECL-1.0.xml
+++ b/src/ECL-1.0.xml
@@ -5,10 +5,6 @@
       <crossRefs>
          <crossRef>http://opensource.org/licenses/ECL-1.0</crossRef>
       </crossRefs>
-      <standardLicenseHeader> Copyright (c) 
-    <alt match=".+" name="copyright">&lt;year&gt; &lt;copyright holders&gt;</alt> Licensed under the Educational
-    Community License version 1.0 
-  </standardLicenseHeader>
     <text>
       <titleText>
          <p>The Educational Community License</p>
@@ -16,10 +12,12 @@
       <p>This Educational Community License (the "License") applies to any original work of authorship (the
          "Original Work") whose owner (the "Licensor") has placed the following notice immediately following
          the copyright notice for the Original Work:</p>
+      <standardLicenseHeader>
       <p>Copyright (c) 
         <alt match=".+" name="copyright">&lt;year&gt; &lt;copyright holders&gt;</alt>
       </p>
       <p>Licensed under the Educational Community License version 1.0</p>
+      </standardLicenseHeader>
       <p>This Original Work, including software, source code, documents, or other related items, is being provided
          by the copyright holder(s) subject to the terms of the Educational Community License. By obtaining,
          using and/or copying this Original Work, you agree that you have read, understand, and will comply

--- a/src/ECL-2.0.xml
+++ b/src/ECL-2.0.xml
@@ -5,14 +5,6 @@
       <crossRefs>
          <crossRef>http://opensource.org/licenses/ECL-2.0</crossRef>
       </crossRefs>
-      <standardLicenseHeader> Copyright 
-    <alt match=".+" name="copyright">[yyyy] [copyright owner]</alt> Licensed under the Educational Community
-    License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at http://www.osedu.org/licenses/ECL-2.0 Unless required by applicable law
-    or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
-    language governing permissions and limitations under the License. 
-  </standardLicenseHeader>
       <notes>The Educational Community License version 2.0 ("ECL") consists of the Apache 2.0 license, modified
          to change the scope of the patent grant in section 3 to be specific to the needs of the education
          communities using this license. The url included in the boilerplate notice does not work.
@@ -230,7 +222,8 @@
         <br/>the same "printed page" as the copyright notice for easier 
         <br/>identification within third-party archives. 
       </p>
-         <p>Copyright [yyyy] [name of copyright owner] Licensed under the 
+      <standardLicenseHeader>
+         <p>Copyright <alt name="copyright" match=".+">[yyyy] [name of copyright owner]</alt> Licensed under the
         <br/>Educational Community License, Version 2.0 (the "License"); you may 
         <br/>not use this file except in compliance with the License. You may 
         <br/>obtain a copy of the License at 
@@ -242,6 +235,7 @@
         <br/>or implied. See the License for the specific language governing 
         <br/>permissions and limitations under the License. 
       </p>
+      </standardLicenseHeader>
       </optional>
     </text>
   </license>

--- a/src/GFDL-1.1-or-later.xml
+++ b/src/GFDL-1.1-or-later.xml
@@ -5,16 +5,6 @@
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/old-licenses/fdl-1.1.txt</crossRef>
     </crossRefs>
-    <standardLicenseHeader>
-      Copyright (c) <alt name="copyright" match=".+">YEAR YOUR NAME</alt>
-      Permission is granted to copy, distribute and/or modify this
-      document under the terms of the GNU Free Documentation License,
-      Version 1.1 or any later version published by the Free Software
-      Foundation; with the Invariant Sections being LIST THEIR
-      TITLES, with the Front-Cover Texts being LIST, and with the
-      Back-Cover Texts being LIST. A copy of the license is included
-      in the section entitled "GNU Free Documentation License".
-    </standardLicenseHeader>
     <notes>
       This license was released March 2000
     </notes>
@@ -456,15 +446,18 @@
         a copy of the License in the document and put the following
         copyright and license notices just after the title page:
       </p>
+      <standardLicenseHeader>
       <p>
         Copyright (c) YEAR YOUR NAME. Permission is granted to copy,
         distribute and/or modify this document under the terms of the
         GNU Free Documentation License, Version 1.1 or any later version
-        published by the Free Software Foundation; with the Invariant Sections
-        being LIST THEIR TITLES, with the Front-Cover Texts being LIST,
-        and with the Back-Cover Texts being LIST. A copy of the license is
+        published by the Free Software Foundation; with <alt name="invariantSections" match="the Invariant Sections
+        being .+|no Invariant Sections">the Invariant Sections
+        being LIST THEIR TITLES</alt>, with <alt name="frontCoverTexts" match="the Front-Cover Texts being .+|no Front-Cover Texts">the Front-Cover Texts being LIST</alt>,
+        and with <alt name="backCoverTexts" match="the Back-Cover Texts being .+|no Back-Cover Texts">the Back-Cover Texts being LIST</alt>. A copy of the license is
         included in the section entitled "GNU Free Documentation License".
       </p>
+      </standardLicenseHeader>
       <p>
         If you have no Invariant Sections, write "with no Invariant
         Sections" instead of saying which ones are invariant. If you have

--- a/src/GFDL-1.2-or-later.xml
+++ b/src/GFDL-1.2-or-later.xml
@@ -5,15 +5,6 @@
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/old-licenses/fdl-1.2.txt</crossRef>
     </crossRefs>
-    <standardLicenseHeader>
-      Copyright (c) <alt name="copyright" match=".+">YEAR YOUR NAME</alt>
-      Permission is granted to copy, distribute and/or modify this
-      document under the terms of the GNU Free Documentation License,
-      Version 1.2 or any later version published by the Free Software
-      Foundation; with no Invariant Sections, no Front-Cover Texts,
-      and no Back-Cover Texts. A copy of the license is included
-      in the section entitled "GNU Free Documentation License".
-    </standardLicenseHeader>
     <notes>
       This license was released November 2002
     </notes>
@@ -498,14 +489,17 @@
         a copy of the License in the document and put the following
         copyright and license notices just after the title page:
       </p>
+      <standardLicenseHeader>
       <p>
-        Copyright (c) YEAR YOUR NAME. Permission is granted to copy,
+        Copyright (c) <alt name="copyright" match=".+">YEAR YOUR NAME</alt>. Permission is granted to copy,
         distribute and/or modify this document under the terms of the GNU
         Free Documentation License, Version 1.2 or any later version published
-        by the Free Software Foundation; with no Invariant Sections, no
-        Front-Cover Texts, and no Back-Cover Texts. A copy of the license is
+        by the Free Software Foundation; with <alt name="invariantSections" match="no Invariant Sections|the Invariant Sections being .*">no Invariant Sections</alt>,
+        <alt name="frontCoverTexts" match="no Front-Cover Texts|with the Front-Cover Texts being .+">no Front-Cover Texts</alt>,
+        and <alt name="backCoverTexts" match="no Back-Cover Texts|with the Back-Cover Texts being .+">no Back-Cover Texts</alt>. A copy of the license is
         included in the section entitled "GNU Free Documentation License".
       </p>
+      </standardLicenseHeader>
       <p>
         If you have Invariant Sections, Front-Cover Texts and
         Back-Cover Texts, replace the "with...Texts." line with this:

--- a/src/GFDL-1.3-or-later.xml
+++ b/src/GFDL-1.3-or-later.xml
@@ -5,15 +5,6 @@
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/fdl-1.3.txt</crossRef>
     </crossRefs>
-    <standardLicenseHeader>
-      Copyright (c) <alt name="copyright" match=".+">YEAR YOUR NAME</alt>
-      Permission is granted to copy, distribute and/or modify this
-      document under the terms of the GNU Free Documentation License,
-      Version 1.3 or any later version published by the Free Software
-      Foundation; with no Invariant Sections, no Front-Cover Texts,
-      and no Back-Cover Texts. A copy of the license is included
-      in the section entitled "GNU Free Documentation License".
-    </standardLicenseHeader>
     <notes>
       This license was released 3 November 2008.
     </notes>
@@ -559,14 +550,17 @@
         a copy of the License in the document and put the following
         copyright and license notices just after the title page:
       </p>
+      <standardLicenseHeader>
       <p>
-        Copyright (c) YEAR YOUR NAME. Permission is granted to copy,
+        Copyright (c) <alt name="copyright" match=".+">YEAR YOUR NAME</alt>. Permission is granted to copy,
         distribute and/or modify this document under the terms of the GNU
         Free Documentation License, Version 1.3 or any later version published
-        by the Free Software Foundation; with no Invariant Sections, no
-        Front-Cover Texts, and no Back-Cover Texts. A copy of the license is
+        by the Free Software Foundation; with <alt name="invariantSections" match="no Invariant Sections|the Invariant Sections being .*">no Invariant Sections</alt>,
+        <alt name="frontCoverTexts" match="no Front-Cover Texts|with the Front-Cover Texts being .+">no Front-Cover Texts</alt>,
+        and <alt name="backCoverTexts" match="no Back-Cover Texts|with the Back-Cover Texts being .+">no Back-Cover Texts</alt>. A copy of the license is
         included in the section entitled "GNU Free Documentation License".
       </p>
+      </standardLicenseHeader>
       <p>
         If you have Invariant Sections, Front-Cover Texts and
         Back-Cover Texts, replace the "with...Texts." line with this:

--- a/src/GPL-1.0+.xml
+++ b/src/GPL-1.0+.xml
@@ -6,15 +6,6 @@
          <crossRef>http://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html</crossRef>
       </crossRefs>
       <notes>DEPRECATED: Use GPL-1.0-or-later</notes>
-      <standardLicenseHeader> Copyright (C) 
-    <alt match=".+" name="copyright">19xx name of author</alt> 
-         <p>This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either version 1, or (at your option) any later version.</p> 
-         <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-    without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
-    Public License for more details. </p>
-         <p>You should have received a copy of the GNU General Public License along with
-    this program; if not, write to the Free Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA. </p>
-      </standardLicenseHeader>
     <text>
       <titleText>
          <p>GNU GENERAL PUBLIC LICENSE 
@@ -208,8 +199,9 @@
          <p>To do so, attach the following notices to the program. It is safest to attach them to the start of each
          source file to most effectively convey the exclusion of warranty; and each file should have at least
          the "copyright" line and a pointer to where the full notice is found.</p>
-         <p>&lt;one line to give the program's name and a brief idea of what it does.&gt; Copyright (C) 19yy
-         &lt;name of author&gt;</p>
+         <standardLicenseHeader>
+         <p><alt name="description" match=".+">&lt;one line to give the program's name and a brief idea of what it does.&gt;</alt><br/>
+         Copyright (C) <alt name="copyright" match=".+">19yy &lt;name of author&gt;</alt></p>
          <p>This program is free software; you can redistribute it and/or modify it under the terms of the GNU
          General Public License as published by the Free Software Foundation; either version 1, or (at your
          option) any later version.</p>
@@ -218,6 +210,7 @@
          Public License for more details.</p>
          <p>You should have received a copy of the GNU General Public License along with this program; if not, write
          to the Free Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.</p>
+         </standardLicenseHeader>
          <p>Also add information on how to contact you by electronic and paper mail.</p>
          <p>If the program is interactive, make it output a short notice like this when it starts in an interactive
          mode:</p>

--- a/src/GPL-1.0-or-later.xml
+++ b/src/GPL-1.0-or-later.xml
@@ -5,26 +5,6 @@
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html</crossRef>
     </crossRefs>
-    <standardLicenseHeader>
-      Copyright (C) <alt name="copyright" match=".+">19xx name of author</alt>
-      <p>
-        This program is free software; you can redistribute it and/or
-        modify it under the terms of the GNU General Public License
-	as published by the Free Software Foundation; version 1
-	or any later version.
-      </p>
-      <p>
-        This program is distributed in the hope that it will be
-        useful, but WITHOUT ANY WARRANTY; without even the implied
-        warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-        PURPOSE. See the GNU General Public License for more details.
-      </p>
-      <p>
-        You should have received a copy of the GNU General Public License
-        along with this program; if not, write to the Free Software
-        Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
-      </p>
-    </standardLicenseHeader>
     <notes>
       This license was released: February 1989. This license
       has been deprecated by its authors.
@@ -302,9 +282,10 @@
         convey the exclusion of warranty; and each file should have at least
         the "copyright" line and a pointer to where the full notice is found.
       </p>
+      <standardLicenseHeader>
       <p>
-        &lt;one line to give the program's name and a brief idea
-        of what it does.&gt; Copyright (C) 19yy &lt;name of author&gt;
+        <alt name="description" match=".+">&lt;one line to give the program's name and a brief idea of what it does.&gt;</alt><br/>
+        Copyright (C) <alt name="copyright" match=".+">19yy &lt;name of author&gt;</alt>
       </p>
       <p>
         This program is free software; you can redistribute it
@@ -323,6 +304,7 @@
         along with this program; if not, write to the Free Software
         Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
       </p>
+      </standardLicenseHeader>
       <p>
         Also add information on how to contact you by electronic and paper mail.
       </p>

--- a/src/GPL-2.0+.xml
+++ b/src/GPL-2.0+.xml
@@ -7,18 +7,6 @@
          <crossRef>http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html</crossRef>
          <crossRef>http://www.opensource.org/licenses/GPL-2.0</crossRef>
       </crossRefs>
-      <standardLicenseHeader> Copyright (C)
-    <alt match=".+" name="copyright">yyyy name of author</alt>
-         <p>This program is free software; you can redistribute
-    it and/or modify it under the terms of the GNU General Public License as published by the Free Software
-    Foundation; version 2. </p>
-         <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-    without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
-    Public License for more details. </p>
-         <p>You should have received a copy of the GNU General Public License along with
-    this program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
-    02110-1301<optional>,</optional> USA.</p>
-      </standardLicenseHeader>
     <text>
       <titleText>
          <p>GNU GENERAL PUBLIC LICENSE
@@ -280,8 +268,9 @@
          <p>To do so, attach the following notices to the program. It is safest to attach them to the start of each
          source file to most effectively convey the exclusion of warranty; and each file should have at least
          the "copyright" line and a pointer to where the full notice is found.</p>
-         <p><optional>&lt;</optional>one line to give the program's name and an idea of what it does.<optional>&gt;</optional>
-         <br/>Copyright (C) <optional>&lt;</optional>yyyy<optional>&gt;</optional> <optional>&lt;</optional>name of author<optional>&gt;</optional></p>
+         <standardLicenseHeader>
+         <p><alt name="description" match=".+">&lt;one line to give the program's name and an idea of what it does.&gt;</alt><br/>
+         Copyright (C) <alt name="copyright" match=".+">&lt;yyyy&gt; &lt;name of author&gt;</alt></p>
          <p>This program is free software; you can redistribute it and/or modify it under the terms of the GNU
          General Public License as published by the Free Software Foundation; either version 2 of the License,
          or (at your option) any later version.</p>
@@ -289,8 +278,9 @@
          the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
          Public License for more details.</p>
          <p>You should have received a copy of the GNU General Public License along with this program; if not, write
-         to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301<optional>,</optional> USA.
-         Also add information on how to contact you by electronic and paper mail.</p>
+         to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301<optional>,</optional> USA.</p>
+         </standardLicenseHeader>
+         <p>Also add information on how to contact you by electronic and paper mail.</p>
          <p>If the program is interactive, make it output a short notice like this when it starts in an interactive
          mode:</p>
          <p>Gnomovision version 69, Copyright (C) year name of author Gnomovision comes with ABSOLUTELY NO WARRANTY;

--- a/src/GPL-2.0-or-later.xml
+++ b/src/GPL-2.0-or-later.xml
@@ -6,28 +6,6 @@
       <crossRef>http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html</crossRef>
       <crossRef>http://www.opensource.org/licenses/GPL-2.0</crossRef>
     </crossRefs>
-    <standardLicenseHeader>
-      Copyright (C) <alt name="copyright" match=".+">yyyy name of author</alt>
-      <p>
-        This program is free software; you can redistribute it and/or
-        modify it under the terms of the GNU General Public License
-	as published by the Free Software Foundation; version 2
-	or any later version.
-      </p>
-      <p>
-        This program is distributed in the hope that it will be
-        useful, but WITHOUT ANY WARRANTY; without even the implied
-        warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-        PURPOSE. See the GNU General Public License for more details.
-      </p>
-      <p>
-        You should have received a copy of the GNU General Public License
-        along with this program; if not, write to the Free Software Foundation,
-        Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301
-        <optional>,</optional>
-        USA.
-      </p>
-    </standardLicenseHeader>
     <notes>
       This license was released: June 1991
     </notes>
@@ -401,18 +379,10 @@
         convey the exclusion of warranty; and each file should have at least
         the "copyright" line and a pointer to where the full notice is found.
       </p>
+      <standardLicenseHeader>
       <p>
-        <optional>&lt;</optional>
-        one line to give the program's name and an idea of what it does.
-        <optional>&gt;</optional>
-        <br></br>
-        Copyright (C)
-        <optional>&lt;</optional>
-        yyyy
-        <optional>&gt;</optional>
-        <optional>&lt;</optional>
-        name of author
-        <optional>&gt;</optional>
+        <alt name="description" match=".+">&lt;one line to give the program's name and an idea of what it does.&gt;</alt><br/>
+        Copyright (C) <alt name="copyright" match=".+">&lt;yyyy&gt; &lt;name of author&gt;</alt>
       </p>
       <p>
         This program is free software; you can redistribute it and/or
@@ -433,7 +403,11 @@
         <optional>
           ,
         </optional>
-        USA. Also add information on how to
+        USA.
+      </p>
+      </standardLicenseHeader>
+      <p>
+        Also add information on how to
         contact you by electronic and paper mail.
       </p>
       <p>

--- a/src/GPL-3.0+.xml
+++ b/src/GPL-3.0+.xml
@@ -7,26 +7,6 @@
          <crossRef>http://www.opensource.org/licenses/GPL-3.0</crossRef>
       </crossRefs>
 	  <notes>DEPRECATED: Use the license identifier GPL-3.0-or-later</notes>
-      <standardLicenseHeader> Copyright (C) 
-    <alt match=".+" name="copyright">&lt;year&gt; &lt;name of author&gt;</alt>
-      <p>
-        This program is free software: you can redistribute it and/or
-        modify it under the terms of the GNU General Public License
-        as published by the Free Software Foundation, either version
-        3 of the License, or (at your option) any later version.
-      </p>
-      <p>
-        This program is distributed in the hope that it will be
-        useful, but WITHOUT ANY WARRANTY; without even the implied
-        warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-        PURPOSE. See the GNU General Public License for more details.
-      </p>
-      <p>
-        You should have received a copy of the GNU General
-        Public License along with this program. If not, see
-        &lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.
-      </p>
-  </standardLicenseHeader>
     <text>
       <titleText>
          <p>GNU GENERAL PUBLIC LICENSE 
@@ -576,9 +556,9 @@
          <p>To do so, attach the following notices to the program. It is safest to attach them to the start of each
          source file to most effectively state the exclusion of warranty; and each file should have at least
          the “copyright” line and a pointer to where the full notice is found.</p>
-         <p>&lt;one line to give the program's name and a brief idea of what it does.&gt; 
-        <br/>Copyright (C) &lt;year&gt; &lt;name of author&gt; 
-      </p>
+         <standardLicenseHeader>
+         <p><alt name="description" match=".+">&lt;one line to give the program's name and a brief idea of what it does.&gt;</alt><br/>
+         Copyright (C) <alt name="copyright" match=".+">&lt;year&gt; &lt;name of author&gt;</alt></p>
          <p>This program is free software: you can redistribute it and/or modify it under the terms of the GNU
          General Public License as published by the Free Software Foundation, either version 3 of the License,
          or (at your option) any later version.</p>
@@ -587,6 +567,7 @@
          Public License for more details.</p>
          <p>You should have received a copy of the GNU General Public License along with this program. If not, see
          &lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.</p>
+         </standardLicenseHeader>
          <p>Also add information on how to contact you by electronic and paper mail.</p>
          <p>If the program does terminal interaction, make it output a short notice like this when it starts in an
          interactive mode:</p>

--- a/src/GPL-3.0-or-later.xml
+++ b/src/GPL-3.0-or-later.xml
@@ -6,27 +6,6 @@
       <crossRef>http://www.gnu.org/licenses/gpl-3.0-standalone.html</crossRef>
       <crossRef>http://www.opensource.org/licenses/GPL-3.0</crossRef>
     </crossRefs>
-    <standardLicenseHeader>
-      Copyright (C) <alt name="copyright"
-      match=".+">&lt;year&gt; &lt;name of author&gt;</alt>
-      <p>
-        This program is free software: you can redistribute it and/or
-        modify it under the terms of the GNU General Public License
-        as published by the Free Software Foundation, either version
-        3 of the License, or (at your option) any later version.
-      </p>
-      <p>
-        This program is distributed in the hope that it will be
-        useful, but WITHOUT ANY WARRANTY; without even the implied
-        warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-        PURPOSE. See the GNU General Public License for more details.
-      </p>
-      <p>
-        You should have received a copy of the GNU General
-        Public License along with this program. If not, see
-        &lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.
-      </p>
-    </standardLicenseHeader>
     <notes>
       This license was released: 29 June 2007
     </notes>
@@ -792,10 +771,11 @@
         state the exclusion of warranty; and each file should have at least
         the “copyright” line and a pointer to where the full notice is found.
       </p>
+      <standardLicenseHeader>
       <p>
-        &lt;one line to give the program's name and
-        a brief idea of what it does.&gt;<br></br>
-        Copyright (C) &lt;year&gt; &lt;name of author&gt;
+        <alt name="description" match=".+">&lt;one line to give the program's name and
+        a brief idea of what it does.&gt;</alt><br/>
+        Copyright (C) <alt name="copyright" match=".+">&lt;year&gt; &lt;name of author&gt;</alt>
       </p>
       <p>
         This program is free software: you can redistribute it and/or
@@ -814,6 +794,7 @@
 	Public License along with this program. If not, see
 	&lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.
       </p>
+      </standardLicenseHeader>
       <p>
         Also add information on how to contact you by electronic and paper mail.
       </p>

--- a/src/Interbase-1.0.xml
+++ b/src/Interbase-1.0.xml
@@ -5,18 +5,6 @@
       <crossRefs>
          <crossRef>https://web.archive.org/web/20060319014854/http://info.borland.com/devsupport/interbase/opensource/IPL.html</crossRef>
       </crossRefs>
-      <standardLicenseHeader> 
-         <p>&gt;The contents of this file are subject to the Interbase Public License Version 1.0 (the "License"); 
-      you may not use this file except in compliance with the License. You may obtain a copy of the License 
-      at http://www.Interbase.com/IPL.html </p>
-         <p>Software distributed under the License is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, 
-      either express or implied. See the License for the specific language governing rights and limitations 
-      under the License.</p>
-         <p>The Original Code was created by InterBase Software Corp and its successors.</p>
-         <p>Portions created by Borland/Inprise are Copyright (C) Borland/Inprise. All Rights Reserved.</p>
-         <p>Contributor(s): <alt match=".+" name="contributor">______________________________________.</alt> 
-         </p>
-      </standardLicenseHeader>
     <text>
       <titleText>
          <p>INTERBASE PUBLIC LICENSE 
@@ -531,7 +519,8 @@
              of the Covered Code under Your choice of the NPL or the alternative licenses, if any,
              specified by the Initial Developer in the file described in Exhibit A.</p>
             <p>EXHIBIT A - InterBase Public License.</p>
-            <p>``The contents of this file are subject to the Interbase Public License Version 1.0 (the
+            <standardLicenseHeader>
+            <p><optional>"</optional>The contents of this file are subject to the Interbase Public License Version 1.0 (the
              "License"); you may not use this file except in compliance with the License. You may
              obtain a copy of the License at http://www.Interbase.com/IPL.html</p>
             <p>Software distributed under the License is distributed on an "AS IS" basis, WITHOUT
@@ -539,7 +528,8 @@
              governing rights and limitations under the License.</p>
             <p>The Original Code was created by InterBase Software Corp and its successors.</p>
             <p>Portions created by Borland/Inprise are Copyright (C) Borland/Inprise. All Rights Reserved.</p>
-            <p>Contributor(s): ______________________________________.</p>
+            <p>Contributor(s): <alt name="contributor" match=".+">______________________________________</alt>.</p>
+            </standardLicenseHeader>
         </item>
       </list>
           <p>AMENDMENTS</p>

--- a/src/LGPL-2.0+.xml
+++ b/src/LGPL-2.0+.xml
@@ -6,15 +6,6 @@
       <crossRefs>
          <crossRef>http://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html</crossRef>
       </crossRefs>
-      <standardLicenseHeader> Copyright (C) 
-    <alt match=".+" name="copyright">year name of author</alt> This library is free software; you can redistribute
-    it and/or modify it under the terms of the GNU Library General Public License as published by the Free Software
-    Foundation; version 2. This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-    without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Library
-    General Public License for more details. You should have received a copy of the GNU Library General Public
-    License along with this library; if not, write to the Free Software Foundation, Inc., 51 Franklin St, Fifth
-    Floor, Boston, MA 02110-1301, USA. 
-  </standardLicenseHeader>
     <text>
       <titleText>
          <p>GNU LIBRARY GENERAL PUBLIC LICENSE</p>
@@ -404,9 +395,9 @@
          <p>To apply these terms, attach the following notices to the library. It is safest to attach them to the
          start of each source file to most effectively convey the exclusion of warranty; and each file should
          have at least the "copyright" line and a pointer to where the full notice is found.</p>
-         <p>one line to give the library's name and an idea of what it does. 
-        <br/>Copyright (C) year name of author 
-      </p>
+         <standardLicenseHeader>
+         <p><alt name="description" match=".+">one line to give the library's name and an idea of what it does.</alt><br/>
+         Copyright (C) <alt name="copyright" match=".+">year name of author</alt></p>
          <p>This library is free software; you can redistribute it and/or modify it under the terms of the GNU
          Library General Public License as published by the Free Software Foundation; either version 2 of the
          License, or (at your option) any later version.</p>
@@ -416,6 +407,7 @@
          <p>You should have received a copy of the GNU Library General Public License along with this library; if
          not, write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301,
          USA.</p>
+         </standardLicenseHeader>
          <p>Also add information on how to contact you by electronic and paper mail.</p>
          <p>You should also get your employer (if you work as a programmer) or your school, if any, to sign a
          "copyright disclaimer" for the library, if necessary. Here is a sample; alter the names:</p>

--- a/src/LGPL-2.0-or-later.xml
+++ b/src/LGPL-2.0-or-later.xml
@@ -5,21 +5,6 @@
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html</crossRef>
     </crossRefs>
-    <standardLicenseHeader>
-      Copyright (C) <alt name="copyright" match=".+">year name of author</alt>
-      <p>This library is free software; you can redistribute it and/or modify it
-      under the terms of the GNU Library General Public License as published
-        by the Free Software Foundation; version 2 or any later version.</p> 
-      <p>This
-      library is distributed in the hope that it will be useful, but WITHOUT ANY
-      WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
-      FOR A PARTICULAR PURPOSE. See the GNU Library General Public License for
-        more details.</p>  
-      <p>You should have received a copy of the GNU Library General
-      Public License along with this library; if not, write to the Free Software
-      Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
-      </p>
-    </standardLicenseHeader>
     <notes>
       This license was released: June 1991. This license has
       been superseded by LGPL v2.1
@@ -590,10 +575,11 @@
         warranty; and each file should have at least the "copyright"
         line and a pointer to where the full notice is found.
       </p>
+      <standardLicenseHeader>
       <p>
-        one line to give the library's name
-        and an idea of what it does.<br></br>
-        Copyright (C) year name of author
+        <alt name="description" match=".+">one line to give the library's name
+        and an idea of what it does.</alt><br/>
+        Copyright (C) <alt name="copyright" match=".+">year name of author</alt>
       </p>
       <p>
         This library is free software; you can redistribute it and/or
@@ -613,6 +599,7 @@
         not, write to the Free Software Foundation, Inc., 51
         Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
       </p>
+      </standardLicenseHeader>
       <p>
         Also add information on how to contact you by electronic and paper mail.
       </p>

--- a/src/LGPL-2.1+.xml
+++ b/src/LGPL-2.1+.xml
@@ -7,18 +7,6 @@
          <crossRef>http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</crossRef>
          <crossRef>http://www.opensource.org/licenses/LGPL-2.1</crossRef>
       </crossRefs>
-      <standardLicenseHeader> Copyright (C)
-    <alt match=".+" name="copyright">year name of author</alt>
-         <p>This library is free software; you can redistribute
-    it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software
-    Foundation; version 2.1.</p>
-         <p>This library is distributed in the hope that it will be useful, but WITHOUT ANY
-    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-    Lesser General Public License for more details.</p>
-         <p>You should have received a copy of the GNU Lesser General Public
-    License along with this library; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth
-    Floor, Boston, MA 02110-1301 USA </p>
-      </standardLicenseHeader>
     <text>
       <titleText>
          <p>GNU LESSER GENERAL PUBLIC LICENSE</p>
@@ -421,9 +409,9 @@
          <p>To apply these terms, attach the following notices to the library. It is safest to attach them to the
          start of each source file to most effectively convey the exclusion of warranty; and each file should
          have at least the "copyright" line and a pointer to where the full notice is found.</p>
-         <p><optional>&lt;</optional>one line to give the library's name and an idea of what it does.<optional>&gt;</optional>
-        <br/>Copyright (C) <optional>&lt;</optional>year<optional>&gt;</optional> <optional>&lt;</optional>name of author<optional>&gt;</optional>
-      </p>
+         <standardLicenseHeader>
+         <p><alt name="description" match=".+">&lt;one line to give the library's name and an idea of what it does.&gt;</alt><br/>
+         Copyright (C) <alt name="copyright" match=".+">&lt;year&gt; &lt;name of author&gt;</alt></p>
          <p>This library is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser
          General Public License as published by the Free Software Foundation; either version 2.1 of the
          License, or (at your option) any later version.</p>
@@ -432,7 +420,9 @@
          General Public License for more details.</p>
          <p>You should have received a copy of the GNU Lesser General Public License along with this library; if not,
          write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301
-         USA Also add information on how to contact you by electronic and paper mail.</p>
+         USA</p>
+         </standardLicenseHeader>
+         <p>Also add information on how to contact you by electronic and paper mail.</p>
          <p>You should also get your employer (if you work as a programmer) or your school, if any, to sign a
          "copyright disclaimer" for the library, if necessary. Here is a sample; alter the names:</p>
          <p>Yoyodyne, Inc., hereby disclaims all copyright interest in

--- a/src/LGPL-2.1-or-later.xml
+++ b/src/LGPL-2.1-or-later.xml
@@ -6,26 +6,6 @@
       <crossRef>http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</crossRef>
       <crossRef>http://www.opensource.org/licenses/LGPL-2.1</crossRef>
     </crossRefs>
-    <standardLicenseHeader>
-      Copyright (C) <alt name="copyright" match=".+">year name of author</alt>
-      <p>
-        This library is free software; you can redistribute it and/or
-        modify it under the terms of the GNU Lesser General Public
-        License as published by the Free Software Foundation; version 2.1
-	or any later version.
-      </p>
-      <p>
-        This library is distributed in the hope that it will be useful,
-        but WITHOUT ANY WARRANTY; without even the implied warranty
-        of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-        See the GNU Lesser General Public License for more details.
-      </p>
-      <p>
-        You should have received a copy of the GNU Lesser General Public License
-        along with this library; if not, write to the Free Software Foundation,
-        Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
-      </p>
-    </standardLicenseHeader>
     <notes>
       This license was released: February 1999.
     </notes>
@@ -613,14 +593,9 @@
         warranty; and each file should have at least the "copyright"
         line and a pointer to where the full notice is found.
       </p>
-      <p>
-	<optional>&lt;</optional>one line to give the library's name
-	and an idea of what it does.<optional>&gt;</optional>
-        <br></br>
-        Copyright (C)
-        <optional>&lt;</optional>year<optional>&gt;</optional>
-        <optional>&lt;</optional>name of author<optional>&gt;</optional>
-      </p>
+      <standardLicenseHeader>
+      <p><alt name="description" match=".+">&lt;one line to give the library's name and an idea of what it does.&gt;</alt><br/>
+      Copyright (C) <alt name="copyright" match=".+">&lt;year&gt; &lt;name of author&gt;</alt></p>
       <p>
         This library is free software; you can redistribute it and/or
         modify it under the terms of the GNU Lesser General Public
@@ -636,8 +611,11 @@
       <p>
         You should have received a copy of the GNU Lesser General Public License
         along with this library; if not, write to the Free Software Foundation,
-        Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA Also
-        add information on how to contact you by electronic and paper mail.
+        Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+      </p>
+      </standardLicenseHeader>
+      <p>
+        Also add information on how to contact you by electronic and paper mail.
       </p>
       <p>
         You should also get your employer (if you work as a programmer)

--- a/src/LPPL-1.0.xml
+++ b/src/LPPL-1.0.xml
@@ -5,11 +5,6 @@
       <crossRefs>
          <crossRef>http://www.latex-project.org/lppl/lppl-1-0.txt</crossRef>
       </crossRefs>
-      <standardLicenseHeader> Copyright 
-    <alt match=".+" name="copyright">2001 M. Y. Name</alt> This program can redistributed and/or modified under the
-    terms of the LaTeX Project Public License Distributed from CTAN archives in directory
-    macros/latex/base/lppl.txt; either version 1 of the License, or (at your option) any later version. 
-  </standardLicenseHeader>
       <notes>This license was released 1 Mar 1999</notes>
     <text>
       <titleText>
@@ -31,12 +26,15 @@
       <p>To use this license, the files of your distribution should have an explicit copyright notice giving your
          name and the year, together with a reference to this license.</p>
       <p>A typical example would be</p>
-      <p>%% pig.sty %% Copyright 2001 M. Y. Name</p>
-      <p>% This program can redistributed and/or modified under the terms 
-        <br/>% of the LaTeX Project Public License Distributed from CTAN 
-        <br/>% archives in directory macros/latex/base/lppl.txt; either 
-        <br/>% version 1 of the License, or (at your option) any later version. 
+      <standardLicenseHeader>
+      <p><optional>%%</optional> <alt name="filename" match=".+">pig.sty</alt>
+      <br/><optional>%%</optional> Copyright <alt name="copyright" match=".+">2001 M. Y. Name</alt></p>
+      <p>% This program can redistributed and/or modified under the terms
+        <br/><optional>%</optional> of the LaTeX Project Public License Distributed from CTAN
+        <br/><optional>%</optional> archives in directory macros/latex/base/lppl.txt; either
+        <br/><optional>%</optional> version 1 of the License, or (at your option) any later version.
       </p>
+      </standardLicenseHeader>
       <p>Given such a notice in the file, the conditions of this document would apply, with:</p>
       <p>`The Program' referring to the software `pig.sty' and `The Copyright Holder' referring to the person `M.
          Y. Name'.</p>

--- a/src/LPPL-1.1.xml
+++ b/src/LPPL-1.1.xml
@@ -5,13 +5,6 @@
       <crossRefs>
          <crossRef>http://www.latex-project.org/lppl/lppl-1-1.txt</crossRef>
       </crossRefs>
-      <standardLicenseHeader> Copyright 
-    <alt match=".+" name="copyright">2001 M. Y. Name</alt> This program may be distributed and/or modified under the
-    conditions of the LaTeX Project Public License, either version 1.1 of this license or (at your option) any later
-    version. The latest version of this license is in http://www.latex-project.org/lppl.txt and version 1.1 or later
-    is part of all distributions of LaTeX version 1999/06/01 or later. This program consists of 
-    <alt match=".+" name="the work">the files pig.dtx and pig.ins</alt>
-      </standardLicenseHeader>
       <notes>This license was released 10 July 1999.</notes>
     <text>
       <titleText>
@@ -240,17 +233,21 @@
          including your name and the year and also a statement that the distribution and/or modification of the
          file is constrained by the conditions in this license.</p>
       <p>Here is an example of such a notice and statement:</p>
-      <p>%% pig.dtx 
-        <br/>%% Copyright 2001 M. Y. Name 
-        <br/>% 
-        <br/>% This program may be distributed and/or modified under the 
-        <br/>% conditions of the LaTeX Project Public License, either version 1.1 
-        <br/>% of this license or (at your option) any later version. 
-        <br/>% The latest version of this license is in % http://www.latex-project.org/lppl.txt 
-        <br/>% and version 1.1 or later is part of all distributions of LaTeX % version 1999/06/01 or later. 
-        <br/>% 
-        <br/>% This program consists of the files pig.dtx and pig.ins 
+      <standardLicenseHeader>
+      <p><optional>%%</optional> <alt name="filename" match=".+">pig.dtx</alt>
+        <br/><optional>%%</optional> Copyright <alt name="copyright" match=".+">2001 M. Y. Name</alt>
+        <br/><optional>%</optional>
+        <br/><optional>%</optional> This program may be distributed and/or modified under the
+        <br/><optional>%</optional> conditions of the LaTeX Project Public License, either version 1.1
+        <br/><optional>%</optional> of this license or (at your option) any later version.
+        <br/><optional>%</optional> The latest version of this license is in
+        <br/><optional>%</optional> http://www.latex-project.org/lppl.txt
+        <br/><optional>%</optional> and version 1.1 or later is part of all distributions of LaTeX
+        <br/><optional>%</optional> version 1999/06/01 or later.
+        <br/><optional>%</optional>
+        <br/><optional>%</optional> This program consists of the <alt name="filenames" match=".+">files pig.dtx and pig.ins</alt>
       </p>
+      </standardLicenseHeader>
       <p>Given such a notice and statement in a file, the conditions given in this license document would apply,
          with `The Program' referring to the two files `pig.dtx' and `pig.ins', and `The
          Copyright Holder' referring to the person `M. Y. Name'.</p>

--- a/src/LPPL-1.2.xml
+++ b/src/LPPL-1.2.xml
@@ -5,13 +5,6 @@
       <crossRefs>
          <crossRef>http://www.latex-project.org/lppl/lppl-1-2.txt</crossRef>
       </crossRefs>
-      <standardLicenseHeader> Copyright 
-    <alt match=".+" name="copyright">2001 M. Y. Name</alt> This program may be distributed and/or modified under the
-    conditions of the LaTeX Project Public License, either version 1.2 of this license or (at your option) any later
-    version. The latest version of this license is in http://www.latex-project.org/lppl.txt and version 1.2 or later
-    is part of all distributions of LaTeX version 1999/12/01 or later. This program consists of 
-    <alt match=".+" name="the work">the files pig.dtx and pig.ins</alt>
-      </standardLicenseHeader>
       <notes>This license was released 3 Sept 1999.</notes>
     <text>
       <titleText>
@@ -237,19 +230,21 @@
          including your name and the year and also a statement that the distribution and/or modification of the
          file is constrained by the conditions in this license.</p>
       <p>Here is an example of such a notice and statement:</p>
-      <p>%% pig.dtx 
-        <br/>%% Copyright 2001 M. Y. Name 
-        <br/>% 
-        <br/>% This program may be distributed and/or modified under the 
-        <br/>% conditions of the LaTeX Project Public License, either version 1.2 
-        <br/>% of this license or (at your option) any later version. 
-        <br/>% The latest version of this license is in 
-        <br/>% http://www.latex-project.org/lppl.txt 
-        <br/>% and version 1.2 or later is part of all distributions of LaTeX 
-        <br/>% version 1999/12/01 or later. 
-        <br/>% 
-        <br/>% This program consists of the files pig.dtx and pig.ins 
+      <standardLicenseHeader>
+      <p><optional>%%</optional> <alt name="filename" match=".+">pig.dtx</alt>
+        <br/><optional>%%</optional> Copyright <alt name="copyright" match=".+">2001 M. Y. Name</alt>
+        <br/><optional>%</optional>
+        <br/><optional>%</optional> This program may be distributed and/or modified under the
+        <br/><optional>%</optional> conditions of the LaTeX Project Public License, either version 1.2
+        <br/><optional>%</optional> of this license or (at your option) any later version.
+        <br/><optional>%</optional> The latest version of this license is in
+        <br/><optional>%</optional> http://www.latex-project.org/lppl.txt
+        <br/><optional>%</optional> and version 1.2 or later is part of all distributions of LaTeX
+        <br/><optional>%</optional> version 1999/12/01 or later.
+        <br/><optional>%</optional>
+        <br/><optional>%</optional> This program consists of the <alt name="filenames" match=".+">files pig.dtx and pig.ins</alt>
       </p>
+      </standardLicenseHeader>
       <p>Given such a notice and statement in a file, the conditions given in this license document would apply,
          with `The Program' referring to the two files `pig.dtx' and `pig.ins', and `The
          Copyright Holder' referring to the person `M. Y. Name'.</p>

--- a/src/MPL-1.0.xml
+++ b/src/MPL-1.0.xml
@@ -5,17 +5,6 @@
          <crossRef>http://www.mozilla.org/MPL/MPL-1.0.html</crossRef>
          <crossRef>http://opensource.org/licenses/MPL-1.0</crossRef>
       </crossRefs>
-      <standardLicenseHeader>The contents of this file are subject to the Mozilla Public License Version 1.0 (the "License");
-          you may not use this file except in compliance with the License. You may obtain a copy of the
-          License at http://www.mozilla.org/MPL/ Software distributed under the License is distributed on an
-          "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
-          for the specific language governing rights and limitations under the License. The Original Code is 
-    <alt match=".+" name="code">_____</alt>. The Initial Developer of the Original Code is 
-    <alt match=".+" name="InitialDeveloper">_____</alt>. Portions created by 
-    <alt match=".+" name="createdby">_____</alt> are Copyright (C) 
-    <alt match=".+" name="copyright">_____</alt>. All Rights Reserved. Contributor(s): 
-    <alt match=".+" name="contributor">_____</alt>. 
-  </standardLicenseHeader>
       <notes>This license has been superseded by v1.1</notes>
     <text>
       <titleText>
@@ -439,7 +428,8 @@
       </list>
       <optional>
          <p>EXHIBIT A.</p>
-         <p>"The contents of this file are subject to the Mozilla Public License Version 1.0 (the
+         <standardLicenseHeader>
+         <p><optional>"</optional>The contents of this file are subject to the Mozilla Public License Version 1.0 (the
          "License"); you may not use this file except in compliance with the License. You may obtain
          a copy of the License at http://www.mozilla.org/MPL/</p>
          <p>Software distributed under the License is distributed on an "AS IS" basis, WITHOUT WARRANTY OF
@@ -450,8 +440,9 @@
         <alt match=".+" name="InitialDeveloper">_____</alt>. Portions created by 
         <alt match=".+" name="createdby">_____</alt> are Copyright (C) 
         <alt match=".+" name="copyright">_____</alt>. All Rights Reserved. Contributor(s): 
-        <alt match=".+" name="contributor">_____</alt>."
+        <alt match=".+" name="contributor">_____</alt>.<optional>"</optional>
       </p>
+        </standardLicenseHeader>
       </optional>
     </text>
   </license>

--- a/src/MPL-1.1.xml
+++ b/src/MPL-1.1.xml
@@ -5,28 +5,6 @@
          <crossRef>http://www.mozilla.org/MPL/MPL-1.1.html</crossRef>
          <crossRef>http://www.opensource.org/licenses/MPL-1.1</crossRef>
       </crossRefs>
-      <standardLicenseHeader> The contents of this file are subject to the Mozilla Public License Version 1.1 (the "License");
-          you may not use this file except in compliance with the License. You may obtain a copy of the
-          License at http://www.mozilla.org/MPL/ Software distributed under the License is distributed on an
-          "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
-          for the specific language governing rights and limitations under the License. The Original Code is 
-    <alt match=".+" name="code">_____</alt>. The Initial Developer of the Original Code is 
-    <alt match=".+" name="InitialDeveloper">_____</alt>. Portions created by 
-    <alt match=".+" name="createdby">_____</alt> are Copyright (C) 
-    <alt match=".+" name="copyright">_____</alt>. All Rights Reserved. Contributor(s): 
-    <alt match=".+" name="contributor">_____</alt>. Alternatively, the contents of this file may be used under the
-    terms of the 
-    <alt match=".+" name="AltLicense">_____</alt> license (the " 
-    <alt match=".+" name="licenseName">[____]</alt> License"), in which case the provisions of 
-    <alt match=".+" name="licenseName">[____]</alt> License are applicable instead of those above. If you wish to
-    allow use of your version of this file only under the terms of the 
-    <alt match=".+" name="licenseName">[____]</alt> License and not to allow others to use your version of this file
-    under the MPL, indicate your decision by deleting the provisions above and replace them with the notice and
-    other provisions required by the 
-    <alt match=".+" name="licenseName">[____]</alt> License. If you do not delete the provisions above, a recipient
-    may use your version of this file under either the MPL or the 
-    <alt match=".+" name="licenseName">[____]</alt>] License." 
-  </standardLicenseHeader>
       <notes>This license has been superseded by v2.0</notes>
     <text>
       <titleText>
@@ -537,25 +515,26 @@
     
       <optional>
          <p>Exhibit A - Mozilla Public License.</p>
-         <p>"The contents of this file are subject to the Mozilla Public License Version 1.1 (the
+         <standardLicenseHeader>
+         <p><optional>"</optional>The contents of this file are subject to the Mozilla Public License Version 1.1 (the
          "License"); you may not use this file except in compliance with the License. You may obtain
          a copy of the License at http://www.mozilla.org/MPL/</p>
          <p>Software distributed under the License is distributed on an "AS IS" basis, WITHOUT WARRANTY OF
          ANY KIND, either express or implied. See the License for the specific language governing rights and
          limitations under the License.</p>
-         <p>The Original Code is ______________________________________.</p>
-         <p>The Initial Developer of the Original Code is ________________________. 
-        <br/>Portions created by ______________________ are Copyright (C) ______ 
-        <br/>_______________________. All Rights Reserved. 
+         <p>The Original Code is <alt name="code" match=".+">______________________________________</alt>.</p>
+         <p>The Initial Developer of the Original Code is <alt name="initialDeveloper" match=".+">________________________</alt>.
+        <br/>Portions created by <alt name="creator" match=".+">______________________</alt> are Copyright (C) <alt name="copyright" match=".+">______</alt>. All Rights Reserved.
       </p>
-         <p>Contributor(s): ______________________________________.</p>
-         <p>Alternatively, the contents of this file may be used under the terms of the _____ license (the
-         "[___] License"), in which case the provisions of [______] License are applicable instead of
-         those above. If you wish to allow use of your version of this file only under the terms of the [____]
+         <p>Contributor(s): <alt name="contributor" match=".+">______________________________________</alt>.</p>
+         <p>Alternatively, the contents of this file may be used under the terms of the <alt name="altLicense" match=".+">_____</alt> license (the
+         "<alt name="altLicenseShort1" match=".+">[___]</alt> License"), in which case the provisions of <alt name="altLicenseShort2" match=".+">[______]</alt> License are applicable instead of
+         those above. If you wish to allow use of your version of this file only under the terms of the <alt name="altLicenseShort3" match=".+">[____]</alt>
          License and not to allow others to use your version of this file under the MPL, indicate your decision
          by deleting the provisions above and replace them with the notice and other provisions required by the
-         [___] License. If you do not delete the provisions above, a recipient may use your version of this
-         file under either the MPL or the [___] License."</p>
+         <alt name="altLicenseShort4" match=".+">[___]</alt> License. If you do not delete the provisions above, a recipient may use your version of this
+         file under either the MPL or the <alt name="altLicenseShort5" match=".+">[___]</alt> License.<optional>"</optional></p>
+         </standardLicenseHeader>
          <p>NOTE: The text of this Exhibit A may differ slightly from the text of the notices in the Source Code
          files of the Original Code. You should use the text of this Exhibit A rather than the text found in
          the Original Code Source Code for Your Modifications.</p>

--- a/src/OCLC-2.0.xml
+++ b/src/OCLC-2.0.xml
@@ -6,22 +6,6 @@
          <crossRef>http://www.oclc.org/research/activities/software/license/v2final.htm</crossRef>
          <crossRef>http://www.opensource.org/licenses/OCLC-2.0</crossRef>
       </crossRefs>
-      <standardLicenseHeader> Copyright (c) 2000- 
-    <alt match=".+" name="year">(insert then current year)</alt>. OCLC Online Computer Library Center, Inc. and
-    other contributors. All rights reserved. The contents of this file, as updated from time to time by the OCLC
-    Office of Research, are subject to OCLC Research Public License Version 2.0 (the "License"); you may not use
-    this file except in compliance with the License. You may obtain a current copy of the License at
-    http://purl.oclc.org/oclc/research/ORPL/. Software distributed under the License is distributed on an "AS IS"
-    basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the specific language
-    governing rights and limitations under the License. This software consists of voluntary contributions made by
-    many individuals on behalf of OCLC Research. For more information on OCLC Research, please see
-    http://www.oclc.org/research/. The Original Code is 
-    <alt match=".+" name="code">_____</alt>.. The Initial Developer of the Original Code is 
-    <alt match=".+" name="InitialDeveloper">_____</alt>. Portions created by 
-    <alt match=".+" name="createdby">_____</alt> are Copyright (C) 
-    <alt match=".+" name="copyright">_____</alt>. All Rights Reserved. Contributor(s): 
-    <alt match=".+" name="contributor">_____</alt>. 
-  </standardLicenseHeader>
       <notes>This license was released: May 2002</notes>
     <text>
       <titleText>
@@ -91,9 +75,9 @@
                source code), the terms of this license apply to use by recipient. In addition, each
                source and data file of the Program and any Modification you distribute must contain the
                following notice: 
-        
-        <p>"Copyright (c) 2000- (insert then current year) OCLC Online Computer Library Center, Inc. and other
-           contributors. All rights reserved. The contents of this file, as updated from time to time by the
+        <standardLicenseHeader>
+        <p><optional>"</optional>Copyright (c) <alt name="copyright" match=".+">2000- (insert then current year) OCLC Online Computer Library Center, Inc. and other
+           contributors</alt>. All rights reserved. The contents of this file, as updated from time to time by the
            OCLC Office of Research, are subject to OCLC Research Public License Version 2.0 (the "License");
            you may not use this file except in compliance with the License. You may obtain a current copy of
            the License at http://purl.oclc.org/oclc/research/ORPL/. Software distributed under the License is
@@ -101,10 +85,10 @@
            License for the specific language governing rights and limitations under the License. This
            software consists of voluntary contributions made by many individuals on behalf of OCLC Research.
            For more information on OCLC Research, please see http://www.oclc.org/research/. The Original Code
-           is ______________________________. The Initial Developer of the Original Code is
-           ________________________. Portions created by ______________________ are Copyright (C) _____
-           _______________________. All Rights Reserved. Contributor(s):
-           ______________________________________."</p>
+           is <alt name="code" match=".+">______________________________</alt>. The Initial Developer of the Original Code is
+           <alt name="initialDeveloper" match=".+">________________________</alt>. Portions created by <alt name="creator" match=".+">______________________</alt> are Copyright (C) <alt name="copyright2" match=".+">____________________________</alt>. All Rights Reserved. Contributor(s):
+           <alt name="contributor" match=".+">______________________________________</alt>.<optional>"</optional></p>
+        </standardLicenseHeader>
          </item>
          <item>
             <bullet>C.</bullet>

--- a/src/OSL-1.0.xml
+++ b/src/OSL-1.0.xml
@@ -4,7 +4,6 @@
       <crossRefs>
          <crossRef>http://opensource.org/licenses/OSL-1.0</crossRef>
       </crossRefs>
-      <standardLicenseHeader>Licensed under the Open Software License version 1.0</standardLicenseHeader>
       <notes>This license has been superseded.</notes>
     <text>
       <titleText>
@@ -14,7 +13,9 @@
       <p>This Open Software License (the "License") applies to any original work of authorship (the
          "Original Work") whose owner (the "Licensor") has placed the following notice
          immediately following the copyright notice for the Original Work:</p>
-      <p>"Licensed under the Open Software License version 1.0"</p>
+      <standardLicenseHeader>
+      <p><optional>"</optional>Licensed under the Open Software License version 1.0<optional>"</optional></p>
+      </standardLicenseHeader>
       <p>License Terms</p>
       <list>
         <item>

--- a/src/OSL-1.1.xml
+++ b/src/OSL-1.1.xml
@@ -4,7 +4,6 @@
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/OSL1.1</crossRef>
       </crossRefs>
-      <standardLicenseHeader>Licensed under the Open Software License version 1.1</standardLicenseHeader>
     <text>
       <titleText>
          <p>The Open Software License v. 1.1</p>
@@ -13,7 +12,9 @@
       <p>This Open Software License (the "License") applies to any original work of authorship (the
          "Original Work") whose owner (the "Licensor") has placed the following notice
          immediately following the copyright notice for the Original Work:</p>
+      <standardLicenseHeader>
       <p>Licensed under the Open Software License version 1.1</p>
+      </standardLicenseHeader>
       <list>
         <item>
             <bullet>1)</bullet>

--- a/src/OSL-2.0.xml
+++ b/src/OSL-2.0.xml
@@ -4,7 +4,6 @@
       <crossRefs>
          <crossRef>http://web.archive.org/web/20041020171434/http://www.rosenlaw.com/osl2.0.html</crossRef>
       </crossRefs>
-      <standardLicenseHeader>Licensed under the Open Software License version 2.0</standardLicenseHeader>
     <text>
       <titleText>
          <p>Open Software Licensev. 2.0</p>
@@ -13,7 +12,9 @@
       <p>This Open Software License (the "License") applies to any original work of authorship (the
          "Original Work") whose owner (the "Licensor") has placed the following notice
          immediately following the copyright notice for the Original Work:</p>
+      <standardLicenseHeader>
       <p>Licensed under the Open Software License version 2.0</p>
+      </standardLicenseHeader>
       <list>
         <item>
             <bullet>1)</bullet>

--- a/src/OSL-2.1.xml
+++ b/src/OSL-2.1.xml
@@ -5,7 +5,6 @@
          <crossRef>http://opensource.org/licenses/OSL-2.1</crossRef>
          <crossRef>http://web.archive.org/web/20050212003940/http://www.rosenlaw.com/osl21.htm</crossRef>
       </crossRefs>
-      <standardLicenseHeader>Licensed under the Open Software License version 2.1</standardLicenseHeader>
       <notes>Same as version 2.0 of this license except with changes to section 10</notes>
     <text>
       <titleText>
@@ -15,7 +14,9 @@
       <p>This Open Software License (the "License") applies to any original work of authorship (the
          "Original Work") whose owner (the "Licensor") has placed the following notice
          immediately following the copyright notice for the Original Work:</p>
+      <standardLicenseHeader>
       <p>Licensed under the Open Software License version 2.1</p>
+      </standardLicenseHeader>
       <list>
         <item>
             <bullet>1)</bullet>

--- a/src/OSL-3.0.xml
+++ b/src/OSL-3.0.xml
@@ -5,9 +5,6 @@
          <crossRef>http://www.rosenlaw.com/OSL3.0.htm</crossRef>
          <crossRef>http://www.opensource.org/licenses/OSL-3.0</crossRef>
       </crossRefs>
-      <standardLicenseHeader>
-    Licensed under the Open Software License version 3.0
-  </standardLicenseHeader>
     <text>
       <titleText>
          <p>Open Software License v. 3.0 (OSL-3.0)</p>
@@ -16,7 +13,9 @@
       <p>This Open Software License (the "License") applies to any original work of authorship (the
          "Original Work") whose owner (the "Licensor") has placed the following licensing
          notice adjacent to the copyright notice for the Original Work:</p>
+      <standardLicenseHeader>
       <p>Licensed under the Open Software License version 3.0</p>
+      </standardLicenseHeader>
       <list>
         <item>
             <bullet>1)</bullet>

--- a/src/RPSL-1.0.xml
+++ b/src/RPSL-1.0.xml
@@ -6,25 +6,6 @@
          <crossRef>https://helixcommunity.org/content/rpsl</crossRef>
          <crossRef>http://www.opensource.org/licenses/RPSL-1.0</crossRef>
       </crossRefs>
-      <standardLicenseHeader> Copyright © 1995-2002 RealNetworks, Inc. and/or its licensors. All Rights Reserved. The contents of this
-          file, and the files included with this file, are subject to the current version of the RealNetworks
-          Public Source License Version 1.0 (the "RPSL") available at
-          https://www.helixcommunity.org/content/rpsl unless you have licensed the file under the RealNetworks
-          Community Source License Version 1.0 (the "RCSL") available at
-          https://www.helixcommunity.org/content/rcsl, in which case the RCSL will apply. You may also obtain
-          the license terms directly from RealNetworks. You may not use this file except in compliance with
-          the RPSL or, if you have a valid RCSL with RealNetworks applicable to this file, the RCSL. Please
-          see the applicable RPSL or RCSL for the rights, obligations and limitations governing use of the
-          contents of the file. This file is part of the Helix DNA Technology. RealNetworks is the developer
-          of the Original code and owns the copyrights in the portions it created. This file, and the files
-          included with this file, is distributed and made available on an 'AS IS' basis, WITHOUT WARRANTY OF
-          ANY KIND, EITHER EXPRESS OR IMPLIED, AND REALNETWORKS HEREBY DISCLAIMS ALL SUCH WARRANTIES,
-          INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE,
-          QUIET ENJOYMENT OR NON-INFRINGEMENT. Contributor(s): 
-    <alt match=".+" name="contributor">_____</alt> Technology Compatibility Kit Test Suite(s) Location (if licensed
-    under the RCSL): 
-    <alt match=".+" name="testLocation">_____</alt>. 
-  </standardLicenseHeader>
     <text>
       <titleText>
          <p>RealNetworks Public Source License Version 1.0</p>
@@ -522,7 +503,8 @@
       
       <optional>
          <p>EXHIBIT A.</p>
-         <p>"Copyright (c) 1995-2002 RealNetworks, Inc. and/or its licensors. All Rights Reserved.</p>
+        <standardLicenseHeader>
+         <p><optional>"</optional>Copyright (c) 1995-2002 RealNetworks, Inc. and/or its licensors. All Rights Reserved.</p>
          <p>The contents of this file, and the files included with this file, are subject to the current version of
          the RealNetworks Public Source License Version 1.0 (the "RPSL") available at
          https://www.helixcommunity.org/content/rpsl unless you have licensed the file under the RealNetworks
@@ -538,9 +520,10 @@
          WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESS OR IMPLIED, AND REALNETWORKS HEREBY DISCLAIMS ALL SUCH
          WARRANTIES, INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
          PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.</p>
-         <p>Contributor(s): ____________________________________</p>
-         <p>Technology Compatibility Kit Test Suite(s) Location (if licensed under the RCSL):</p>
-         <p>________________________________"</p>
+         <p>Contributor(s): <alt name="contributor" match=".+">____________________________________</alt></p>
+         <p>Technology Compatibility Kit Test Suite(s) Location (if licensed under the RCSL):
+         <alt match=".+" name="testLocation">_____</alt><optional>"</optional></p>
+         </standardLicenseHeader>
          <p>Object Code Notice: Helix DNA Client technology included. Copyright (c) RealNetworks, Inc., 1995-2002.
          All rights reserved.</p>
          <p>EXHIBIT B</p>

--- a/src/SCEA.xml
+++ b/src/SCEA.xml
@@ -4,17 +4,6 @@
       <crossRefs>
          <crossRef>http://research.scea.com/scea_shared_source_license.html</crossRef>
       </crossRefs>
-      <standardLicenseHeader>
-         <p>Copyright 2005 Sony Computer Entertainment Inc.</p>
-         <p>Licensed under the SCEA Shared Source License, Version 1.0 (the "License"); you may not use this file
-         except in compliance with the License. You may obtain a copy of the License at: 
-        <br/>http://research.scea.com/scea_shared_source_license.html 
-      </p>
-         <p>Unless required by applicable law or agreed to in writing, software distributed under the License is
-         distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-         implied. See the License for the specific language governing permissions and limitations under the
-         License.</p>
-      </standardLicenseHeader>
     <text>
       <titleText>
          <p>SCEA Shared Source License 1.0</p>
@@ -147,7 +136,8 @@
           Copyright Notice for Redistribution of Source Code
         </item>
       </list>
-      <p>Copyright 2005 Sony Computer Entertainment Inc.</p>
+      <standardLicenseHeader>
+      <p>Copyright <alt name="copyright" match=".+">2005 Sony Computer Entertainment Inc.</alt></p>
       <p>Licensed under the SCEA Shared Source License, Version 1.0 (the "License"); you may not use this file
          except in compliance with the License. You may obtain a copy of the License at: 
         <br/>http://research.scea.com/scea_shared_source_license.html 
@@ -156,6 +146,7 @@
          distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
          implied. See the License for the specific language governing permissions and limitations under the
          License.</p>
+      </standardLicenseHeader>
     </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/SGI-B-1.0.xml
+++ b/src/SGI-B-1.0.xml
@@ -5,33 +5,6 @@
       <crossRefs>
          <crossRef>http://oss.sgi.com/projects/FreeB/SGIFreeSWLicB.1.0.html</crossRef>
       </crossRefs>
-      <standardLicenseHeader>
-         <p>License Applicability. Except to the extent portions of this file are made subject to an alternative
-         license as permitted in the SGI Free Software License B, Version 1.0 (the "License"), the contents of
-         this file are subject only to the provisions of the License. You may not use this file except in
-         compliance with the License. You may obtain a copy of the License at Silicon Graphics, Inc., attn:
-         Legal Services, 1600 Ampitheatre Parkway, Mountain View, CA 94043-1351, or at:</p>
-         <p>http://oss.sgi.com/projects/FreeB</p>
-         <p>Note that, as provided in the License, the Software is distributed on an "AS IS" basis, with ALL EXPRESS
-         AND IMPLIED WARRANTIES AND CONDITIONS DISCLAIMED, INCLUDING, WITHOUT LIMITATION, ANY IMPLIED
-         WARRANTIES AND CONDITIONS OF MERCHANTABILITY, SATISFACTORY QUALITY, FITNESS FOR A PARTICULAR PURPOSE,
-         AND NON-INFRINGEMENT.</p>
-         <p>Original Code. The Original Code is: <optional>[</optional>
-            <alt match=".+" name="softwareNameHeader">name of software</alt>,
-      <alt match=".+" name="softwareVersionHeader">version number</alt>, and 
-      <alt match=".+" name="softwareReleaseDateHeader">release date</alt>
-            <optional>]</optional>, developed by Silicon Graphics, Inc. The Original Code is Copyright (c) 
-      <optional>[</optional>
-            <alt match=".+" name="softwareFirstPublicationDateHeader">dates of first publication, as appearing in
-        the Notice in the Original Code</alt>
-            <optional>]</optional> Silicon Graphics, Inc. Copyright in any 
-        portions created by third parties is as indicated elsewhere herein. All Rights Reserved.</p>
-         <p>Additional Notice Provisions: <optional>[</optional>
-            <alt match=".+" name="additionalProvisionsHeader">such additional provisions, if any, as appear in 
-          the Notice in the Original Code under the heading "Additional Notice Provisions"</alt>
-            <optional>]</optional>
-         </p>
-      </standardLicenseHeader>
       <notes>This license was released 25 January 2000</notes>
     <text>
       <titleText>
@@ -300,6 +273,7 @@
       </list>
       <optional>
          <p>Exhibit A</p>
+        <standardLicenseHeader>
          <p>License Applicability. Except to the extent portions of this file are made subject to an alternative
          license as permitted in the SGI Free Software License B, Version 1.0 (the "License"), the contents of
          this file are subject only to the provisions of the License. You may not use this file except in
@@ -311,20 +285,21 @@
          WARRANTIES AND CONDITIONS OF MERCHANTABILITY, SATISFACTORY QUALITY, FITNESS FOR A PARTICULAR PURPOSE,
          AND NON-INFRINGEMENT.</p>
          <p>Original Code. The Original Code is: <optional>[</optional>
-            <alt match=".+" name="softwareNameExhibitA">name of software</alt>,
-      <alt match=".+" name="softwareVersionExhibitA">version number</alt>, and 
-      <alt match=".+" name="softwareReleaseDateExhibitA">release date</alt>
+            <alt match=".+" name="softwareName">name of software</alt>,
+      <alt match=".+" name="softwareVersion">version number</alt>, and
+      <alt match=".+" name="softwareReleaseDate">release date</alt>
             <optional>]</optional>, developed by Silicon Graphics, Inc. The Original Code is Copyright (c) 
       <optional>[</optional>
-            <alt match=".+" name="softwareFirstPublicationDateExhibitA">dates of first publication, as appearing in
+            <alt match=".+" name="softwareFirstPublicationDate">dates of first publication, as appearing in
         the Notice in the Original Code</alt>
             <optional>]</optional> Silicon Graphics, Inc. Copyright in any 
         portions created by third parties is as indicated elsewhere herein. All Rights Reserved.</p>
          <p>Additional Notice Provisions: <optional>[</optional>
-            <alt match=".+" name="additionalProvisionsExhibitA">such additional provisions, if any, as appear in 
+            <alt match=".+" name="additionalProvisions">such additional provisions, if any, as appear in
           the Notice in the Original Code under the heading "Additional Notice Provisions"</alt>
             <optional>]</optional>
          </p>
+        </standardLicenseHeader>
       </optional>
     </text>
   </license>

--- a/src/SGI-B-1.1.xml
+++ b/src/SGI-B-1.1.xml
@@ -5,28 +5,6 @@
       <crossRefs>
          <crossRef>http://oss.sgi.com/projects/FreeB/</crossRef>
       </crossRefs>
-      <standardLicenseHeader>
-         <p>License Applicability. Except to the extent portions of this file are made subject to an alternative
-         license as permitted in the SGI Free Software License B, Version 1.1 (the "License"), the contents of
-         this file are subject only to the provisions of the License. You may not use this file except in
-         compliance with the License. You may obtain a copy of the License at Silicon Graphics, Inc., attn:
-         Legal Services, 1600 Amphitheatre Parkway, Mountain View, CA 94043-1351, or at:</p>
-         <p>http://oss.sgi.com/projects/FreeB</p>
-         <p>Note that, as provided in the License, the Software is distributed on an "AS IS" basis, with ALL EXPRESS
-         AND IMPLIED WARRANTIES AND CONDITIONS DISCLAIMED, INCLUDING, WITHOUT LIMITATION, ANY IMPLIED
-         WARRANTIES AND CONDITIONS OF MERCHANTABILITY, SATISFACTORY QUALITY, FITNESS FOR A PARTICULAR PURPOSE,
-         AND NON-INFRINGEMENT.</p>
-         <p>Original Code. The Original Code is: <optional>[</optional>
-            <alt match=".+" name="softwareNameHeader">name of software</alt>,
-      <alt match=".+" name="softwareVersionHeader">version number</alt>, and 
-      <alt match=".+" name="softwareReleaseDateHeader">release date</alt>
-            <optional>]</optional>, developed by Silicon Graphics, Inc. The Original Code is Copyright (c) 
-      <optional>[</optional>
-            <alt match=".+" name="softwareFirstPublicationDateHeader">dates of first publication, as appearing in
-        the Notice in the Original Code</alt>
-            <optional>]</optional> Silicon Graphics, Inc. Copyright in any portions created by third
-         parties is as indicated elsewhere herein. All Rights Reserved.</p>
-      </standardLicenseHeader>
       <notes>This license was released 22 February 2002</notes>
     <text>
       <titleText>
@@ -308,6 +286,7 @@
       </list>
       <optional>
          <p>Exhibit A</p>
+         <standardLicenseHeader>
          <p>License Applicability. Except to the extent portions of this file are made subject to an alternative
          license as permitted in the SGI Free Software License B, Version 1.1 (the "License"), the contents of
          this file are subject only to the provisions of the License. You may not use this file except in
@@ -319,21 +298,24 @@
          WARRANTIES AND CONDITIONS OF MERCHANTABILITY, SATISFACTORY QUALITY, FITNESS FOR A PARTICULAR PURPOSE,
          AND NON-INFRINGEMENT.</p>
          <p>Original Code. The Original Code is: <optional>[</optional>
-            <alt match=".+" name="softwareNameExhibitA">name of software</alt>,
-      <alt match=".+" name="softwareVersionExhibitA">version number</alt>, and 
-      <alt match=".+" name="softwareReleaseDateExhibitA">release date</alt>
+            <alt match=".+" name="softwareName">name of software</alt>,
+      <alt match=".+" name="softwareVersion">version number</alt>, and
+      <alt match=".+" name="softwareReleaseDate">release date</alt>
             <optional>]</optional>, developed by Silicon Graphics, Inc. The Original Code is Copyright (c) 
       <optional>[</optional>
-            <alt match=".+" name="softwareFirstPublicationDateExhibitA">dates of first publication, as appearing in
+            <alt match=".+" name="softwareFirstPublicationDate">dates of first publication, as appearing in
         the Notice in the Original Code</alt>
             <optional>]</optional>
        Silicon Graphics, Inc. Copyright in any portions created by third
          parties is as indicated elsewhere herein. All Rights Reserved.</p>
+         <optional>
          <p>Additional Notice Provisions: <optional>[</optional>
-            <alt match=".+" name="additionalProvisionsExhibitA">such additional provisions, if any, as appear in the
+            <alt match=".+" name="additionalProvisions">such additional provisions, if any, as appear in the
           Notice in the Original Code under the heading "Additional Notice Provisions"</alt>
             <optional>]</optional>
          </p>
+         </optional>
+         </standardLicenseHeader>
       </optional>
     </text>
   </license>

--- a/src/SISSL-1.2.xml
+++ b/src/SISSL-1.2.xml
@@ -5,16 +5,6 @@
       <crossRefs>
          <crossRef>http://gridscheduler.sourceforge.net/Gridengine_SISSL_license.html</crossRef>
       </crossRefs>
-      <standardLicenseHeader> The contents of this file are subject to the Sun Industry Standards Source License Version 1.2 (the
-          License); You may not use this file except in compliance with the License. You may obtain a copy of
-          the License at gridengine.sunsource.net/license.html Software distributed under the License is
-          distributed on an AS IS basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
-          License for the specific language governing rights and limitations under the License. The Original
-          Code is Grid Engine. The Initial Developer of the Original Code is: Sun Microsystems, Inc. Portions
-          created by: Sun Microsystems, Inc. are Copyright (C) 2001 Sun Microsystems, Inc. All Rights
-          Reserved. "Contributor(s): 
-    <alt match=".+" name="contributor">_____</alt>
-      </standardLicenseHeader>
     <text>
       <titleText>
          <br/>SUN INDUSTRY STANDARDS SOURCE LICENSE
@@ -275,22 +265,24 @@
   
       <optional>
          <p>EXHIBIT A - Sun Industry Standards Source License</p>
-         <p>"The contents of this file are subject to the Sun Industry Standards Source License Version 1.2 (the
+      <standardLicenseHeader>
+         <p><optional>"</optional>The contents of this file are subject to the Sun Industry Standards Source License Version 1.2 (the
        License); You 
-      <br/>may not use this file except in compliance with the License." 
+      <br/>may not use this file except in compliance with the License.<optional>"</optional>
     </p>
-         <p>"You may obtain a copy of the License at gridengine.sunsource.net/license.html"</p>
-         <p>"Software distributed under the License is distributed on an AS IS basis, WITHOUT WARRANTY OF ANY KIND,
+         <p><optional>"</optional>You may obtain a copy of the License at gridengine.sunsource.net/license.html<optional>"</optional></p>
+         <p><optional>"</optional>Software distributed under the License is distributed on an AS IS basis, WITHOUT WARRANTY OF ANY KIND,
        either express or 
-      <br/>implied. See the License for the specific language governing rights and limitations under the License." 
+      <br/>implied. See the License for the specific language governing rights and limitations under the License.<optional>"</optional>
     </p>
-         <p>"The Original Code is Grid Engine."</p>
-         <p>"The Initial Developer of the Original Code is: 
-      <br/>Sun Microsystems, Inc." 
+         <p><optional>"</optional>The Original Code is Grid Engine.<optional>"</optional></p>
+         <p><optional>"</optional>The Initial Developer of the Original Code is:
+      <br/>Sun Microsystems, Inc.<optional>"</optional>
     </p>
-         <p>"Portions created by: Sun Microsystems, Inc. are Copyright (C) 2001 Sun Microsystems, Inc."</p>
-         <p>"All Rights Reserved."</p>
-         <p>"Contributor(s):__________________________________"</p>
+         <p><optional>"</optional>Portions created by: Sun Microsystems, Inc. are Copyright (C) 2001 Sun Microsystems, Inc.<optional>"</optional></p>
+         <p><optional>"</optional>All Rights Reserved.<optional>"</optional></p>
+         <p><optional>"</optional>Contributor(s): <alt name="contributor" match=".+">__________________________________"</alt></p>
+      </standardLicenseHeader>
          <p>EXHIBIT B - Standards</p>
          <list>
             <item>

--- a/src/SISSL.xml
+++ b/src/SISSL.xml
@@ -6,17 +6,6 @@
          <crossRef>http://www.openoffice.org/licenses/sissl_license.html</crossRef>
          <crossRef>http://opensource.org/licenses/SISSL</crossRef>
       </crossRefs>
-      <standardLicenseHeader> The contents of this file are subject to the Sun Standards License Version 1.1 (the "License"); You may not
-          use this file except in compliance with the License. You may obtain a copy of the License at 
-    <alt match=".+" name="LicLocation">_______</alt>. Software distributed under the License is distributed on an
-    "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the specific
-    language governing rights and limitations under the License. The Original Code is 
-    <alt match=".+" name="code">_____</alt>. The Initial Developer of the Original Code is: Sun Microsystems, Inc..
-    Portions created by: 
-    <alt match=".+" name="createdby">_____</alt> are Copyright (C): 
-    <alt match=".+" name="copyright">_____</alt> All Rights Reserved. Contributor(s): 
-    <alt match=".+" name="contributor">_____</alt>
-      </standardLicenseHeader>
     <text>
       <titleText>
          <p>Sun Industry Standards Source License - Version 1.1</p>
@@ -328,24 +317,23 @@
     
       <optional>
          <p>EXHIBIT A - Sun Standards License</p>
-         <p>"The contents of this file are subject to the Sun Standards License Version 1.1 (the "License"); You may
+         <standardLicenseHeader>
+         <p><optional>"</optional>The contents of this file are subject to the Sun Standards License Version 1.1 (the "License"); You may
          not use this file except in compliance with the License. You may obtain a copy of the License at
-         _______________________________.</p>
+         <alt name="source" match=".+">_______________________________</alt>.</p>
          <p>Software distributed under the License is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
          either 
         <br/>express or implied. See the License for the specific language governing rights and limitations
              under the License. 
       </p>
-         <p>The Original Code is ______________________________________.</p>
-         <p>The Initial Developer of the Original Code is: 
-        <br/>Sun Microsystems, Inc.. 
-      </p>
-         <p>Portions created by: _______________________________________</p>
-         <p>are Copyright (C): _______________________________________</p>
+         <p>The Original Code is <alt name="code" match=".+">______________________________________</alt>.</p>
+         <p>The Initial Developer of the Original Code is: <alt name="initialDeveloper" match=".+">Sun Microsystems, Inc.</alt>.</p>
+         <p>Portions created by: <alt name="creator" match=".+">_______________________________________</alt></p>
+         <p>are Copyright (C): <alt name="copyright" match=".+">_______________________________________</alt></p>
          <p>All Rights Reserved.</p>
-         <p>Contributor(s): _______________________________________ 
-        <br/>EXHIBIT B - Standards 
-      </p>
+         <p>Contributor(s): <alt name="contributor" match=".+">_______________________________________</alt></p>
+         </standardLicenseHeader>
+         <p>EXHIBIT B - Standards</p>
          <p>The Standard is defined as the following: 
         <br/>OpenOffice.org XML File Format Specification, located at http://xml.openoffice.org 
         <br/>OpenOffice.org Application Programming Interface Specification, located at 

--- a/src/SPL-1.0.xml
+++ b/src/SPL-1.0.xml
@@ -4,26 +4,6 @@
       <crossRefs>
          <crossRef>http://www.opensource.org/licenses/SPL-1.0</crossRef>
       </crossRefs>
-      <standardLicenseHeader> The contents of this file are subject to the Sun Public License Version 1.0 (the License); you may not use
-          this file except in compliance with the License. A copy of the License is available at
-          http://www.sun.com/ The Original Code is 
-    <alt match=".+" name="code">_____</alt>. The Initial Developer of the Original Code is 
-    <alt match=".+" name="InitialDeveloper">_____</alt>. Portions created by 
-    <alt match=".+" name="createdby">_____</alt> are Copyright (C) 
-    <alt match=".+" name="copyright">_____</alt>. All Rights Reserved. Contributor(s): 
-    <alt match=".+" name="contributor">_____</alt> Alternatively, the contents of this file may be used under the
-    terms of the 
-    <alt match=".+" name="AltLicense">_____</alt> license (the 
-    <alt match=".+" name="licenseName">[____]</alt> License), in which case the provisions of 
-    <alt match=".+" name="licenseName">[____]</alt> License are applicable instead of those above. If you wish to
-    allow use of your version of this file only under the terms of the 
-    <alt match=".+" name="licenseName">[____]</alt> License and not to allow others to use your version of this file
-    under the SPL, indicate your decision by deleting the provisions above and replace them with the notice and
-    other provisions required by the 
-    <alt match=".+" name="licenseName">[____]</alt> License. If you do not delete the provisions above, a recipient
-    may use your version of this file under either the SPL or the 
-    <alt match=".+" name="licenseName">[____]</alt> License. 
-  </standardLicenseHeader>
     <text>
       <titleText>
          <p>SUN PUBLIC LICENSE Version 1.0</p>
@@ -510,19 +490,23 @@
     
       <optional>
          <p>Exhibit A -Sun Public License Notice.</p>
+        <standardLicenseHeader>
          <p>The contents of this file are subject to the Sun Public License Version 1.0 (the License); you may not
          use this file except in compliance with the License. A copy of the License is available at
          http://www.sun.com/</p>
-         <p>The Original Code is _________________. The Initial Developer of the Original Code is ___________.
-         Portions created by ______ are Copyright (C)_________. All Rights Reserved.</p>
-         <p>Contributor(s): ______________________________________.</p>
-         <p>Alternatively, the contents of this file may be used under the terms of the _____ license (the ?[___]
-         License?), in which case the provisions of [______] License are applicable instead of those above. If
-         you wish to allow use of your version of this file only under the terms of the [____] License and not
+         <p>The Original Code is <alt name="code" match=".+">_________________</alt>.
+         The Initial Developer of the Original Code is <alt name="initialDeveloper" match=".+">___________</alt>.
+         Portions created by <alt name="createdBy" match=".+">______</alt> are Copyright (C) <alt name="copyright" match=".+">_________</alt>.
+         All Rights Reserved.</p>
+         <p>Contributor(s): <alt name="contributor" match=".+">______________________________________</alt>.</p>
+         <p>Alternatively, the contents of this file may be used under the terms of the <alt name="altLicense" match=".+">_____ license</alt> (the <alt name="altLicenseShort1" match=".+">?[___] License?</alt>), in which case the provisions of <alt name="altLicenseShort2" match=".+">[______]</alt> License are applicable instead of those above. If
+         you wish to allow use of your version of this file only under the terms of the <alt name="altLicenseShort3" match=".+">[____]</alt> License and not
          to allow others to use your version of this file under the SPL, indicate your decision by deleting the
-         provisions above and replace them with the notice and other provisions required by the [___] License.
+         provisions above and replace them with the notice and other provisions required by the <alt name="altLicenseShort4" match=".+">[___]</alt> License.
          If you do not delete the provisions above, a recipient may use your version of this file under either
-         the SPL or the [___] License. [NOTE: The text of this Exhibit A may differ slightly from the text of
+         the SPL or the <alt name="altLicenseShort5" match=".+">[___]</alt> License.</p>
+        </standardLicenseHeader>
+         <p>[NOTE: The text of this Exhibit A may differ slightly from the text of
          the notices in the Source Code files of the Original Code. You should use the text of this Exhibit A
          rather than the text found in the Original Code Source Code for Your Modifications.]</p>
       </optional>


### PR DESCRIPTION
This PR builds on #452; review that first.

Two changes here:

* Rename `<standardLicenseHeader>` → `<fileGrant>`.  “License” is redundant as long as we only include these for licenses, and would be incorrect if/when we start supplying these for exceptions.  “standard” is also redundant as long as we are requiring these to come from the license text itself (more on that below).  “header” alone might be confused with `<h1>`, etc., and is about where the content shows up.  `<fileGrant>`, on the other hand, is about what the content *is*.  In fact, the GPL family grants are generic enough to be applied at the program level (as well as per-file), but the file-specific `<fileGrant>` is more specific for licenses like Apache-2.0 whose text only makes sense in a per-file context.

* Make the `<fileGrant>` element a descendant of the text element (it used to be a sibling).  We may restore the possibility of siblings later, but for now, the ancestor requirement makes it easy to [enforce][1]:

    ```
    F) Standard License Header

    * Should only include text intended to be put in the header of
      source files or other files as specified in the license or
      license appendix when specifically delineated
    …
    * Leave this field blank if there is no standard header as
      specifically defined in the license
    ```

This also makes it easy to cover licenses where the license text and header are identical (e.g. the BSDs and the OFL, #451), because you can use:

```xml
<text>
  <fileGrant>
    …
  </fileGrant>
<text>
```

and it makes it easy to stay DRY and avoid header/license divergence (#578).

I've mocked up the changes to the `Apache-2.0`, so folks can see what this will look like.  If we think this approach has legs (and #452 lands), I'll go through and update the rest of our licenses.

[1]: https://spdx.org/spdx-license-list/license-list-overview#fields
[2]: https://github.com/spdx/license-list-XML/issues/451