### PR TITLE
schema/ListedLicense: Drop isDeprecated

### DIFF
--- a/schema/ListedLicense.xsd
+++ b/schema/ListedLicense.xsd
@@ -47,7 +47,6 @@
 			<element name="text" type="tns:formattedAltTextType" minOccurs="0" maxOccurs="1"/>
 		</all>
 		<attribute name="licenseId" type="string" use="required" />
-		<attribute name="isDeprecated" type="boolean"/>
 		<attribute name="name" type="string" use="required" />
 		<attribute name="listVersionAdded" type="string"/>
 		<attribute name="deprecatedVersion" type="string"/>
@@ -104,15 +103,6 @@
 				<documentation xml:lang="en">
 					<xhtml:p>
 						<xhtml:code>isOsiApproved</xhtml:code> is true if and only if the license is approved by Open Source Initiative as listed <xhtml:a href="https://opensource.org/licenses">here</xhtml:a>.
-					</xhtml:p>
-				</documentation>
-			</annotation>
-		</attribute>
-		<attribute name="isDeprecated" type="boolean">
-			<annotation>
-				<documentation xml:lang="en">
-					<xhtml:p>
-						<xhtml:code>isDeprecated</xhtml:code> is true if and only if the short identifier has been superseded by another.  See the <xhtml:code>deprecatedVersion</xhtml:code> documentation for more details.
 					</xhtml:p>
 				</documentation>
 			</annotation>

--- a/src/AGPL-1.0.xml
+++ b/src/AGPL-1.0.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="false" licenseId="AGPL-1.0"
             name="Affero General Public License v1.0"
-            isDeprecated="true" deprecatedVersion="3.1">
+            deprecatedVersion="3.1">
       <crossRefs>
          <crossRef>http://www.affero.org/oagpl.html</crossRef>
       </crossRefs>

--- a/src/AGPL-3.0.xml
+++ b/src/AGPL-3.0.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
   <license licenseId="AGPL-3.0" isOsiApproved="true"
   name="GNU Affero General Public License v3.0"
-  isDeprecated="true" deprecatedVersion="3.0">
+  deprecatedVersion="3.0">
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/agpl.txt</crossRef>
       <crossRef>http://www.opensource.org/licenses/AGPL-3.0</crossRef>

--- a/src/GFDL-1.1.xml
+++ b/src/GFDL-1.1.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
   <license licenseId="GFDL-1.1" isOsiApproved="false"
   name="GNU Free Documentation License v1.1"
-  isDeprecated="true" deprecatedVersion="3.0">
+  deprecatedVersion="3.0">
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/old-licenses/fdl-1.1.txt</crossRef>
     </crossRefs>

--- a/src/GFDL-1.2.xml
+++ b/src/GFDL-1.2.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
   <license licenseId="GFDL-1.2" isOsiApproved="false"
   name="GNU Free Documentation License v1.2"
-  isDeprecated="true" deprecatedVersion="3.0">
+  deprecatedVersion="3.0">
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/old-licenses/fdl-1.2.txt</crossRef>
     </crossRefs>

--- a/src/GFDL-1.3.xml
+++ b/src/GFDL-1.3.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
   <license licenseId="GFDL-1.3" isOsiApproved="false"
   name="GNU Free Documentation License v1.3"
-  isDeprecated="true" deprecatedVersion="3.0">
+  deprecatedVersion="3.0">
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/fdl-1.3.txt</crossRef>
     </crossRefs>

--- a/src/GPL-1.0+.xml
+++ b/src/GPL-1.0+.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isDeprecated="true" deprecatedVersion="2.0rc2" isOsiApproved="false" licenseId="GPL-1.0+"
+   <license deprecatedVersion="2.0rc2" isOsiApproved="false" licenseId="GPL-1.0+"
             name="GNU General Public License v1.0 or later">
       <crossRefs>
          <crossRef>http://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html</crossRef>

--- a/src/GPL-1.0.xml
+++ b/src/GPL-1.0.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
   <license licenseId="GPL-1.0" isOsiApproved="false"
   name="GNU General Public License v1.0 only"
-  isDeprecated="true" deprecatedVersion="3.0">
+  deprecatedVersion="3.0">
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html</crossRef>
     </crossRefs>

--- a/src/GPL-2.0+.xml
+++ b/src/GPL-2.0+.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isOsiApproved="true" licenseId="GPL-2.0+" isDeprecated="true" deprecatedVersion="2.0rc2"
+   <license isOsiApproved="true" licenseId="GPL-2.0+" deprecatedVersion="2.0rc2"
             name="GNU General Public License v2.0 or later">
 	  <notes>DEPRECATED: Use the license identifier GPL-2.0-or-later</notes>
       <crossRefs>

--- a/src/GPL-2.0-with-GCC-exception.xml
+++ b/src/GPL-2.0-with-GCC-exception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isDeprecated="true" deprecatedVersion="2.0rc2" licenseId="GPL-2.0-with-GCC-exception"
+   <license deprecatedVersion="2.0rc2" licenseId="GPL-2.0-with-GCC-exception"
             name="GNU General Public License v2.0 w/GCC Runtime Library exception">
       <crossRefs>
          <crossRef>https://gcc.gnu.org/git/?p=gcc.git;a=blob;f=gcc/libgcc1.c;h=762f5143fc6eed57b6797c82710f3538aa52b40b;hb=cb143a3ce4fb417c68f5fa2691a1b1b1053dfba9#l10</crossRef>

--- a/src/GPL-2.0-with-autoconf-exception.xml
+++ b/src/GPL-2.0-with-autoconf-exception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isDeprecated="true" deprecatedVersion="2.0rc2" licenseId="GPL-2.0-with-autoconf-exception"
+   <license deprecatedVersion="2.0rc2" licenseId="GPL-2.0-with-autoconf-exception"
             name="GNU General Public License v2.0 w/Autoconf exception">
       <crossRefs>
          <crossRef>http://ac-archive.sourceforge.net/doc/copyright.html</crossRef>

--- a/src/GPL-2.0-with-bison-exception.xml
+++ b/src/GPL-2.0-with-bison-exception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isDeprecated="true" deprecatedVersion="2.0rc2" licenseId="GPL-2.0-with-bison-exception"
+   <license deprecatedVersion="2.0rc2" licenseId="GPL-2.0-with-bison-exception"
             name="GNU General Public License v2.0 w/Bison exception">
       <crossRefs>
          <crossRef>http://git.savannah.gnu.org/cgit/bison.git/tree/data/yacc.c?id=193d7c7054ba7197b0789e14965b739162319b5e#n141</crossRef>

--- a/src/GPL-2.0-with-classpath-exception.xml
+++ b/src/GPL-2.0-with-classpath-exception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isDeprecated="true" deprecatedVersion="2.0rc2" licenseId="GPL-2.0-with-classpath-exception"
+   <license deprecatedVersion="2.0rc2" licenseId="GPL-2.0-with-classpath-exception"
             name="GNU General Public License v2.0 w/Classpath exception">
       <crossRefs>
          <crossRef>http://www.gnu.org/software/classpath/license.html</crossRef>

--- a/src/GPL-2.0-with-font-exception.xml
+++ b/src/GPL-2.0-with-font-exception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isDeprecated="true" deprecatedVersion="2.0rc2" licenseId="GPL-2.0-with-font-exception"
+   <license deprecatedVersion="2.0rc2" licenseId="GPL-2.0-with-font-exception"
             name="GNU General Public License v2.0 w/Font exception">
       <crossRefs>
          <crossRef>http://www.gnu.org/licenses/gpl-faq.html#FontException</crossRef>

--- a/src/GPL-2.0.xml
+++ b/src/GPL-2.0.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
   <license licenseId="GPL-2.0" isOsiApproved="true"
   name="GNU General Public License v2.0 only"
-  isDeprecated="true" deprecatedVersion="3.0">
+  deprecatedVersion="3.0">
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html</crossRef>
       <crossRef>http://www.opensource.org/licenses/GPL-2.0</crossRef>

--- a/src/GPL-3.0+.xml
+++ b/src/GPL-3.0+.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isOsiApproved="true" licenseId="GPL-3.0+" isDeprecated="true" deprecatedVersion="2.0rc2"
+   <license isOsiApproved="true" licenseId="GPL-3.0+" deprecatedVersion="2.0rc2"
             name="GNU General Public License v3.0 or later">
       <crossRefs>
          <crossRef>http://www.gnu.org/licenses/gpl-3.0-standalone.html</crossRef>

--- a/src/GPL-3.0-with-GCC-exception.xml
+++ b/src/GPL-3.0-with-GCC-exception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isOsiApproved="true" licenseId="GPL-3.0-with-GCC-exception" isDeprecated="true" deprecatedVersion="2.0rc2"
+   <license isOsiApproved="true" licenseId="GPL-3.0-with-GCC-exception" deprecatedVersion="2.0rc2"
             name="GNU General Public License v3.0 w/GCC Runtime Library exception">
 	  <notes>DEPRECATED: Use License Expression Syntax and Exceptions list to create equivalent license.</notes>
       <crossRefs>

--- a/src/GPL-3.0-with-autoconf-exception.xml
+++ b/src/GPL-3.0-with-autoconf-exception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isDeprecated="true" deprecatedVersion="2.0rc2" licenseId="GPL-3.0-with-autoconf-exception"
+   <license deprecatedVersion="2.0rc2" licenseId="GPL-3.0-with-autoconf-exception"
             name="GNU General Public License v3.0 w/Autoconf exception">
       <crossRefs>
          <crossRef>http://www.gnu.org/licenses/autoconf-exception-3.0.html</crossRef>

--- a/src/GPL-3.0.xml
+++ b/src/GPL-3.0.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
   <license licenseId="GPL-3.0" isOsiApproved="true"
   name="GNU General Public License v3.0 only"
-  isDeprecated="true" deprecatedVersion="3.0">
+  deprecatedVersion="3.0">
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/gpl-3.0-standalone.html</crossRef>
       <crossRef>http://www.opensource.org/licenses/GPL-3.0</crossRef>

--- a/src/LGPL-2.0+.xml
+++ b/src/LGPL-2.0+.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isOsiApproved="true" licenseId="LGPL-2.0+" isDeprecated="true" deprecatedVersion="2.0rc2"
+   <license isOsiApproved="true" licenseId="LGPL-2.0+" deprecatedVersion="2.0rc2"
             name="GNU Library General Public License v2 or later">
 	  <notes>DEPRECATED: Use the license identifier LGPL-2.0-or-later</notes>
       <crossRefs>

--- a/src/LGPL-2.0.xml
+++ b/src/LGPL-2.0.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
   <license licenseId="LGPL-2.0" isOsiApproved="true"
   name="GNU Library General Public License v2 only"
-  isDeprecated="true" deprecatedVersion="3.0">
+  deprecatedVersion="3.0">
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html</crossRef>
     </crossRefs>

--- a/src/LGPL-2.1+.xml
+++ b/src/LGPL-2.1+.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isOsiApproved="true" licenseId="LGPL-2.1+"  isDeprecated="true" deprecatedVersion="2.0rc2"
+   <license isOsiApproved="true" licenseId="LGPL-2.1+" deprecatedVersion="2.0rc2"
             name="GNU Library General Public License v2.1 or later">
 	  <notes>DEPRECATED: Use the license identifier LGPL-2.1-or-later</notes>
       <crossRefs>

--- a/src/LGPL-2.1.xml
+++ b/src/LGPL-2.1.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
   <license licenseId="LGPL-2.1" isOsiApproved="true"
   name="GNU Lesser General Public License v2.1 only"
-  isDeprecated="true" deprecatedVersion="3.0">
+  deprecatedVersion="3.0">
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</crossRef>
       <crossRef>http://www.opensource.org/licenses/LGPL-2.1</crossRef>

--- a/src/LGPL-3.0+.xml
+++ b/src/LGPL-3.0+.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isOsiApproved="true" licenseId="LGPL-3.0+"  isDeprecated="true" deprecatedVersion="2.0rc2"
+   <license isOsiApproved="true" licenseId="LGPL-3.0+"  deprecatedVersion="2.0rc2"
             name="GNU Lesser General Public License v3.0 or later">
 	  <notes>DEPRECATED: Use the license identifier LGPL-3.0-or-later</notes>
       <crossRefs>

--- a/src/LGPL-3.0.xml
+++ b/src/LGPL-3.0.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
   <license licenseId="LGPL-3.0" isOsiApproved="true"
   name="GNU Lesser General Public License v3.0 only"
-  isDeprecated="true" deprecatedVersion="3.0">
+  deprecatedVersion="3.0">
     <crossRefs>
       <crossRef>http://www.gnu.org/licenses/lgpl-3.0-standalone.html</crossRef>
       <crossRef>http://www.opensource.org/licenses/LGPL-3.0</crossRef>

--- a/src/Nunit.xml
+++ b/src/Nunit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isDeprecated="true" deprecatedVersion="3.0" licenseId="Nunit" name="Nunit License">
+   <license deprecatedVersion="3.0" licenseId="Nunit" name="Nunit License">
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/Nunit</crossRef>
       </crossRefs>

--- a/src/StandardML-NJ.xml
+++ b/src/StandardML-NJ.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isOsiApproved="false" licenseId="StandardML-NJ" isDeprecated="true" deprecatedVersion="2.0rc2"
+   <license isOsiApproved="false" licenseId="StandardML-NJ" deprecatedVersion="2.0rc2"
             name="Standard ML of New Jersey License">
 	  <notes>DEPRECATED: This license was added twice (as of v1.17 and then in v1.20) by accident. Use short identifier: SMLNJ</notes>
       <crossRefs>

--- a/src/eCos-2.0.xml
+++ b/src/eCos-2.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isDeprecated="true" deprecatedVersion="2.0rc2" licenseId="eCos-2.0" name="eCos license version 2.0">
+   <license deprecatedVersion="2.0rc2" licenseId="eCos-2.0" name="eCos license version 2.0">
       <crossRefs>
          <crossRef>http://www.gnu.org/licenses/ecos-license.html</crossRef>
       </crossRefs>

--- a/src/wxWindows.xml
+++ b/src/wxWindows.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license licenseId="wxWindows" name="wxWindows Library License"  isDeprecated="true" deprecatedVersion="2.0rc2">
+   <license licenseId="wxWindows" name="wxWindows Library License" deprecatedVersion="2.0rc2">
       <crossRefs>
          <crossRef>http://www.opensource.org/licenses/WXwindows</crossRef>
       </crossRefs>


### PR DESCRIPTION
`deprecatedVersion` should be set if and only if `isDeprecated` was true.  So instead of recording that information twice, tooling which consumes this format should just check `deprecatedVersion`.  If `deprecatedVersion` is non-empty, the license is deprecated.  If `deprecatedVersion` is empty, the license is not deprecated.

This protects us from desynchronization like that fixed by cc1e05e8 (added deprecated version, 2017-12-28), because it is now impossible to deprecate a license without recording the deprecated version.

The schema change is a two-liner, and the `src/*` change was generated with:

```console
$ sed -i 's/isDeprecated="true" //' $(git grep -l isDeprecated)
```

which should make review straightforward.

Downstream, this will need spdx/tools changes to get the license/exception-loading code looking at `deprecatedVersion` to generate `isDeprecatedLicenseId` output [here][1] and similar.  This change is easy enough here that, if folks think this change is promising, we should probably block this PR on landing the spdx/tools update.  I propose the following order:

1. Review this PR for the general thrust.  If, for some reason, the license list maintainers feel it is not productive, we can close this without further changes.
2. Update spdx/tools to only consider `deprecatedVersion` when generating `isDeprecatedLicenseId` and similar.
3. Rebase this PR to pick up whatever changes have landed in this repository in the meantime.
4. Merge this PR.

[1]: https://github.com/spdx/license-list-data/blob/c4f1648c4931db3ce071ff4b15e52ef749d68076/json/details/GPL-1.0%2B.json#L2