### PR TITLE
remove old broken URL

### DIFF
--- a/src/AFL-2.0.xml
+++ b/src/AFL-2.0.xml
@@ -2,7 +2,6 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="AFL-2.0" name="Academic Free License v2.0">
       <crossRefs>
-         <crossRef>http://opensource.linux-mirror.org/licenses/afl-2.0.txt</crossRef>
          <crossRef>http://wayback.archive.org/web/20060924134533/http://www.opensource.org/licenses/afl-2.0.txt</crossRef>
       </crossRefs>
     <text>


### PR DESCRIPTION
we have wayback archive link now, so no need to have both broken link and wayback link
https://github.com/spdx/license-list-XML/issues/652