### PR TITLE
BitTorrent-1.1: Move standardLicenseHeader inside text and support 1.1 grants

### DIFF
--- a/src/BitTorrent-1.1.xml
+++ b/src/BitTorrent-1.1.xml
@@ -5,15 +5,7 @@
       <crossRefs>
          <crossRef>http://directory.fsf.org/wiki/License:BitTorrentOSL1.1</crossRef>
       </crossRefs>
-      <standardLicenseHeader>
-         <p>The contents of this file are subject to the BitTorrent Open Source License Version 1.0 (the License). 
-      You may not copy or use this file, in either source code or executable form, except in compliance with the 
-      License. You may obtain a copy of the License at http://www.bittorrent.com/license/. </p>
-         <p>Software distributed under the License is distributed on an AS IS basis, WITHOUT WARRANTY OF ANY 
-      KIND, either express or implied. See the License for the specific language governing rights and limitations 
-      under the License.</p>
-      </standardLicenseHeader>
-      <notes>Standard header seems to use wrong version number (this is how it appears on all references found.)</notes>
+      <notes>The upstream Exhibit A suggests the wrong version number.</notes>
     <text>
       <titleText>
          <p>BitTorrent Open Source License 
@@ -502,15 +494,16 @@
          <p>The Notice below must appear in each file of the Source Code of any copy you distribute of the Licensed
          Product or any hereto. Contributors to any Modifications may add their own copyright notices to
          identify their own contributions.</p>
-         <p>License: 
-        <br/>The contents of this file are subject to the BitTorrent Open Source License Version 1.0 (the
+         <p>License:</p>
+         <standardLicenseHeader>
+           <p>The contents of this file are subject to the BitTorrent Open Source License Version <alt name="version" match="1\.[01]">1.1</alt> (the
              License). You may not copy or use this file, in either source code or executable form, except
              in compliance with the License. You may obtain a copy of the License at
-             http://www.bittorrent.com/license/. 
-      </p>
+             http://www.bittorrent.com/license/.</p>
          <p>Software distributed under the License is distributed on an AS IS basis, WITHOUT WARRANTY OF ANY KIND,
          either express or implied. See the License for the specific language governing rights and limitations
          under the License.</p>
+         </standardLicenseHeader>
          <p>BitTorrent, Inc.</p>
       </optional>
     </text>


### PR DESCRIPTION
Builds on #581; review that first.

Allow matching for folks who fix the referenced license version from “1.0” → “1.1”.  Make “1.1” our canonical text to reduce future reader confusion.