### PR TITLE
add markup to Unicode-DFS-2016

### DIFF
--- a/src/Unicode-DFS-2016.xml
+++ b/src/Unicode-DFS-2016.xml
@@ -1,41 +1,45 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isOsiApproved="false" licenseId="Unicode-DFS-2016" listVersionAdded="2.6"
+    <license isOsiApproved="false" licenseId="Unicode-DFS-2016" listVersionAdded="2.6"
             name="Unicode License Agreement - Data Files and Software (2016)">
-      <crossRefs>
-         <crossRef>http://www.unicode.org/copyright.html</crossRef>
-      </crossRefs>
-    <text>
-      <titleText>
-         <p>UNICODE, INC. LICENSE AGREEMENT - DATA FILES AND SOFTWARE</p>
-      </titleText>
-      <p>Unicode Data Files include all data files under the directories
+        <crossRefs>
+            <crossRef>http://www.unicode.org/copyright.html</crossRef>
+        </crossRefs>
+        <text>
+            <titleText>
+                <p>UNICODE, INC. LICENSE AGREEMENT - DATA FILES AND SOFTWARE</p>
+            </titleText>
+            <p>Unicode Data Files include all data files under the directories
          http://www.unicode.org/Public/,
          http://www.unicode.org/reports/,
          http://www.unicode.org/cldr/data/,
-         http://source.icu-project.org/repos/icu/, and
-         http://www.unicode.org/utility/trac/browser/.</p>
-      <p>Unicode Data Files do not include PDF online code charts under
+         http://source.icu-project.org/repos/icu/,
+                <optional>http://www.unicode.org/ivd/data/,</optional> and
+         http://www.unicode.org/utility/trac/browser/.
+            </p>
+            <p>Unicode Data Files do not include PDF online code charts under
          the directory http://www.unicode.org/Public/.</p>
-      <p>Software includes any source code published in the Unicode
+            <p>Software includes any source code published in the Unicode
          Standard or under the directories
          http://www.unicode.org/Public/,
          http://www.unicode.org/reports/,
          http://www.unicode.org/cldr/data/,
          http://source.icu-project.org/repos/icu/, and
          http://www.unicode.org/utility/trac/browser/.</p>
-      <p>NOTICE TO USER: Carefully read the following legal agreement. BY
+            <p>NOTICE TO USER: Carefully read the following legal agreement. BY
          DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING UNICODE
          INC.'S DATA FILES ("DATA FILES"), AND/OR SOFTWARE
          ("SOFTWARE"), YOU UNEQUIVOCALLY ACCEPT, AND AGREE TO BE BOUND
          BY, ALL OF THE TERMS AND CONDITIONS OF THIS AGREEMENT. IF YOU
          DO NOT AGREE, DO NOT DOWNLOAD, INSTALL, COPY, DISTRIBUTE OR
          USE THE DATA FILES OR SOFTWARE.</p>
-      <p>COPYRIGHT AND PERMISSION NOTICE</p>
-      <p>Copyright © 1991-2016 Unicode, Inc. All rights reserved.
+            <p>COPYRIGHT AND PERMISSION NOTICE</p>
+            <copyrightText>
+                <p>Copyright © 1991-2016 Unicode, Inc. All rights reserved.
          Distributed under the Terms of Use in
          http://www.unicode.org/copyright.html.</p>
-      <p>Permission is hereby granted, free of charge, to any person
+            </copyrightText>
+            <p>Permission is hereby granted, free of charge, to any person
          obtaining a copy of the Unicode data files and any associated
          documentation (the "Data Files") or Unicode software and any
          associated documentation (the "Software") to deal in the Data
@@ -44,19 +48,19 @@
          distribute, and/or sell copies of the Data Files or Software,
          and to permit persons to whom the Data Files or Software are
          furnished to do so, provided that either</p>
-      <list>
-        <item>
-            <bullet>(a)</bullet>
+            <list>
+                <item>
+                    <bullet>(a)</bullet>
           this copyright and permission notice appear with all
              copies of the Data Files or Software, or
-        </item>
-        <item>
-            <bullet>(b)</bullet>
+                </item>
+                <item>
+                    <bullet>(b)</bullet>
           this copyright and permission notice appear in associated
              Documentation.
-        </item>
-      </list>
-      <p>THE DATA FILES AND SOFTWARE ARE PROVIDED "AS IS", WITHOUT
+                </item>
+            </list>
+            <p>THE DATA FILES AND SOFTWARE ARE PROVIDED "AS IS", WITHOUT
          WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
          LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
          PARTICULAR PURPOSE AND NONINFRINGEMENT OF THIRD PARTY RIGHTS.
@@ -67,11 +71,11 @@
          CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
          OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THE DATA FILES
          OR SOFTWARE.</p>
-      <p>Except as contained in this notice, the name of a copyright
+            <p>Except as contained in this notice, the name of a copyright
          holder shall not be used in advertising or otherwise to
          promote the sale, use or other dealings in these Data Files or
          Software without prior written authorization of the copyright
          holder.</p>
-    </text>
-  </license>
+        </text>
+    </license>
 </SPDXLicenseCollection>


### PR DESCRIPTION
adding optional markup to an additional URL in first part of license and adding copyright tag to copyright notice (which has also been recently updated to 2019 and should not fail a match)
