### PR TITLE
Add alt around the copyright text

### DIFF
--- a/src/MIT.xml
+++ b/src/MIT.xml
@@ -9,7 +9,9 @@
          <p>MIT License</p>
       </titleText>
       <copyrightText>
-         <p><alt match=".+" name="copyright">Copyright (c) &lt;year&gt; &lt;copyright holders&gt;</alt></p>
+         <p>Copyright (c) 
+		    <alt match=".+" name="copyright">&lt;year&gt; &lt;copyright holders&gt;</alt>
+	     </p>
       </copyrightText>
     
       <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software and

--- a/src/MIT.xml
+++ b/src/MIT.xml
@@ -9,7 +9,7 @@
          <p>MIT License</p>
       </titleText>
       <copyrightText>
-         <p>Copyright (c) &lt;year&gt; &lt;copyright holders&gt;</p>
+         <p><alt match=".+" name="copyright">Copyright (c) &lt;year&gt; &lt;copyright holders&gt;</alt></p>
       </copyrightText>
     
       <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software and


### PR DESCRIPTION
Signed-off-by: Gary O'Neall <gary@sourceauditor.com>

This would help anyone using the SPDX matching templates for most common MIT uses.