### PR TITLE
Remove section 4.g. from BitTorrent-1.0 license.

### DIFF
--- a/src/BitTorrent-1.0.xml
+++ b/src/BitTorrent-1.0.xml
@@ -260,28 +260,6 @@
                this License are fulfilled for those portions of the Derivative Works that consist of the
                Licensed Product or any Modifications thereto.
           </item>
-               <item>
-                  <bullet>g.</bullet>
-            Compensation for Distribution of Executable Versions of Licensed Products, Modifications 
-            or Derivative Works. Notwithstanding any provision of this License to the contrary, by distributing, 
-            selling, licensing, sublicensing or otherwise making available any Licensed Product, or Modification 
-            or Derivative Work thereof, you and Licensor hereby acknowledge and agree that you may sell, license 
-            or sublicense for a fee, accept donations or otherwise receive compensation for executable versions 
-            of a Licensed Product, without paying a royalty or other fee to the Licensor or any other Contributor, 
-            provided that such executable versions (i) contain your or another Contributor's material Modifications, 
-            or (ii) are otherwise material Derivative Works. For purposes of this License, an executable version of 
-            the Licensed Product will be deemed to contain a material Modification, or will otherwise be deemed a 
-            material Derivative Work, if (a) the Licensed Product is modified with your own or a third party's software 
-            programs or other code, and/or the Licensed Product is combined with a number of your own or a third party's 
-            software programs or code, respectively, and (b) such software programs or code add or contribute material 
-            value, functionality or features to the License Product. For the avoidance of doubt, to the extent your 
-            executable version of a Licensed Product does not contain your or another Contributor's material Modifications 
-            or is otherwise not a material Derivative Work, in each case as contemplated herein, you may not sell, license 
-            or sublicense for a fee, accept donations or otherwise receive compensation for such executable. Additionally, 
-            without limitation of the foregoing and notwithstanding any provision of this License to the contrary, you 
-            cannot charge for, sell, license or sublicense for a fee, accept donations or otherwise receive compensation 
-            for the Source Code.
-          </item>
             </list>
         </item>
         <item>


### PR DESCRIPTION
BitTorrent-1.0 on license-list has a section 4.g. that does not appear in original license. This section did not appear in pre-XML license-list, so possibly is an error introduced during conversion. See link here http://sources.gentoo.org/cgi-bin/viewvc.cgi/gentoo-x86/licenses/BitTorrent?r1=1.1&amp;r2=1.1.1.1&amp;diff_format=s and I have also downloaded an old BitTorrent source archive and confirmed included LICENSE.txt does not include this clause (http://web.archive.org/web/20090309024144/http://download.bittorrent.com:80/dl/archive/BitTorrent-4.0.0.tar.gz). Propose to remove clause 4.g.