### PR TITLE
schema/ListedLicense: Use anyURI for crossRef

### DIFF
--- a/schema/ListedLicense.xsd
+++ b/schema/ListedLicense.xsd
@@ -59,7 +59,7 @@
 	</complexType>
 	<complexType name="crossRefsType">
 		<sequence>
-			<element name="crossRef" type="string" minOccurs="1" maxOccurs="unbounded"/>
+			<element name="crossRef" type="anyURI" minOccurs="1" maxOccurs="unbounded"/>
 		</sequence>
 	</complexType>
 	<complexType name="altType" mixed="true">


### PR DESCRIPTION
The type is documented [here][1].  This gives us stricter validation than the previous `string`.

[1]: https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/datatypes.html#anyURI