### PR TITLE
Add crossref for Zimbra-1.3

### DIFF
--- a/src/Zimbra-1.3.xml
+++ b/src/Zimbra-1.3.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="false" licenseId="Zimbra-1.3" name="Zimbra Public License v1.3">
+      <crossRefs>
+         <crossRef>http://web.archive.org/web/20100302225219/http://www.zimbra.com/license/zimbra-public-license-1-3.html</crossRef>
+      </crossRefs>
       <titleText>
          <p>Zimbra Public License, Version 1.3 (ZPL)</p>
       </titleText>


### PR DESCRIPTION
The only license without a crossref.

Note wayback machine copies used for crossrefs for 4 other licenses.