### PR TITLE
OSL-2.0: Fix “Licensev.” → “License v.”

### DIFF
--- a/src/OSL-2.0.xml
+++ b/src/OSL-2.0.xml
@@ -7,7 +7,7 @@
       <standardLicenseHeader>Licensed under the Open Software License version 2.0</standardLicenseHeader>
     <text>
       <titleText>
-         <p>Open Software Licensev. 2.0</p>
+         <p><optional>The </optional>Open Software License v. 2.0</p>
       </titleText>
     
       <p>This Open Software License (the "License") applies to any original work of authorship (the

--- a/test/simpleTestForGenerator/OSL-2.0.txt
+++ b/test/simpleTestForGenerator/OSL-2.0.txt
@@ -1,4 +1,4 @@
-Open Software Licensev. 2.0
+Open Software License v. 2.0
 
 This Open Software License (the "License") applies to any original work of authorship (the "Original Work") whose owner (the "Licensor") has placed the following notice immediately following the copyright notice for the Original Work:
 


### PR DESCRIPTION
The typo came in with the license in 0162ea9a (Automated, 2016-03-30, #180).

Also add an optional “The ” to match the archived original:

```console
$ curl -s https://web.archive.org/web/20041020171434/http://www.rosenlaw.com/osl2.0.html | grep 'Open Software License' | head -n2
<!-- End Wayback Rewrite JS Include --><h1>The Open Software License<br/> v. 2.0</h1>
<p>This Open Software License (the "License") …
```