### PR TITLE
Add missing close quote to Apache-1.0.xml

### DIFF
--- a/src/Apache-1.0.xml
+++ b/src/Apache-1.0.xml
@@ -52,7 +52,7 @@
             <bullet>6.</bullet>
           Redistributions of any form whatsoever must retain the following acknowledgment:
           <p>"This product includes software developed by <alt match=".+" name="nameClause6">the 
-          Apache Group for use in the Apache HTTP server project (http://www.apache.org/)</alt>.</p>
+          Apache Group for use in the Apache HTTP server project (http://www.apache.org/)</alt>."</p>
         </item>
       </list>
       <p>THIS SOFTWARE IS PROVIDED BY 


### PR DESCRIPTION
Added missing close quote character relative to original text at http://www.apache.org/licenses/LICENSE-1.0.