### PR TITLE
Update LLVM exception link to use the URL provided by exception originator

### DIFF
--- a/src/exceptions/LLVM-exception.xml
+++ b/src/exceptions/LLVM-exception.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <exception licenseId="LLVM-exception" name="LLVM Exception">
       <crossRefs>
-         <crossRef>http://lists.llvm.org/pipermail/llvm-dev/2017-August/116266.html</crossRef>
+         <crossRef>http://llvm.org/foundation/relicensing/LICENSE.txt</crossRef>
       </crossRefs>
       <notes>This exception was created specifically to be used with Apache-2.0</notes>
 	  <text>


### PR DESCRIPTION
This should replace the previous link which points to an email thread.

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>