### PR TITLE
Correct OSI approval status

### DIFF
--- a/src/0BSD.xml
+++ b/src/0BSD.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isOsiApproved="false" licenseId="0BSD" name="BSD Zero Clause License">
+   <license isOsiApproved="true" licenseId="0BSD" name="BSD Zero Clause License">
       <crossRefs>
          <crossRef>http://landley.net/toybox/license.html</crossRef>
       </crossRefs>


### PR DESCRIPTION
The license associated with SPDX short identifier [0BSD](https://spdx.org/licenses/0BSD.html) has actually been OSI-approved since 2015. 