### PR TITLE
match philosophy or licenses in path of why-not-lgpl url

### DIFF
--- a/src/GPL-3.0+.xml
+++ b/src/GPL-3.0+.xml
@@ -588,7 +588,7 @@
          your program is a subroutine library, you may consider it more useful to permit linking proprietary
          applications with the library. If this is what you want to do, use the GNU Lesser General Public
          License instead of this License. But first, please read
-         &lt;http<optional>s</optional>://www.gnu.org/philosophy/why-not-lgpl.html&gt;.</p>
+         &lt;http<optional>s</optional>://www.gnu.org/<alt match="philosophy|licenses" name="philicenses">licenses</alt>/why-not-lgpl.html&gt;.</p>
       </optional>
     </text>
   </license>

--- a/src/GPL-3.0-only.xml
+++ b/src/GPL-3.0-only.xml
@@ -849,7 +849,7 @@
         linking proprietary applications with the library. If this
         is what you want to do, use the GNU Lesser General Public
 	License instead of this License. But first, please read
-	&lt;http<optional>s</optional>://www.gnu.org/philosophy/why-not-lgpl.html&gt;.
+	&lt;http<optional>s</optional>://www.gnu.org/<alt match="philosophy|licenses" name="philicenses">licenses</alt>/why-not-lgpl.html&gt;.
       </p>
     </optional>
     </text>

--- a/src/GPL-3.0-or-later.xml
+++ b/src/GPL-3.0-or-later.xml
@@ -830,7 +830,7 @@
         linking proprietary applications with the library. If this
         is what you want to do, use the GNU Lesser General Public
 	License instead of this License. But first, please read
-	&lt;http<optional>s</optional>://www.gnu.org/philosophy/why-not-lgpl.html&gt;.
+	&lt;http<optional>s</optional>://www.gnu.org/<alt match="philosophy|licenses" name="philicenses">licenses</alt>/why-not-lgpl.html&gt;.
       </p>
     </optional>
     </text>

--- a/src/GPL-3.0.xml
+++ b/src/GPL-3.0.xml
@@ -850,7 +850,7 @@
         linking proprietary applications with the library. If this
         is what you want to do, use the GNU Lesser General Public
 	License instead of this License. But first, please read
-	&lt;http<optional>s</optional>://www.gnu.org/philosophy/why-not-lgpl.html&gt;.
+	&lt;http<optional>s</optional>://www.gnu.org/<alt match="philosophy|licenses" name="philicenses">licenses</alt>/why-not-lgpl.html&gt;.
       </p>
     </optional>
     </text>


### PR DESCRIPTION
changed by publisher (FSF) between
http://web.archive.org/web/20170908053542/http://www.gnu.org/licenses/gpl-3.0.txt
and
http://web.archive.org/web/20170930072152/http://www.gnu.org/licenses/gpl-3.0.txt

noted by @ale5000-git at
https://github.com/github/choosealicense.com/pull/581#issuecomment-397477772