### PR TITLE
validate-schema: Catch XML parsing errors

### DIFF
--- a/validate-schema.js
+++ b/validate-schema.js
@@ -15,7 +15,11 @@ var fs = require('fs');
  */
 function validate(schema, file) {
 	var documentString = fs.readFileSync(file, 'utf8');
-	var validationErrors = schema.validate(documentString);
+	try {
+		var validationErrors = schema.validate(documentString);
+	} catch(error) {
+		return new Error('File ' + file + ': ' + error);
+	}
 	if (validationErrors) {
 		var errormsg = null;
 		validationErrors.forEach(function(error) {


### PR DESCRIPTION
Replace:

```
  /home/wking/src/spdx/license-list-XML/node_modules/libxml-xsd/index.js:103
                          throw err;
                          ^

  Error: Opening and ending tag mismatch: standardLicenseHeader line 8 and text

      at Error (native)
      at Object.module.exports.fromXml (/home/wking/src/spdx/license-list-XML/node_modules/libxmljs-mt/lib/document.js:167:21)
      at Schema.validate (/home/wking/src/spdx/license-list-XML/node_modules/libxml-xsd/index.js:100:22)
      at validate (/home/wking/src/spdx/license-list-XML/validate-schema.js:18:32)
      at /home/wking/src/spdx/license-list-XML/validate-schema.js:49:19
      at Array.forEach (native)
      at main (/home/wking/src/spdx/license-list-XML/validate-schema.js:48:8)
      at Object.<anonymous> (/home/wking/src/spdx/license-list-XML/validate-schema.js:69:1)
      at Module._compile (module.js:570:32)
      at Object.Module._extensions..js (module.js:579:10)
```

with:

```
  validation complete 0 passed, 1 failed
  File src/Bahyph.xml: Error: Opening and ending tag mismatch: optional line 7 and text
```

You may want to introduce an unbalanced tag or some such to test.