### PR TITLE
src/GPL-2.0*: Add paragraph between “USA” and “Also add information”

### DIFF
--- a/src/GPL-2.0-only.xml
+++ b/src/GPL-2.0-only.xml
@@ -422,7 +422,10 @@
         You should have received a copy of the GNU General Public License
         along with this program; if not, write to the Free Software Foundation,
         Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301<optional>,</optional>
-        USA. Also add information on how to
+        USA.
+      </p>
+      <p>
+        Also add information on how to
         contact you by electronic and paper mail.
       </p>
       <p>

--- a/src/GPL-2.0.xml
+++ b/src/GPL-2.0.xml
@@ -423,7 +423,10 @@
         You should have received a copy of the GNU General Public License
         along with this program; if not, write to the Free Software Foundation,
         Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301<optional>,</optional>
-        USA. Also add information on how to
+        USA.
+      </p>
+      <p>
+        Also add information on how to
         contact you by electronic and paper mail.
       </p>
       <p>


### PR DESCRIPTION
The missing paragraph dates back to 6045f28a (#84) in this repository.  `GPL-2.0-or-later` had this typo fixed in #581.