### PR TITLE
LGPL-2.1+: Fix the name for this license

### DIFF
--- a/src/LGPL-2.1+.xml
+++ b/src/LGPL-2.1+.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="LGPL-2.1+"  isDeprecated="true" deprecatedVersion="2.0rc2"
-            name="GNU Library General Public License v2 or later">
+            name="GNU Library General Public License v2.1 or later">
 	  <notes>DEPRECATED: Use the license identifier LGPL-2.1-or-later</notes>
       <crossRefs>
          <crossRef>http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</crossRef>


### PR DESCRIPTION
The broken name (which is for `LGPL-2.0+`) came in with 68cdda9e (#552).