### PR TITLE
AGPL-3.0: Drop redundant release-date <notes>

### DIFF
--- a/src/AGPL-3.0.xml
+++ b/src/AGPL-3.0.xml
@@ -23,9 +23,6 @@
       along with this program. If not, see
       &lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;
     </standardLicenseHeader>
-    <notes>
-      This version was released: 19 November 2007
-    </notes>
     <titleText>
       <p>
         GNU AFFERO GENERAL PUBLIC LICENSE<br></br>


### PR DESCRIPTION
The XSD suggests (buggily) that we only want a single <notes> element (more details on this in #577).  And the information contained in the `<notes>` section I'm removing is redundant, because the `titleText` contains the release date.  I don't see a need to include that release date as unstrucutured information in two places, and the license title is clearly the more important location.

This is the second per-license change spun out of #566 (based on @jlovejoy's request for [individual review][1]).

[1]: https://github.com/spdx/license-list-XML/pull/566#issuecomment-354372728