### PR TITLE
Replacement for #551: New Exception: OpenJDK Assembly exception

### DIFF
--- a/src/exceptions/OpenJDK-assembly-exception-1.0.xml
+++ b/src/exceptions/OpenJDK-assembly-exception-1.0.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SPDXLicenseCollection xmlns="http://www.spdx.org/license">
+   <exception licenseId="OpenJDK-assembly-exception-1.0" name="OpenJDK Assembly exception 1.0">
+      <crossRefs>
+         <crossRef>http://openjdk.java.net/legal/assembly-exception.html
+         </crossRef>
+      </crossRefs>
+      <text>
+      <titleText>OpenJDK Assembly Exception</titleText>
+      <p>
+         The OpenJDK source code made available by Oracle America, Inc.
+         (Oracle) at openjdk.java.net ("OpenJDK Code") is distributed
+         under the terms of the GNU General Public License
+         &lt;http://www.gnu.org/copyleft/gpl.html&gt; version 2 only
+         ("GPL2"), with the following clarification and special
+         exception.
+      </p>
+
+      <list>
+         <item>
+            <p>Linking this OpenJDK Code statically or dynamically with
+               other code is making a combined work based on this
+               library. Thus, the terms and conditions of GPL2 cover the
+               whole combination.
+            </p>
+
+            <p>As a special exception, Oracle gives you permission to
+               link this OpenJDK Code with certain code licensed by
+               Oracle as indicated at
+               http://openjdk.java.net/legal/exception-modules-2007-05-08.html
+               ("Designated Exception Modules") to produce an
+               executable, regardless of the license terms of the
+               Designated Exception Modules, and to copy and distribute
+               the resulting executable under GPL2, provided that the
+               Designated Exception Modules continue to be governed by
+               the licenses under which they were offered by Oracle.
+            </p>
+         </item>
+      </list>
+
+      <p>As such, it allows licensees and sublicensees of Oracle's GPL2
+         OpenJDK Code to build an executable that includes those
+         portions of necessary code that Oracle could not provide under
+         GPL2 (or that Oracle has provided under GPL2 with the Classpath
+         exception). If you modify or add to the OpenJDK code, that new
+         GPL2 code may still be combined with Designated Exception
+         Modules if the new code is made subject to this exception by
+         its copyright holder.
+      </p>
+      </text>
+   </exception>
+</SPDXLicenseCollection>

--- a/test/simpleTestForGenerator/OpenJDK-assembly-exception-1.0.txt
+++ b/test/simpleTestForGenerator/OpenJDK-assembly-exception-1.0.txt
@@ -1,0 +1,31 @@
+The OpenJDK source code made available by Oracle America, Inc.
+(Oracle) at openjdk.java.net ("OpenJDK Code") is distributed
+under the terms of the GNU General Public License
+&lt;http://www.gnu.org/copyleft/gpl.html&gt; version 2 only
+("GPL2"), with the following clarification and special
+exception.
+
+Linking this OpenJDK Code statically or dynamically with
+other code is making a combined work based on this
+library. Thus, the terms and conditions of GPL2 cover the
+whole combination.
+
+As a special exception, Oracle gives you permission to
+link this OpenJDK Code with certain code licensed by
+Oracle as indicated at
+http://openjdk.java.net/legal/exception-modules-2007-05-08.html
+("Designated Exception Modules") to produce an
+executable, regardless of the license terms of the
+Designated Exception Modules, and to copy and distribute
+the resulting executable under GPL2, provided that the
+Designated Exception Modules continue to be governed by
+the licenses under which they were offered by Oracle.
+
+As such, it allows licensees and sublicensees of Oracle's GPL2
+OpenJDK Code to build an executable that includes those
+portions of necessary code that Oracle could not provide under
+GPL2 (or that Oracle has provided under GPL2 with the Classpath
+exception). If you modify or add to the OpenJDK code, that new
+GPL2 code may still be combined with Designated Exception
+Modules if the new code is made subject to this exception by
+its copyright holder.

--- a/test/simpleTestForGenerator/OpenJDK-assembly-exception-1.0.txt
+++ b/test/simpleTestForGenerator/OpenJDK-assembly-exception-1.0.txt
@@ -1,7 +1,7 @@
 The OpenJDK source code made available by Oracle America, Inc.
 (Oracle) at openjdk.java.net ("OpenJDK Code") is distributed
 under the terms of the GNU General Public License
-&lt;http://www.gnu.org/copyleft/gpl.html&gt; version 2 only
+<http://www.gnu.org/copyleft/gpl.html> version 2 only
 ("GPL2"), with the following clarification and special
 exception.
 


### PR DESCRIPTION
This PR is meant to fix the build errors from #551. I'm submitting it as a separate PR solely because my Github skills aren't good enough for me to know how to add on to the existing PR at #551...

The content of the XML file for the OpenJDK assembly exception in this PR is identical to #551.
I've also made the following changes:

- Changed the XML's filename to make "assembly" lowercase and to have version 1.0 in the filename, to mirror the licenseID in the XML.
- Added a test file