### PR TITLE
Modify gSOAP-1.3b to cope with "shall" versus "will"

### DIFF
--- a/src/gSOAP-1.3b.xml
+++ b/src/gSOAP-1.3b.xml
@@ -209,7 +209,7 @@
                     <item>
                         <bullet>3.2.</bullet>
                         Availability of Source Code.
-                        <p>Any Modification created by You will be provided to the Initial Developer in Source Code
+                        <p>Any Modification created by You <alt name=“shall” match=“will|shall”>shall</alt> be provided to the Initial Developer in Source Code
                          form and are subject to the terms of the License.</p>
                     </item>
                     <item>

--- a/src/gSOAP-1.3b.xml
+++ b/src/gSOAP-1.3b.xml
@@ -209,7 +209,7 @@
                     <item>
                         <bullet>3.2.</bullet>
                         Availability of Source Code.
-                        <p>Any Modification created by You <alt name=“shall” match=“will|shall”>shall</alt> be provided to the Initial Developer in Source Code
+                        <p>Any Modification created by You <alt name="shall" match="will|shall">shall</alt> be provided to the Initial Developer in Source Code
                          form and are subject to the terms of the License.</p>
                     </item>
                     <item>


### PR DESCRIPTION
Cross referenced license at http://www.cs.fsu.edu/~engelen/license.html uses the word "shall" in section 3.2 instead of "will". Propose to amend XML to cope with either.