### PR TITLE
u-boot-exception diverges from original text

### DIFF
--- a/src/exceptions/u-boot-exception-2.0.xml
+++ b/src/exceptions/u-boot-exception-2.0.xml
@@ -6,7 +6,7 @@
       </crossRefs>
       <notes>Typically used with GPL-2.0+</notes>
       <titleText>
-         <p>The U-Boot License Exception:</p>
+         <p>GPL License Exception:</p>
       </titleText>
       <p>Even though U-Boot in general is covered by the GPL-2.0/GPL-2.0+,
          this does *not* cover the so-called "standalone" applications

--- a/src/exceptions/u-boot-exception-2.0.xml
+++ b/src/exceptions/u-boot-exception-2.0.xml
@@ -6,7 +6,7 @@
       </crossRefs>
       <notes>Typically used with GPL-2.0+</notes>
       <titleText>
-         <p>GPL License Exception:</p>
+         <p><alt name="title" match="GPL|The U-Boot">GPL</alt> License Exception:</p>
       </titleText>
       <p>Even though U-Boot in general is covered by the GPL-2.0/GPL-2.0+,
          this does *not* cover the so-called "standalone" applications


### PR DESCRIPTION
u-boot-exception diverges from original text. License list text says:
"The U-Boot License Exception:"

Where as original (http://git.denx.de/?p=u-boot.git;a=blob;f=Licenses/Exceptions) says:
"GPL License Exception:"

Google shows no matches for the text that is on the license list, except for the license list itself. Propose to change license list to match original.