### PR TITLE
Nokia-Qt-exception-1.1: Fix doubled quote ("") typos

### DIFF
--- a/src/exceptions/Nokia-Qt-exception-1.1.xml
+++ b/src/exceptions/Nokia-Qt-exception-1.1.xml
@@ -10,8 +10,8 @@
          <p>Nokia Qt LGPL Exception version 1.1</p>
       </titleText>
       <p>As an additional permission to the GNU Lesser General Public
-       License version 2.1, the object code form of a ""work that
-       uses the Library"" may incorporate material from a header file
+       License version 2.1, the object code form of a "work that
+       uses the Library" may incorporate material from a header file
        that is part of the Library. You may distribute such object
        code under terms of your choice, provided that:</p>
       <list>

--- a/test/simpleTestForGenerator/Nokia-Qt-exception-1.1.txt
+++ b/test/simpleTestForGenerator/Nokia-Qt-exception-1.1.txt
@@ -1,6 +1,6 @@
 Nokia Qt LGPL Exception version 1.1
 
-As an additional permission to the GNU Lesser General Public License version 2.1, the object code form of a ""work that uses the Library"" may incorporate material from a header file that is part of the Library. You may distribute such object code under terms of your choice, provided that: 
+As an additional permission to the GNU Lesser General Public License version 2.1, the object code form of a "work that uses the Library" may incorporate material from a header file that is part of the Library. You may distribute such object code under terms of your choice, provided that:
  
      (i) the header files of the Library have not been modified; and  
      (ii) the incorporated material is limited to numerical parameters, data structure layouts, accessors, macros, inline functions and templates; and 


### PR DESCRIPTION
We've had these in this repository since the exception landed in e3555218 (#354), and they've been in license-list-data since the exception landed there in spdx/license-list-data@cec28dc7.  I haven't bothered with an `<alt>` tag because [the matching guidelines have][1]:

> 5.1.3 Guideline: Quotes Any variation of quotations (single, double, curly, etc.) should be considered equivalent.

That doesn't explicitly say that you can add/remove quotes in the general case.  And maybe that's intentional.  But if we treat the whole unit as a quote (going from quad-quotes to double-quotes) then this change should have no impact on matching.

In practice, I think it's unlikely that folks copied the exception with the quad-quotes.  And the upstream linked from our XML is pinned to a specific revision and only uses double-quotes.

[1]: https://spdx.org/spdx-license-list/matching-guidelines