### PR TITLE
LLVM-exception: Replace optional dash-rules with alts

### DIFF
--- a/src/exceptions/LLVM-exception.xml
+++ b/src/exceptions/LLVM-exception.xml
@@ -8,7 +8,9 @@
 	  <text>
 	  <titleText>
 		<p>
-		<optional>---- </optional>LLVM Exceptions to the Apache 2.0 License<optional> ----</optional>
+		    <alt match="-*" name="titleDash1"/>
+		    LLVM Exceptions to the Apache 2.0 License
+		    <alt match="-*" name="titleDash2"/>
 		</p>
 	  </titleText>
       <p> As an exception, if, as a result of your compiling your source 


### PR DESCRIPTION
Use an `alt` instead of an `optional` because there's no legal significance to the number of dashes (if any) used to set off the header.

The `alt` is empty, because I see the dashes as header markup.  I'd much rather they not be part of our canonical HTML, and instead would rather use `<h1>` or other canonical HTML markup for “this is a header”.  We don't have “this is a header” markup in our XML schema yet, but I'd still rather not have these dashes be a part of the canonical HTML we display under spdx.org/licenses/.

Spun off from [here][1].

[1]: https://github.com/spdx/license-list-XML/pull/570#discussion_r158875572