### PR TITLE
Qt-LGPL-exception-1.1: Add new ID for Nokia-Qt-exception-1.1

### DIFF
--- a/src/exceptions/Nokia-Qt-exception-1.1.xml
+++ b/src/exceptions/Nokia-Qt-exception-1.1.xml
@@ -10,8 +10,8 @@
          <p>Nokia Qt LGPL Exception version 1.1</p>
       </titleText>
       <p>As an additional permission to the GNU Lesser General Public
-       License version 2.1, the object code form of a ""work that
-       uses the Library"" may incorporate material from a header file
+       License version 2.1, the object code form of a "work that
+       uses the Library" may incorporate material from a header file
        that is part of the Library. You may distribute such object
        code under terms of your choice, provided that:</p>
       <list>

--- a/src/exceptions/Qt-LGPL-exception-1.1.xml
+++ b/src/exceptions/Qt-LGPL-exception-1.1.xml
@@ -1,16 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <exception licenseId="Nokia-Qt-exception-1.1" name="Nokia Qt LGPL exception 1.1" isDeprecated="true" deprecatedVersion="3.1">
-      <obsoletedBys>
-         <obsoletedBy>Qt-LGPL-exception-1.1</obsoletedBy>
-      </obsoletedBys>
+   <exception licenseId="Qt-LGPL-exception-1.1" name="Qt LGPL exception 1.1" listVersionAdded="3.1">
       <crossRefs>
-         <crossRef>https://www.keepassx.org/dev/projects/keepassx/repository/revisions/b8dfb9cc4d5133e0f09cd7533d15a4f1c19a40f2/entry/LICENSE.NOKIA-LGPL-EXCEPTION</crossRef>
+         <crossRef>http://code.qt.io/cgit/qt/qtbase.git/tree/LGPL_EXCEPTION.txt</crossRef>
       </crossRefs>
-      <notes>DEPRECATED: Use Qt-LGPL-exception-1.1</notes>
+      <notes>Used with the LGPL-2.1, which is mentioned explicitly in the exception text.</notes>
     <text>
       <titleText>
-         <p>Nokia Qt LGPL Exception version 1.1</p>
+         <p><alt name="nokia" match="|Nokia |The Qt Company ">The Qt Company </alt>Qt LGPL Exception version 1.1</p>
       </titleText>
       <p>As an additional permission to the GNU Lesser General Public
        License version 2.1, the object code form of a "work that

--- a/src/exceptions/Qt-LGPL-exception-1.1.xml
+++ b/src/exceptions/Qt-LGPL-exception-1.1.xml
@@ -7,7 +7,7 @@
       <notes>Used with the LGPL-2.1, which is mentioned explicitly in the exception text.</notes>
     <text>
       <titleText>
-         <p><alt name="nokia" match="|Nokia |The Qt Company ">The Qt Company </alt>Qt LGPL Exception version 1.1</p>
+         <p><alt name="nokia" match="|Nokia|The Qt Company">The Qt Company</alt> Qt LGPL Exception version 1.1</p>
       </titleText>
       <p>As an additional permission to the GNU Lesser General Public
        License version 2.1, the object code form of a "work that

--- a/src/exceptions/Qt-LGPL-exception-1.1.xml
+++ b/src/exceptions/Qt-LGPL-exception-1.1.xml
@@ -7,7 +7,7 @@
       <notes>Used with the LGPL-2.1, which is mentioned explicitly in the exception text.</notes>
     <text>
       <titleText>
-         <p><alt name="nokia" match="|Nokia|The Qt Company">The Qt Company</alt> Qt LGPL Exception version 1.1</p>
+         <p><alt name="nokia" match="The Qt Company|Nokia|">The Qt Company</alt> Qt LGPL Exception version 1.1</p>
       </titleText>
       <p>As an additional permission to the GNU Lesser General Public
        License version 2.1, the object code form of a "work that

--- a/test/simpleTestForGenerator/Nokia-Qt-exception-1.1.txt
+++ b/test/simpleTestForGenerator/Nokia-Qt-exception-1.1.txt
@@ -1,6 +1,6 @@
 Nokia Qt LGPL Exception version 1.1
 
-As an additional permission to the GNU Lesser General Public License version 2.1, the object code form of a ""work that uses the Library"" may incorporate material from a header file that is part of the Library. You may distribute such object code under terms of your choice, provided that: 
+As an additional permission to the GNU Lesser General Public License version 2.1, the object code form of a "work that uses the Library" may incorporate material from a header file that is part of the Library. You may distribute such object code under terms of your choice, provided that:
  
      (i) the header files of the Library have not been modified; and  
      (ii) the incorporated material is limited to numerical parameters, data structure layouts, accessors, macros, inline functions and templates; and 

--- a/test/simpleTestForGenerator/Qt-LGPL-exception-1.1.txt
+++ b/test/simpleTestForGenerator/Qt-LGPL-exception-1.1.txt
@@ -1,0 +1,22 @@
+The Qt Company Qt LGPL Exception version 1.1
+
+As an additional permission to the GNU Lesser General Public License version
+2.1, the object code form of a "work that uses the Library" may incorporate
+material from a header file that is part of the Library.  You may distribute
+such object code under terms of your choice, provided that:
+    (i)   the header files of the Library have not been modified; and
+    (ii)  the incorporated material is limited to numerical parameters, data
+          structure layouts, accessors, macros, inline functions and
+          templates; and
+    (iii) you comply with the terms of Section 6 of the GNU Lesser General
+          Public License version 2.1.
+
+Moreover, you may apply this exception to a modified version of the Library,
+provided that such modification does not involve copying material from the
+Library into the modified Library's header files unless such material is
+limited to (i) numerical parameters; (ii) data structure layouts;
+(iii) accessors; and (iv) small macros, templates and inline functions of
+five lines or less in length.
+
+Furthermore, you are not required to apply this additional permission to a
+modified version of the Library.


### PR DESCRIPTION
And deprecate the old ID, which [had two problems][1]:

* Qt no longer belongs to Nokia, and they've changed the title upstream to reflect that.
* Qt has another exception for GPL3, and the old ID didn't mention the target license.

This commit adds the new identifier and deprecates the old one in its favor.

I've used Qt-LGPL-exception-1.1 instead of Kai's suggested Qt-exception-LGPL-1.1 to match the `{name}-{target}-exception-{version}` pattern suggested by the existing i2p-gpl-java-exception.

I've set an `<alt>` in the exception title so it will match the old “Nokia ” prefix, the current “The Qt Company ” prefix, or no prefix at all.  I've used “The Qt Company ” prefix in the test file to match the upstream text (the test is a copy/paste of the upstream text with trailing whitespace removed).

Builds on #626; review that first.  Someone with write access should label this “[new license/exception request][2]”.

CC @kkoehne.

[1]: https://lists.spdx.org/pipermail/spdx-legal/2018-March/002511.html
[2]: https://github.com/spdx/license-list-XML/labels/new%20license%2Fexception%20request