### PR TITLE
re-add old (stale) URL for Imlib2

### DIFF
--- a/src/Imlib2.xml
+++ b/src/Imlib2.xml
@@ -2,13 +2,14 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="false" licenseId="Imlib2" name="Imlib2 License">
       <crossRefs>
+         <crossRef>http://trac.enlightenment.org/e/browser/trunk/imlib2/COPYING</crossRef>
          <crossRef>https://git.enlightenment.org/legacy/imlib2.git/tree/COPYING</crossRef>
       </crossRefs>
     <text>
       <titleText>
          <p>Imlib2 License</p>
       </titleText>
-    
+
       <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
          associated documentation files (the "Software"), to deal in the Software without restriction,
          including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,


### PR DESCRIPTION
re-add old (stale) URL for imlib2, per #573 (implicit policy of retaining stale URLs)