### PR TITLE
MIT-0: Add the license used for some AWS samples

### DIFF
--- a/src/MIT-0.xml
+++ b/src/MIT-0.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SPDXLicenseCollection xmlns="http://www.spdx.org/license">
+  <license isOsiApproved="true" licenseId="MIT-0" name="MIT No Attribution">
+    <crossRefs>
+      <crossRef>https://github.com/aws/mit-0</crossRef>
+      <crossRef>https://romanrm.net/mit-zero</crossRef>
+      <crossRef>https://github.com/awsdocs/aws-cloud9-user-guide/blob/master/LICENSE-SAMPLECODE</crossRef>
+    </crossRefs>
+    <notes>
+      This license is a modified version of the common MIT license,
+      with the attribution paragraph removed.
+    </notes>
+    <text>
+      <titleText>
+        <p><alt name="title" match="The MIT-Zero License|MIT No Attribution|">MIT No Attribution</alt></p>
+      </titleText>
+      <copyrightText>
+        <p>
+          Copyright <alt name="copyright" match="(c)|"/> <alt match=".+" name="copyright">&lt;YEARr&gt; &lt;COPYRIGHT HOLDER&gt;</alt>
+        </p>
+      </copyrightText>
+
+      <p>
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this
+        software and associated documentation files (the "Software"), to deal in the Software
+        without restriction, including without limitation the rights to use, copy, modify,
+        merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+        permit persons to whom the Software is furnished to do so.
+      </p>
+      <p>
+        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+        INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+        PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+        HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+        OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+        SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+      </p>
+    </text>
+  </license>
+</SPDXLicenseCollection>

--- a/test/simpleTestForGenerator/MIT-0.txt
+++ b/test/simpleTestForGenerator/MIT-0.txt
@@ -1,0 +1,16 @@
+MIT No Attribution
+
+Copyright <YEAR> <COPYRIGHT HOLDER>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this
+software and associated documentation files (the "Software"), to deal in the Software
+without restriction, including without limitation the rights to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
Previous discussion [here][1] and in #619.  The MIT-0 ID is from [the mailing list][1].

The “MIT No Attribution” title is from [the mailing list][1].  The “The MIT-Zero License” title is from [the mit-zero page][3] ([linked from the mit-0 repo][4]).  The empty-title case explicitly supports instances like [the AWS sample][5] which leave the title off.

The copyright line's optional “(c)” is for [the mit-zero page][3].  The “(c)” is also [in the vanilla MIT template][3.5].  The “(c)” is not part of our canonical template though, because it's not in [the mit-0 repo][6].

I have not included “. All Rights Reserved.” in the copyright template.  It is not in [the vanilla MIT][3.5], [the mit-zero page][3], or [the mit-0 repo][6].  [The AWS sample][5] includes it, possibly borrowing from BSD-2-Clause or similar (more on this in 85df23f80, #527).  The copyright regexp is broad enough to cover this text when it is included.

The test content is copy/pasted from [the mit-0 repo][6].

[1]: https://lists.spdx.org/pipermail/spdx-legal/2018-March/002532.html
[2]: https://github.com/spdx/license-list-XML/issues/619
[3]: https://romanrm.net/mit-zero
[3.5]: https://github.com/spdx/license-list-XML/blob/v3.0/src/MIT.xml#L11
[4]: https://github.com/aws/mit-0#see-also
[5]: https://github.com/awsdocs/aws-cloud9-user-guide/blob/master/LICENSE-SAMPLECODE
[6]: https://github.com/aws/mit-0#license-text