### PR TITLE
MIT: Remove tab indents

### DIFF
--- a/src/MIT.xml
+++ b/src/MIT.xml
@@ -9,9 +9,9 @@
          <p>MIT License</p>
       </titleText>
       <copyrightText>
-         <p>Copyright (c) 
-		    <alt match=".+" name="copyright">&lt;year&gt; &lt;copyright holders&gt;</alt>
-	     </p>
+         <p>Copyright (c)
+           <alt match=".+" name="copyright">&lt;year&gt; &lt;copyright holders&gt;</alt>
+         </p>
       </copyrightText>
     
       <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software and


### PR DESCRIPTION
And also remove a trailing space.  These were recently added in ab0d06aa (#657), before which the MIT source contained no tabs at all.