### PR TITLE
Apache-1.1: Add an <alt> to the <copyright> section

### DIFF
--- a/src/Apache-1.1.xml
+++ b/src/Apache-1.1.xml
@@ -10,7 +10,7 @@
          <p>Apache License 1.1</p>
       </titleText>
       <copyrightText>
-         <p>Copyright (c) 2000 The Apache Software Foundation. All rights reserved.</p>
+         <p>Copyright (c) <alt name="copyright" match=".+">2000 The Apache Software Foundation</alt>. All rights reserved.</p>
       </copyrightText>
       <p>Redistribution and use in source and binary forms, with or without modification, are permitted provided
        that the following conditions are met:</p>


### PR DESCRIPTION
Following the example set by the ISC license in 378fe01b (2017-10-17).  This also allows automated [matching with][2] the [MX4J text][1].

[1]: http://mx4j.sourceforge.net/docs/ch01s06.html
[2]: https://bugs.linuxfoundation.org/show_bug.cgi?id=1194