### PR TITLE
Sendmail: Drop page-end 139848.1 from the canonical text

### DIFF
--- a/src/Sendmail.xml
+++ b/src/Sendmail.xml
@@ -81,7 +81,7 @@
         <item>
             <bullet>(i)</bullet>
           Redistributions of source code must retain the above copyright notice, this list of conditions
-             and the following disclaimer. 139848.1
+             and the following disclaimer.
         </item>
         <item>
             <bullet>(ii)</bullet>

--- a/test/simpleTestForGenerator/Sendmail.txt
+++ b/test/simpleTestForGenerator/Sendmail.txt
@@ -25,7 +25,7 @@ Use, Modification and Redistribution (including distribution of any modified or 
 
      (b) Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: 
 
-          (i) Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. 139848.1 
+          (i) Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
 
           (ii) Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. 
 


### PR DESCRIPTION
But continue to match it via an `<alt>`, in case anyone had copied our old, previously-canonical text.

In [the upstream PDF][1] (linked with [a crossRef to the archive.org URI][2]) this text is part of the footer on every page.  We've had it in this repo since ef01296f (#212), but I imagine this is a copy/paste issue dating back to the original SPDX version of this license (sometime [around 2015-09-16][3]).

[1]: https://web.archive.org/web/20160322142305/https://www.sendmail.com/pdfs/open_source/sendmail_license.pdf
[2]: https://github.com/spdx/license-list-XML/blob/v3.0/src/Sendmail.xml#L6
[3]: https://lists.spdx.org/pipermail/spdx-legal/2015-September/001497.html