### PR TITLE
Fix URL for OSL-3.0

### DIFF
--- a/src/OSL-3.0.xml
+++ b/src/OSL-3.0.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="OSL-3.0" name="Open Software License 3.0">
       <crossRefs>
-         <crossRef>http://www.rosenlaw.com/OSL3.0.htm</crossRef>
+         <crossRef>https://web.archive.org/web/20120101081418/http://rosenlaw.com:80/OSL3.0.htm</crossRef>
          <crossRef>http://www.opensource.org/licenses/OSL-3.0</crossRef>
       </crossRefs>
     <text>


### PR DESCRIPTION
The URL to the canonical OSL-3.0 text is a dead link, so I changed it to a working Internet Archive URL (in line with other OSL-* versions).