### PR TITLE
added new exception GPL-CC-1.0.xml

### DIFF
--- a/src/exceptions/GPL-CC-1.0.xml
+++ b/src/exceptions/GPL-CC-1.0.xml
@@ -2,11 +2,11 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
   <exception licenseId="GPL-CC-1.0" name="GPL Cooperation Commitment 1.0">
     <crossRefs>
-      <crossRef>https://gplcc.github.io/</crossRef>
+      <crossRef>https://github.com/gplcc/gplcc/blob/master/Project/COMMITMENT</crossRef>
+	    <crossRef>https://gplcc.github.io/gplcc/Project/README-PROJECT.html</crossRef> 	
     </crossRefs>
     <notes>
-      Single exception covering three variants:
-      Individual, Company, and Project.
+      This is the GPL Cooperation Commitment for projects. It is distinct from the GPL Cooperation Commitment for companies or individuals in that it applies at the project level for all contributions going forward as of the date it is adopted. 
     </notes>
     <text>
       <titleText>

--- a/src/exceptions/GPL-CC-1.0.xml
+++ b/src/exceptions/GPL-CC-1.0.xml
@@ -8,94 +8,96 @@
       Single exception covering three variants:
       Individual, Company, and Project.
     </notes>
-    <titleText>
+    <text>
+      <titleText>
+	<optional>
+	<p>
+	  GPL Cooperation Commitment Version 1.0
+	</p>
+	</optional>
+      </titleText>
+      <p>
+	<optional>Solely for any software for which I personally own
+	copyright that is licensed under a Covered License,</optional>
+	<alt name="before" match="before|Before">before</alt>
+	filing or continuing to prosecute any legal proceeding or claim
+	(other than a Defensive Action) arising from termination of a
+	Covered License,<alt name="subject" match="I|we|.*">we</alt>
+	commit<optional>s</optional>
+	to extend to the person or entity ("you") accused of violating
+	the Covered License the following provisions regarding cure and
+	reinstatement, taken from GPL version 3. As used here, the term
+	"this License" refers to the specific Covered License being enforced.
+      </p>
+      <p>
+	<optional>"</optional>However,
+	if you cease all violation of this License, then your
+	license from a particular copyright holder is reinstated (a)
+	provisionally, unless and until the copyright holder explicitly
+	and finally terminates your license, and (b) permanently, if
+	the copyright holder fails to notify you of the violation by
+	some reasonable means prior to 60 days after the cessation.
+      </p>
+      <p>
+	Moreover, your license from a particular copyright holder is
+	reinstated permanently if the copyright holder notifies you of
+	the violation by some reasonable means, this is the first time you
+	have received notice of violation of this License (for any work)
+	from that copyright holder, and you cure the violation prior to
+	30 days after your receipt of the notice.<optional>"</optional>
+      </p>
+      <p>
+	<alt name="subject" match="I|We|.*">We</alt>
+	intend<optional>s</optional>
+	this Commitment to be irrevocable, and binding and enforceable
+	against <alt name="object" match="me|us|.*">us</alt>
+	and assignees of or successors to
+	<alt name="possessive" match="my|our|.*">our</alt>
+	copyrights.
+      </p>
       <optional>
       <p>
-        GPL Cooperation Commitment Version 1.0
+	<alt name="subject" match=".*">COMPANY</alt>
+	may modify this Commitment by publishing a new
+	edition on this page or a successor location.
       </p>
       </optional>
-    </titleText>
-    <p>
-      <optional>Solely for any software for which I personally own
-      copyright that is licensed under a Covered License,</optional>
-      <alt name="before" match="before|Before">before</alt>
-      filing or continuing to prosecute any legal proceeding or claim
-      (other than a Defensive Action) arising from termination of a
-      Covered License,<alt name="subject" match="I|we|.*">we</alt>
-      commit<optional>s</optional>
-      to extend to the person or entity ("you") accused of violating
-      the Covered License the following provisions regarding cure and
-      reinstatement, taken from GPL version 3. As used here, the term
-      "this License" refers to the specific Covered License being enforced.
-    </p>
-    <p>
-      <optional>"</optional>However,
-      if you cease all violation of this License, then your
-      license from a particular copyright holder is reinstated (a)
-      provisionally, unless and until the copyright holder explicitly
-      and finally terminates your license, and (b) permanently, if
-      the copyright holder fails to notify you of the violation by
-      some reasonable means prior to 60 days after the cessation.
-    </p>
-    <p>
-      Moreover, your license from a particular copyright holder is
-      reinstated permanently if the copyright holder notifies you of
-      the violation by some reasonable means, this is the first time you
-      have received notice of violation of this License (for any work)
-      from that copyright holder, and you cure the violation prior to
-      30 days after your receipt of the notice.<optional>"</optional>
-    </p>
-    <p>
-      <alt name="subject" match="I|We|.*">We</alt>
-      intend<optional>s</optional>
-      this Commitment to be irrevocable, and binding and enforceable
-      against <alt name="object" match="me|us|.*">us</alt>
-      and assignees of or successors to
-      <alt name="possessive" match="my|our|.*">our</alt>
-      copyrights.
-    </p>
-    <optional>
-    <p>
-      <alt name="subject" match=".*">COMPANY</alt>
-      may modify this Commitment by publishing a new
-      edition on this page or a successor location.
-    </p>
-    </optional>
-    <p>
-      Definitions<optional>:</optional>
-    </p>
-    <p>
-      "Covered License" means the GNU General Public License, version
-      2 (GPLv2), the GNU Lesser General Public License, version 2.1
-      (LGPLv2.1), or the GNU Library General Public License, version
-      2 (LGPLv2), all as published by the Free Software Foundation.
-    </p>
-    <p>
-      "Defensive Action" means a legal proceeding or claim
-      that<alt name="subject" match="I|We|.*">We</alt>
-      bring<optional>s</optional>
-      against you in response to a prior proceeding
-      or claim initiated by you or your affiliate.
-    </p>
-    <optional>
-    <p>
-      "<alt name="subject" match=".*">COMPANY</alt>"
-      means
-      <alt name="subject" match=".*">COMPANY</alt>
-      and its subsidiaries.
-    </p>
-    </optional>
-    <optional>
-    <p>
-      "We" means each contributor to this repository as of the date of
-      inclusion of this file, including subsidiaries of a corporate contributor.
-    </p>
-    </optional>
-    <optional>
-    <p>
-      This work is available under a Creative Commons Attribution-ShareAlike 4.0
-      International license (https://creativecommons.org/licenses/by-sa/4.0/).
-    </p>
-    </optional>
+      <p>
+	Definitions<optional>:</optional>
+      </p>
+      <p>
+	"Covered License" means the GNU General Public License, version
+	2 (GPLv2), the GNU Lesser General Public License, version 2.1
+	(LGPLv2.1), or the GNU Library General Public License, version
+	2 (LGPLv2), all as published by the Free Software Foundation.
+      </p>
+      <p>
+	"Defensive Action" means a legal proceeding or claim
+	that<alt name="subject" match="I|We|.*">We</alt>
+	bring<optional>s</optional>
+	against you in response to a prior proceeding
+	or claim initiated by you or your affiliate.
+      </p>
+      <optional>
+      <p>
+	"<alt name="subject" match=".*">COMPANY</alt>"
+	means
+	<alt name="subject" match=".*">COMPANY</alt>
+	and its subsidiaries.
+      </p>
+      </optional>
+      <optional>
+      <p>
+	"We" means each contributor to this repository as of the date of
+	inclusion of this file, including subsidiaries of a corporate contributor.
+      </p>
+      </optional>
+      <optional>
+      <p>
+	This work is available under a Creative Commons Attribution-ShareAlike 4.0
+	International license (https://creativecommons.org/licenses/by-sa/4.0/).
+      </p>
+      </optional>
+    </text>
   </exception>
 </SPDXLicenseCollection>

--- a/src/exceptions/GPL-CC-1.0.xml
+++ b/src/exceptions/GPL-CC-1.0.xml
@@ -17,26 +17,21 @@
 	</optional>
       </titleText>
       <p>
-	<optional>Solely for any software for which I personally own
-	copyright that is licensed under a Covered License,</optional>
-	<alt name="before" match="before|Before">before</alt>
-	filing or continuing to prosecute any legal proceeding or claim
-	(other than a Defensive Action) arising from termination of a
-	Covered License,<alt name="subject" match="I|we|.*">we</alt>
-	commit<optional>s</optional>
-	to extend to the person or entity ("you") accused of violating
-	the Covered License the following provisions regarding cure and
-	reinstatement, taken from GPL version 3. As used here, the term
-	"this License" refers to the specific Covered License being enforced.
+	Before filing or continuing to prosecute any legal proceeding or claim
+	(other than a Defensive Action) arising from termination of a Covered
+	License, we commit to extend to the person or entity ('you') accused
+	of violating the Covered License the following provisions regarding
+	cure and reinstatement, taken from GPL version 3. As used here, the
+	term 'this License' refers to the specific Covered License being
+	enforced.
       </p>
       <p>
-	<optional>"</optional>However,
-	if you cease all violation of this License, then your
-	license from a particular copyright holder is reinstated (a)
-	provisionally, unless and until the copyright holder explicitly
-	and finally terminates your license, and (b) permanently, if
-	the copyright holder fails to notify you of the violation by
-	some reasonable means prior to 60 days after the cessation.
+	However, if you cease all violation of this License, then your
+    	license from a particular copyright holder is reinstated (a)
+    	provisionally, unless and until the copyright holder explicitly
+   	and finally terminates your license, and (b) permanently, if the
+   	copyright holder fails to notify you of the violation by some
+    	reasonable means prior to 60 days after the cessation.
       </p>
       <p>
 	Moreover, your license from a particular copyright holder is
@@ -44,24 +39,13 @@
 	the violation by some reasonable means, this is the first time you
 	have received notice of violation of this License (for any work)
 	from that copyright holder, and you cure the violation prior to
-	30 days after your receipt of the notice.<optional>"</optional>
+	30 days after your receipt of the notice.
       </p>
       <p>
-	<alt name="subject" match="I|We|.*">We</alt>
-	intend<optional>s</optional>
-	this Commitment to be irrevocable, and binding and enforceable
-	against <alt name="object" match="me|us|.*">us</alt>
-	and assignees of or successors to
-	<alt name="possessive" match="my|our|.*">our</alt>
+	We intend this Commitment to be irrevocable, and binding and
+	enforceable against us and assignees of or successors to our
 	copyrights.
       </p>
-      <optional>
-      <p>
-	<alt name="subject" match=".*">COMPANY</alt>
-	may modify this Commitment by publishing a new
-	edition on this page or a successor location.
-      </p>
-      </optional>
       <p>
 	Definitions<optional>:</optional>
       </p>
@@ -73,25 +57,13 @@
       </p>
       <p>
 	"Defensive Action" means a legal proceeding or claim
-	that<alt name="subject" match="I|We|.*">We</alt>
-	bring<optional>s</optional>
-	against you in response to a prior proceeding
+	that We bring against you in response to a prior proceeding
 	or claim initiated by you or your affiliate.
       </p>
-      <optional>
-      <p>
-	"<alt name="subject" match=".*">COMPANY</alt>"
-	means
-	<alt name="subject" match=".*">COMPANY</alt>
-	and its subsidiaries.
-      </p>
-      </optional>
-      <optional>
       <p>
 	"We" means each contributor to this repository as of the date of
 	inclusion of this file, including subsidiaries of a corporate contributor.
       </p>
-      </optional>
       <optional>
       <p>
 	This work is available under a Creative Commons Attribution-ShareAlike 4.0

--- a/src/exceptions/GPL-CC-1.0.xml
+++ b/src/exceptions/GPL-CC-1.0.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SPDXLicenseCollection xmlns="http://www.spdx.org/license">
+  <exception licenseId="GPL-CC-1.0" name="GPL Cooperation Commitment 1.0">
+    <crossRefs>
+      <crossRef>https://gplcc.github.io/</crossRef>
+    </crossRefs>
+    <notes>
+      Single exception covering three variants:
+      Individual, Company, and Project.
+    </notes>
+    <titleText>
+      <optional>
+      <p>
+        GPL Cooperation Commitment Version 1.0
+      </p>
+      </optional>
+    </titleText>
+    <p>
+      <optional>Solely for any software for which I personally own
+      copyright that is licensed under a Covered License,</optional>
+      <alt name="before" match="before|Before">before</alt>
+      filing or continuing to prosecute any legal proceeding or claim
+      (other than a Defensive Action) arising from termination of a
+      Covered License,<alt name="subject" match="I|we|.*">we</alt>
+      commit<optional>s</optional>
+      to extend to the person or entity ("you") accused of violating
+      the Covered License the following provisions regarding cure and
+      reinstatement, taken from GPL version 3. As used here, the term
+      "this License" refers to the specific Covered License being enforced.
+    </p>
+    <p>
+      <optional>"</optional>However,
+      if you cease all violation of this License, then your
+      license from a particular copyright holder is reinstated (a)
+      provisionally, unless and until the copyright holder explicitly
+      and finally terminates your license, and (b) permanently, if
+      the copyright holder fails to notify you of the violation by
+      some reasonable means prior to 60 days after the cessation.
+    </p>
+    <p>
+      Moreover, your license from a particular copyright holder is
+      reinstated permanently if the copyright holder notifies you of
+      the violation by some reasonable means, this is the first time you
+      have received notice of violation of this License (for any work)
+      from that copyright holder, and you cure the violation prior to
+      30 days after your receipt of the notice.<optional>"</optional>
+    </p>
+    <p>
+      <alt name="subject" match="I|We|.*">We</alt>
+      intend<optional>s</optional>
+      this Commitment to be irrevocable, and binding and enforceable
+      against <alt name="object" match="me|us|.*">us</alt>
+      and assignees of or successors to
+      <alt name="possessive" match="my|our|.*">our</alt>
+      copyrights.
+    </p>
+    <optional>
+    <p>
+      <alt name="subject" match=".*">COMPANY</alt>
+      may modify this Commitment by publishing a new
+      edition on this page or a successor location.
+    </p>
+    </optional>
+    <p>
+      Definitions<optional>:</optional>
+    </p>
+    <p>
+      "Covered License" means the GNU General Public License, version
+      2 (GPLv2), the GNU Lesser General Public License, version 2.1
+      (LGPLv2.1), or the GNU Library General Public License, version
+      2 (LGPLv2), all as published by the Free Software Foundation.
+    </p>
+    <p>
+      "Defensive Action" means a legal proceeding or claim
+      that<alt name="subject" match="I|We|.*">We</alt>
+      bring<optional>s</optional>
+      against you in response to a prior proceeding
+      or claim initiated by you or your affiliate.
+    </p>
+    <optional>
+    <p>
+      "<alt name="subject" match=".*">COMPANY</alt>"
+      means
+      <alt name="subject" match=".*">COMPANY</alt>
+      and its subsidiaries.
+    </p>
+    </optional>
+    <optional>
+    <p>
+      "We" means each contributor to this repository as of the date of
+      inclusion of this file, including subsidiaries of a corporate contributor.
+    </p>
+    </optional>
+    <optional>
+    <p>
+      This work is available under a Creative Commons Attribution-ShareAlike 4.0
+      International license (https://creativecommons.org/licenses/by-sa/4.0/).
+    </p>
+    </optional>
+  </exception>
+</SPDXLicenseCollection>

--- a/test/simpleTestForGenerator/GPL-CC-1.0.txt
+++ b/test/simpleTestForGenerator/GPL-CC-1.0.txt
@@ -1,0 +1,47 @@
+GPL Cooperation Commitment
+Version 1.0
+
+Before filing or continuing to prosecute any legal proceeding or claim
+(other than a Defensive Action) arising from termination of a Covered
+License, we commit to extend to the person or entity ('you') accused
+of violating the Covered License the following provisions regarding
+cure and reinstatement, taken from GPL version 3. As used here, the
+term 'this License' refers to the specific Covered License being
+enforced.
+
+    However, if you cease all violation of this License, then your
+    license from a particular copyright holder is reinstated (a)
+    provisionally, unless and until the copyright holder explicitly
+    and finally terminates your license, and (b) permanently, if the
+    copyright holder fails to notify you of the violation by some
+    reasonable means prior to 60 days after the cessation.
+
+    Moreover, your license from a particular copyright holder is
+    reinstated permanently if the copyright holder notifies you of the
+    violation by some reasonable means, this is the first time you
+    have received notice of violation of this License (for any work)
+    from that copyright holder, and you cure the violation prior to 30
+    days after your receipt of the notice.
+
+We intend this Commitment to be irrevocable, and binding and
+enforceable against us and assignees of or successors to our
+copyrights.
+
+Definitions
+
+'Covered License' means the GNU General Public License, version 2
+(GPLv2), the GNU Lesser General Public License, version 2.1
+(LGPLv2.1), or the GNU Library General Public License, version 2
+(LGPLv2), all as published by the Free Software Foundation.
+
+'Defensive Action' means a legal proceeding or claim that We bring
+against you in response to a prior proceeding or claim initiated by
+you or your affiliate.
+
+'We' means each contributor to this repository as of the date of
+inclusion of this file, including subsidiaries of a corporate
+contributor.
+
+This work is available under a Creative Commons Attribution-ShareAlike
+4.0 International license (https://creativecommons.org/licenses/by-sa/4.0/).
+

--- a/test/simpleTestForGenerator/GPL-CC-1.0.txt
+++ b/test/simpleTestForGenerator/GPL-CC-1.0.txt
@@ -44,4 +44,3 @@ contributor.
 
 This work is available under a Creative Commons Attribution-ShareAlike
 4.0 International license (https://creativecommons.org/licenses/by-sa/4.0/).
-


### PR DESCRIPTION
As per #714, an exception to track the GPL Cooperation Commitment.

A single file with `optional` sections and `alt` matches to handle all variants: Individual, Company, and Project.

**Note**: The matching is simple, accepting for example the originals
> I commit

and
> COMPANY commits

The simplicity means that it also accepts the grammatically incorrect
> I commits

If we really want to make sure this is not OK, the matches have to be extended from single words to phrases.