### PR TITLE
OCaml-LGPL-linking-exception: fix errors and case in ID

### DIFF
--- a/src/exceptions/OCaml-LGPL-linking-exception.xml
+++ b/src/exceptions/OCaml-LGPL-linking-exception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-    <exception licenseId="OCaml-LGPL-Linking-Exception" name="OCaml LGPL Linking Exception" listVersionAdded="3.3">
+    <exception licenseId="OCaml-LGPL-linking-exception" name="OCaml LGPL Linking Exception" listVersionAdded="3.3">
         <crossRefs>
             <crossRef>https://caml.inria.fr/ocaml/license.en.html</crossRef>
         </crossRefs>
@@ -18,7 +18,7 @@
               may link, statically or dynamically, a "work that uses <alt
               name="linkedSoftwareName1"
               match="the OCaml Core System|opam|the Library">the OCaml Core
-              System</alt>with a publicly distributed version of <alt
+              System</alt>" with a publicly distributed version of <alt
               name="linkedSoftwareName2"
               match="the OCaml Core System|opam|the Library">the OCaml Core
               System</alt> to produce an executable file containing portions of

--- a/test/simpleTestForGenerator/OCaml-LGPL-linking-exception.txt
+++ b/test/simpleTestForGenerator/OCaml-LGPL-linking-exception.txt
@@ -1,5 +1,1 @@
-In the following, "the OCaml Core System" refers to all files marked "Copyright INRIA" in this distribution.
-
-The OCaml Core System is distributed under the terms of the GNU Lesser General Public License (LGPL) version 2.1 (included below).
-
 As a special exception to the GNU Lesser General Public License, you may link, statically or dynamically, a "work that uses the OCaml Core System" with a publicly distributed version of the OCaml Core System to produce an executable file containing portions of the OCaml Core System, and distribute that executable file under terms of your choice, without any of the additional requirements listed in clause 6 of the GNU Lesser General Public License. By "a publicly distributed version of the OCaml Core System", we mean either the unmodified OCaml Core System as distributed by INRIA, or a modified version of the OCaml Core System that is distributed under the conditions defined in clause 2 of the GNU Lesser General Public License. This exception does not however invalidate any other reasons why the executable file might be covered by the GNU Lesser General Public License.


### PR DESCRIPTION
Fixes errors in test for OCaml-LGPL-linking-exception - removes extraneous text and inserts a missing quote mark + space. 
Also changes capitalization of license ID to match filename (and to match capitalization format for other exceptions' IDs).

Signed-off-by: Steve Winslow <swinslow@gmail.com>