### PR TITLE
Linux-OpenIB: Add new license to add #620

### DIFF
--- a/src/Linux-OpenIB.xml
+++ b/src/Linux-OpenIB.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SPDXLicenseCollection xmlns="http://www.spdx.org/license">
+   <license isOsiApproved="true" licenseId="Linux-OpenIB"
+            name="Linux Kernel Variant of OpenIB.org license">
+      <crossRefs>
+         <crossRef>https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/infiniband/core/sa.h</crossRef>
+      </crossRefs>
+    <text>
+      <p>Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:</p>
+      <list>
+        <item>
+            <bullet>-</bullet>
+          Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+        </item>
+        <item>
+            <bullet>-</bullet>
+          Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+        </item>
+      </list>
+      <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</p>
+    </text>
+  </license>
+</SPDXLicenseCollection>

--- a/src/Linux-OpenIB.xml
+++ b/src/Linux-OpenIB.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isOsiApproved="true" licenseId="Linux-OpenIB"
+   <license isOsiApproved="false" licenseId="Linux-OpenIB"
             name="Linux Kernel Variant of OpenIB.org license">
       <crossRefs>
          <crossRef>https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/infiniband/core/sa.h</crossRef>
       </crossRefs>
+      <notes>This license is BSD-2-Clause with the MIT disclaimer. The linux kernel uses this license extensively throughout the driver subsystem since 2005. Note that the OpenIB.org license is a true match to BSD-2-Clause. </notes>
     <text>
       <p>Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:</p>
       <list>

--- a/test/simpleTestForGenerator/Linux-OpenIB.txt
+++ b/test/simpleTestForGenerator/Linux-OpenIB.txt
@@ -1,0 +1,18 @@
+Redistribution and use in source and binary forms, with or
+without modification, are permitted provided that the following
+conditions are met:
+
+- Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+- Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Adding XML and test .txt file to add #620 

Two comments / questions: 
1. This is my first time contributing to the license list; someone may want to take a look at these and confirm I'm on-track.
2. The crossRef is to the current header file in Linus's trunk of the Linux kernel. Do we want to point to a specific commit, in case this file changes or is removed in the future?