### PR TITLE
Makefile: Change validate-canonical-match source from '.' to 'src'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ matrix:
   include:
     - language: java
       script:
-        - make TEST_DATA=test/simpleTestForGenerator validate-canonical-match
+        - make validate-canonical-match
     - language: node_js
       node_js:
       - "node"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 TOOL_VERSION = 2.1.9
-TEST_DATA = ../license-test-files
+TEST_DATA = test/simpleTestForGenerator
 
 .PHONY: validate-canonical-match
 validate-canonical-match: spdx-tools-$(TOOL_VERSION).jar-valid resources/licenses-full.json $(TEST_DATA) .tmp

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ TEST_DATA = test/simpleTestForGenerator
 
 .PHONY: validate-canonical-match
 validate-canonical-match: spdx-tools-$(TOOL_VERSION).jar-valid resources/licenses-full.json $(TEST_DATA) .tmp
-	java -jar -DLocalFsfFreeJson=true spdx-tools-$(TOOL_VERSION).jar LicenseRDFAGenerator . .tmp 1.0 2000-01-01 $(TEST_DATA) expected-warnings
+	java -jar -DLocalFsfFreeJson=true spdx-tools-$(TOOL_VERSION).jar LicenseRDFAGenerator src .tmp 1.0 2000-01-01 $(TEST_DATA) expected-warnings
 
 .PRECIOUS: spdx-tools-%.jar
 spdx-tools-%.jar:


### PR DESCRIPTION
The old `.` lead to errors like:

```
  [Fatal Error] comment.xml:5:10: An invalid XML character (Unicode: 0xe) was found in the comment.
  16:10:09.437 [main] ERROR org.spdx.licensexml.LicenseXmlDocument - Error parsing license XML document
  org.xml.sax.SAXParseException: An invalid XML character (Unicode: 0xe) was found in the comment.
          at org.apache.xerces.parsers.DOMParser.parse(DOMParser.java:245) ~[spdx-tools-2.1.9.jar:?]
          at org.apache.xerces.jaxp.DocumentBuilderImpl.parse(DocumentBuilderImpl.java:298) ~[spdx-tools-2.1.9.jar:?]
          at javax.xml.parsers.DocumentBuilder.parse(DocumentBuilder.java:205) ~[?:1.8.0_151]
          at org.spdx.licensexml.LicenseXmlDocument.<init>(LicenseXmlDocument.java:74) [spdx-tools-2.1.9.jar:?]
          at org.spdx.licensexml.XmlLicenseProvider$XmlLicenseIterator.findNextItem(XmlLicenseProvider.java:63) [spdx-tools-2.1.9.jar:?]
          at org.spdx.licensexml.XmlLicenseProvider$XmlLicenseIterator.next(XmlLicenseProvider.java:99) [spdx-tools-2.1.9.jar:?]
          at org.spdx.licensexml.XmlLicenseProvider$XmlLicenseIterator.next(XmlLicenseProvider.java:48) [spdx-tools-2.1.9.jar:?]
          at org.spdx.tools.LicenseRDFAGenerator.writeLicenseList(LicenseRDFAGenerator.java:478) [spdx-tools-2.1.9.jar:?]
          at org.spdx.tools.LicenseRDFAGenerator.generateLicenseData(LicenseRDFAGenerator.java:309) [spdx-tools-2.1.9.jar:?]
          at org.spdx.tools.LicenseRDFAGenerator.main(LicenseRDFAGenerator.java:193) [spdx-tools-2.1.9.jar:?]
          at org.spdx.tools.Main.main(Main.java:49) [spdx-tools-2.1.9.jar:?]
```

My guess is that the tooling was walking into an already-populated `.tmp` (from a previous validation run) and then choking on the XML-ish it found there.

Also change default test-data location, which should have been updated as part of 36bce3f (#593).