### PR TITLE
schema/ListedLicense: Drop isFsfLibre

### DIFF
--- a/schema/ListedLicense.xsd
+++ b/schema/ListedLicense.xsd
@@ -51,7 +51,6 @@
 		</choice>
 		<attribute name="licenseId" type="string" use="required" />
 		<attribute name="isOsiApproved" type="boolean"/>
-		<attribute name="isFsfLibre" type="boolean"/>
 		<attribute name="isDeprecated" type="boolean"/>
 		<attribute name="name" type="string" use="required" />
 		<attribute name="listVersionAdded" type="string"/>


### PR DESCRIPTION
This had been added in 378fe01b, but we later [decided that we didn't need it][1] because we could lean on [our mock FSF API][2].

[1]: https://github.com/spdx/license-list-XML/pull/453#issuecomment-347960055
[2]: https://github.com/wking/fsf-api