### PR TITLE
Remove UPL-1.0 duplicate titleText

### DIFF
--- a/src/UPL-1.0.xml
+++ b/src/UPL-1.0.xml
@@ -6,9 +6,6 @@
          <crossRef>http://opensource.org/licenses/UPL</crossRef>
       </crossRefs>
     <text>
-      <titleText>
-         <p>The Universal Permissive License (UPL), Version 1.0</p>
-      </titleText>
       <copyrightText>
          <p>Copyright (c) [year] [copyright holders]</p>
       </copyrightText>

--- a/test/simpleTestForGenerator/UPL-1.0.txt
+++ b/test/simpleTestForGenerator/UPL-1.0.txt
@@ -1,5 +1,3 @@
-The Universal Permissive License (UPL), Version 1.0
-
 Copyright (c) [year] [copyright holders]
 
 The Universal Permissive License (UPL), Version 1.0


### PR DESCRIPTION
I realize titleText is optional, so it doesn't hurt matching to have arbitrary titleTexts, but it looks silly eg at https://spdx.org/licenses/UPL-1.0.html and doesn't reflect actual use eg 

  - https://github.com/oracle/weblogic-kubernetes-operator/blob/master/LICENSE
  - https://github.com/oracle/docker-images/blob/master/LICENSE
  - https://github.com/oracle/vagrant-boxes/blob/master/LICENSE