### PR TITLE
add OCaml linking exception to LGPL

### DIFF
--- a/src/exceptions/OCaml-LGPL-linking-exception.xml
+++ b/src/exceptions/OCaml-LGPL-linking-exception.xml
@@ -16,24 +16,25 @@
               As a special exception to the GNU <alt name="libraryTypo"
               match="Library|Lesser">Lesser</alt> General Public License, you
               may link, statically or dynamically, a "work that uses <alt
-              name="linkedSoftwareName1" match="the OCaml Core System|opam">
-              the OCaml Core System</alt>with a publicly distributed version of
-              <alt name="linkedSoftwareName2"
-              match="the OCaml Core System|opam">the OCaml Core System</alt> to
-              produce an executable file containing portions of
+              name="linkedSoftwareName1"
+              match="the OCaml Core System|opam|the Library">the OCaml Core
+              System</alt>with a publicly distributed version of <alt
+              name="linkedSoftwareName2"
+              match="the OCaml Core System|opam|the Library">the OCaml Core
+              System</alt> to produce an executable file containing portions of
               <alt name="linkedSoftwareName3"
-              match="the OCaml Core System|opam">the OCaml Core System</alt>,
-              and distribute that executable file under terms of your choice,
-              without any of the additional requirements listed in clause 6 of
-              the GNU Lesser General Public License. By "a publicly distributed
-              version of <alt name="linkedSoftwareName4"
-              match="the OCaml Core System|opam">
-              the OCaml Core System</alt>", we mean either the unmodified <alt
-              name="linkedSoftwareName5" match="OCaml Core System|opam">
+              match="the OCaml Core System|opam|the Library">the OCaml Core
+              System</alt>, and distribute that executable file under terms of
+              your choice, without any of the additional requirements listed in
+              clause 6 of the GNU Lesser General Public License. By "a publicly
+              distributed version of <alt name="linkedSoftwareName4"
+              match="the OCaml Core System|opam|the Library">the OCaml Core
+              System</alt>", we mean either the unmodified <alt
+              name="linkedSoftwareName5" match="OCaml Core System|opam|Library">
               OCaml Core System</alt> as distributed by <alt name="distributor"
               match="INRIA|OCamlPro">INRIA</alt>, or a modified version of <alt
               name="linkedSoftwareName6"
-              match="the OCaml Core System|opam|the opam">
+              match="the OCaml Core System|opam|the opam|the Library">
               the OCaml Core System</alt> that is distributed under the
               conditions defined in clause 2 of the GNU Lesser General Public
               License. This exception does not however invalidate any other

--- a/src/exceptions/OCaml-LGPL-linking-exception.xml
+++ b/src/exceptions/OCaml-LGPL-linking-exception.xml
@@ -12,8 +12,8 @@
          <p>OCaml LGPL Linking Exception</p>
       </titleText>
       <p>
-        As a special exception to the GNU <alt name="lesser" match="Library|Lesser">Lesser</alt> 
-        General Public License, you may
+        As a special exception to the GNU <alt name="lesser" 
+        match="Library|Lesser">Lesser</alt> General Public License, you may 
         link, statically or dynamically, a "work that uses the OCaml Core System"
         with a publicly distributed version of the OCaml Core System to produce
         an executable file containing portions of the OCaml Core System, and

--- a/src/exceptions/OCaml-LGPL-linking-exception.xml
+++ b/src/exceptions/OCaml-LGPL-linking-exception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <exception licenseId="OCaml-LGPL-Linking-Exception" name="OCaml LGPL Linking Exception">
+   <exception licenseId="OCaml-LGPL-Linking-Exception" name="OCaml LGPL Linking Exception" listVersionAdded="TODO">
       <crossRefs>
          <crossRef>https://caml.inria.fr/ocaml/license.en.html</crossRef>
       </crossRefs>

--- a/src/exceptions/OCaml-LGPL-linking-exception.xml
+++ b/src/exceptions/OCaml-LGPL-linking-exception.xml
@@ -12,13 +12,8 @@
          <p>OCaml LGPL Linking Exception</p>
       </titleText>
       <p>
-        In the following, "the OCaml Core System" refers to all files marked
-        "Copyright INRIA" in this distribution.
-
-        The OCaml Core System is distributed under the terms of the GNU Lesser
-        General Public License (LGPL) version 2.1 (included below).
-
-        As a special exception to the GNU Lesser General Public License, you may
+        As a special exception to the GNU <alt name="lesser" match="Library|Lesser">Lesser</alt> 
+        General Public License, you may
         link, statically or dynamically, a "work that uses the OCaml Core System"
         with a publicly distributed version of the OCaml Core System to produce
         an executable file containing portions of the OCaml Core System, and

--- a/src/exceptions/OCaml-LGPL-linking-exception.xml
+++ b/src/exceptions/OCaml-LGPL-linking-exception.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SPDXLicenseCollection xmlns="http://www.spdx.org/license">
+   <exception licenseId="OCaml-LGPL-Linking-Exception" name="OCaml LGPL Linking Exception">
+      <crossRefs>
+         <crossRef>https://caml.inria.fr/ocaml/license.en.html</crossRef>
+      </crossRefs>
+      <notes>
+        Adopted by OCaml core in 2001 here: https://github.com/ocaml/ocaml/commit/02ef950033b81fe371759f024faa55f361ba83a6#diff-9879d6db96fd29134fc802214163b95a (git-svn-id: http://caml.inria.fr/svn/ocaml/trunk@4146 f963ae5c-01c2-4b8c-9fe0-0dff7051ff02)
+      </notes>
+    <text>
+      <titleText>
+         <p>OCaml LGPL Linking Exception</p>
+      </titleText>
+      <p>
+        In the following, "the OCaml Core System" refers to all files marked
+        "Copyright INRIA" in this distribution.
+
+        The OCaml Core System is distributed under the terms of the GNU Lesser
+        General Public License (LGPL) version 2.1 (included below).
+
+        As a special exception to the GNU Lesser General Public License, you may
+        link, statically or dynamically, a "work that uses the OCaml Core System"
+        with a publicly distributed version of the OCaml Core System to produce
+        an executable file containing portions of the OCaml Core System, and
+        distribute that executable file under terms of your choice, without any
+        of the additional requirements listed in clause 6 of the GNU Lesser
+        General Public License. By "a publicly distributed version of the OCaml
+        Core System", we mean either the unmodified OCaml Core System as
+        distributed by INRIA, or a modified version of the OCaml Core System
+        that is distributed under the conditions defined in clause 2 of the GNU
+        Lesser General Public License. This exception does not however
+        invalidate any other reasons why the executable file might be covered
+        by the GNU Lesser General Public License.
+      </p>
+    </text>
+  </exception>
+</SPDXLicenseCollection>

--- a/src/exceptions/OCaml-LGPL-linking-exception.xml
+++ b/src/exceptions/OCaml-LGPL-linking-exception.xml
@@ -1,32 +1,45 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <exception licenseId="OCaml-LGPL-Linking-Exception" name="OCaml LGPL Linking Exception" listVersionAdded="TODO">
-      <crossRefs>
-         <crossRef>https://caml.inria.fr/ocaml/license.en.html</crossRef>
-      </crossRefs>
-      <notes>
+    <exception licenseId="OCaml-LGPL-Linking-Exception" name="OCaml LGPL Linking Exception" listVersionAdded="3.3">
+        <crossRefs>
+            <crossRef>https://caml.inria.fr/ocaml/license.en.html</crossRef>
+        </crossRefs>
+        <notes>
         Adopted by OCaml core in 2001 here: https://github.com/ocaml/ocaml/commit/02ef950033b81fe371759f024faa55f361ba83a6#diff-9879d6db96fd29134fc802214163b95a (git-svn-id: http://caml.inria.fr/svn/ocaml/trunk@4146 f963ae5c-01c2-4b8c-9fe0-0dff7051ff02)
-      </notes>
-    <text>
-      <titleText>
-         <p>OCaml LGPL Linking Exception</p>
-      </titleText>
-      <p>
-        As a special exception to the GNU <alt name="lesser" 
-        match="Library|Lesser">Lesser</alt> General Public License, you may 
-        link, statically or dynamically, a "work that uses the OCaml Core System"
-        with a publicly distributed version of the OCaml Core System to produce
-        an executable file containing portions of the OCaml Core System, and
-        distribute that executable file under terms of your choice, without any
-        of the additional requirements listed in clause 6 of the GNU Lesser
-        General Public License. By "a publicly distributed version of the OCaml
-        Core System", we mean either the unmodified OCaml Core System as
-        distributed by INRIA, or a modified version of the OCaml Core System
-        that is distributed under the conditions defined in clause 2 of the GNU
-        Lesser General Public License. This exception does not however
-        invalidate any other reasons why the executable file might be covered
-        by the GNU Lesser General Public License.
-      </p>
-    </text>
-  </exception>
+        LGPL clause typo (was: 3; intended:2; fixed-to:2) fixed in 2007 here: https://github.com/ocaml/ocaml/commit/2d26308ad4d34ea0c00e44db62c4c24c7031c78c#diff-9879d6db96fd29134fc802214163b95a
+        </notes>
+        <text>
+            <titleText>
+              <p>OCaml LGPL Linking Exception</p>
+            </titleText>
+            <p>
+              As a special exception to the GNU <alt name="libraryTypo"
+              match="Library|Lesser">Lesser</alt> General Public License, you
+              may link, statically or dynamically, a "work that uses <alt
+              name="linkedSoftwareName1" match="the OCaml Core System|opam">
+              the OCaml Core System</alt>with a publicly distributed version of
+              <alt name="linkedSoftwareName2"
+              match="the OCaml Core System|opam">the OCaml Core System</alt> to
+              produce an executable file containing portions of
+              <alt name="linkedSoftwareName3"
+              match="the OCaml Core System|opam">the OCaml Core System</alt>,
+              and distribute that executable file under terms of your choice,
+              without any of the additional requirements listed in clause 6 of
+              the GNU Lesser General Public License. By "a publicly distributed
+              version of <alt name="linkedSoftwareName4"
+              match="the OCaml Core System|opam">
+              the OCaml Core System</alt>", we mean either the unmodified <alt
+              name="linkedSoftwareName5" match="OCaml Core System|opam">
+              OCaml Core System</alt> as distributed by <alt name="distributor"
+              match="INRIA|OCamlPro">INRIA</alt>, or a modified version of <alt
+              name="linkedSoftwareName6"
+              match="the OCaml Core System|opam|the opam">
+              the OCaml Core System</alt> that is distributed under the
+              conditions defined in clause 2 of the GNU Lesser General Public
+              License. This exception does not however invalidate any other
+              reasons why the executable file might be covered by the GNU Lesser
+              General Public License.
+            </p>
+        </text>
+    </exception>
 </SPDXLicenseCollection>

--- a/test/simpleTestForGenerator/OCaml-LGPL-linking-exception.txt
+++ b/test/simpleTestForGenerator/OCaml-LGPL-linking-exception.txt
@@ -1,0 +1,5 @@
+In the following, "the OCaml Core System" refers to all files marked "Copyright INRIA" in this distribution.
+
+The OCaml Core System is distributed under the terms of the GNU Lesser General Public License (LGPL) version 2.1 (included below).
+
+As a special exception to the GNU Lesser General Public License, you may link, statically or dynamically, a "work that uses the OCaml Core System" with a publicly distributed version of the OCaml Core System to produce an executable file containing portions of the OCaml Core System, and distribute that executable file under terms of your choice, without any of the additional requirements listed in clause 6 of the GNU Lesser General Public License. By "a publicly distributed version of the OCaml Core System", we mean either the unmodified OCaml Core System as distributed by INRIA, or a modified version of the OCaml Core System that is distributed under the conditions defined in clause 2 of the GNU Lesser General Public License. This exception does not however invalidate any other reasons why the executable file might be covered by the GNU Lesser General Public License.


### PR DESCRIPTION
add OCaml linking exception to LGPL to address #649 

Note: Legal team still need to officially decide whether to add this to the exceptions list.