### PR TITLE
EPL-2.0: Add a note recommending OR for Secondary Licenses

### DIFF
--- a/src/EPL-2.0.xml
+++ b/src/EPL-2.0.xml
@@ -7,10 +7,7 @@
 			<crossRef>https://www.opensource.org/licenses/EPL-2.0</crossRef>
 		</crossRefs>
     <notes>
-      <p>Secondary Licenses declared via Exhibit-A-style wording should be represented by the disjunctive OR in SPDX License Expressions.  For example, a header comment like:</p>
-      <p>This program and the accompanying materials are made available under the terms of the Eclipse Public License v. 2.0 which is available at https://www.eclipse.org/legal/epl-2.0.</p>
-      <p>This Source Code may also be made available under the following Secondary Licenses when the conditions for such availability set forth in the Eclipse Public License v. 2.0 are satisfied: GNU General Public License, version 2 with the GNU Classpath Exception which is available at https://www.gnu.org/software/classpath/license.html.</p>
-      <p>would be represented by EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0.</p>
+      <p>Secondary Licenses declared via Exhibit A should be represented using the disjunctive OR operator (See: SPDX spec, section on SPDX License Expressions and https://www.eclipse.org/legal/epl-2.0/faq.php for more info).</p>  
     </notes>
     <text>
 		<titleText>

--- a/src/EPL-2.0.xml
+++ b/src/EPL-2.0.xml
@@ -6,6 +6,12 @@
 			<crossRef>https://www.eclipse.org/legal/epl-2.0</crossRef>
 			<crossRef>https://www.opensource.org/licenses/EPL-2.0</crossRef>
 		</crossRefs>
+    <notes>
+      <p>Secondary Licenses declared via Exhibit-A-style wording should be represented by the disjunctive OR in SPDX License Expressions.  For example, a header comment like:</p>
+      <p>This program and the accompanying materials are made available under the terms of the Eclipse Public License v. 2.0 which is available at https://www.eclipse.org/legal/epl-2.0.</p>
+      <p>This Source Code may also be made available under the following Secondary Licenses when the conditions for such availability set forth in the Eclipse Public License v. 2.0 are satisfied: GNU General Public License, version 2 with the GNU Classpath Exception which is available at https://www.gnu.org/software/classpath/license.html.</p>
+      <p>would be represented by EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0.</p>
+    </notes>
     <text>
 		<titleText>
 			<p>Eclipse Public License - v 2.0</p>


### PR DESCRIPTION
Based on @waynebeaton's [comment][1]:

On Wed, Apr 18, 2018 at 11:05:31AM -0400, Wayne Beaton [wrote][1]:
> FWIW, it is the perspective the Eclipse Foundation that, from the point of view of a consumer, the notion of secondary license is effectively the same as dual licensing. We therefore encourage our projects to use the disjunctive OR when expressing licenses.
>
> For content that uses the EPL-2.0 with a GPL-2.0 + Classpath Exception, we'd expect to see a header along these lines:
>
> ```
> /********************************************************************************
>  * Copyright (c) {date} {owner}[ and others]
>  *
>  * This program and the accompanying materials are made available under the
>  * terms of the Eclipse Public License v. 2.0 which is available at
>  * http://www.eclipse.org/legal/epl-2.0.
>  *
>  * This Source Code may also be made available under the following Secondary
>  * Licenses when the conditions for such availability set forth in the Eclipse
>  * Public License v. 2.0 are satisfied: GNU General Public License, version 2
>  * with the GNU Classpath Exception which is available at
>  * https://www.gnu.org/software/classpath/license.html.
>  *
>  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
>  ********************************************************************************/
> ```
>
> Again, we think of this from the perspective of the consumer of the content.
>
> There's more in the EPL-2.0 FAQ:
>
> https://www.eclipse.org/legal/epl-2.0/faq.php#h.lgjcpvoq08a9

And from [that FAQ entry][2]:

> #### 2.3. Is EPL-2.0 with the Secondary License clause considered dual licensing?
>
> It is extremely close to dual licensing.  The EPL-2.0 is the only license, until such time as it is combined and distributed with a work under the Secondary License.  After such time, any recipient of the combined work can consider the content licensed under the Secondary License.  The original work remains under the EPL-2.0 and is never really dual-licensed.  Once a downstream adopter has received the content under the Secondary License, they can modify and further distribute it solely under the terms of the Secondary License.
>
> The EPL-2.0 file headers should remain on the source code content even if it has been made available under the Secondary License.

I'm really missing the ability to use block quotes or preformatted text inside `<notes>`, hopefully readers can tell that the middle two paragraphs in the note are the example header comment, while the first and last paragraphs are my discussion of that comment.

[1]: https://lists.spdx.org/pipermail/spdx-legal/2018-April/002560.html
[2]: https://www.eclipse.org/legal/epl-2.0/faq.php#h.lgjcpvoq08a9