### PR TITLE
ODbL-1.0: Remove ## header markup from canonical text

### DIFF
--- a/src/ODbL-1.0.xml
+++ b/src/ODbL-1.0.xml
@@ -7,11 +7,11 @@
       </crossRefs>
     <text>
       <titleText>
-	     <optional>##</optional>
+        <alt name="header1" match="#*"/>
          <p>ODC Open Database License (ODbL)</p>
       </titleText>
       <optional>
-	     <optional>###</optional>
+        <alt name="header2" match="#*"/>
          <p>Preamble</p>
          <p>The Open Database License (ODbL) is a license agreement intended to allow users to freely share, modify,
          and use this Database while maintaining this same freedom for others. Many databases are covered by


### PR DESCRIPTION
This markup makes sense in plain-text renderings to denote headers.  But HTML has other ways to represent headers (`<h1>`, etc.), as seen [in the canonical upstream source][1].  This comment removes those entries from the canonical text (which we will eventually render as HTML at [2]), while still allowing us to match [upstream's canonical plain-text version][3].

Previous discussion [here][4].  There's also a precedent for this sort of thing in #429 and #623.

[1]: https://opendatacommons.org/licenses/odbl/1.0/
[2]: https://spdx.org/licenses/ODbL-1.0.html
[3]: https://opendatacommons.org/files/2018/02/odbl-10.txt
[4]: https://github.com/spdx/license-list-XML/pull/656#discussion_r197598522