### PR TITLE
crossRefs: HTTP -> HTTPS: gnu.org, creativecommons.org, opensource.org

### DIFF
--- a/src/AAL.xml
+++ b/src/AAL.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="AAL" name="Attribution Assurance License">
       <crossRefs>
-         <crossRef>http://www.opensource.org/licenses/attribution</crossRef>
+         <crossRef>https://opensource.org/licenses/attribution</crossRef>
       </crossRefs>
       <notes>
     This license was released: 2002

--- a/src/AFL-3.0.xml
+++ b/src/AFL-3.0.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="true" licenseId="AFL-3.0" name="Academic Free License v3.0">
       <crossRefs>
          <crossRef>http://www.rosenlaw.com/AFL3.0.htm</crossRef>
-         <crossRef>http://www.opensource.org/licenses/afl-3.0</crossRef>
+         <crossRef>https://opensource.org/licenses/afl-3.0</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/AGPL-3.0-only.xml
+++ b/src/AGPL-3.0-only.xml
@@ -4,7 +4,7 @@
   name="GNU Affero General Public License v3.0 only">
     <crossRefs>
       <crossRef>https://www.gnu.org/licenses/agpl.txt</crossRef>
-      <crossRef>http://www.opensource.org/licenses/AGPL-3.0</crossRef>
+      <crossRef>https://opensource.org/licenses/AGPL-3.0</crossRef>
     </crossRefs>
     <standardLicenseHeader>
       Copyright (C) <alt name="copyright" match=".+">[year] [name of author]</alt>

--- a/src/AGPL-3.0-only.xml
+++ b/src/AGPL-3.0-only.xml
@@ -3,7 +3,7 @@
   <license licenseId="AGPL-3.0-only" isOsiApproved="true"
   name="GNU Affero General Public License v3.0 only">
     <crossRefs>
-      <crossRef>http://www.gnu.org/licenses/agpl.txt</crossRef>
+      <crossRef>https://www.gnu.org/licenses/agpl.txt</crossRef>
       <crossRef>http://www.opensource.org/licenses/AGPL-3.0</crossRef>
     </crossRefs>
     <standardLicenseHeader>

--- a/src/AGPL-3.0-or-later.xml
+++ b/src/AGPL-3.0-or-later.xml
@@ -3,7 +3,7 @@
   <license licenseId="AGPL-3.0-or-later" isOsiApproved="true"
   name="GNU Affero General Public License v3.0 or later">
     <crossRefs>
-      <crossRef>http://www.gnu.org/licenses/agpl.txt</crossRef>
+      <crossRef>https://www.gnu.org/licenses/agpl.txt</crossRef>
       <crossRef>http://www.opensource.org/licenses/AGPL-3.0</crossRef>
     </crossRefs>
     <notes>

--- a/src/AGPL-3.0-or-later.xml
+++ b/src/AGPL-3.0-or-later.xml
@@ -4,7 +4,7 @@
   name="GNU Affero General Public License v3.0 or later">
     <crossRefs>
       <crossRef>https://www.gnu.org/licenses/agpl.txt</crossRef>
-      <crossRef>http://www.opensource.org/licenses/AGPL-3.0</crossRef>
+      <crossRef>https://opensource.org/licenses/AGPL-3.0</crossRef>
     </crossRefs>
     <notes>
       This version was released: 19 November 2007

--- a/src/AGPL-3.0.xml
+++ b/src/AGPL-3.0.xml
@@ -8,7 +8,7 @@
       <obsoletedBy expression="AGPL-3.0+">AGPL-3.0-or-later</obsoletedBy>
     </obsoletedBys>
     <crossRefs>
-      <crossRef>http://www.gnu.org/licenses/agpl.txt</crossRef>
+      <crossRef>https://www.gnu.org/licenses/agpl.txt</crossRef>
       <crossRef>http://www.opensource.org/licenses/AGPL-3.0</crossRef>
     </crossRefs>
     <standardLicenseHeader>

--- a/src/AGPL-3.0.xml
+++ b/src/AGPL-3.0.xml
@@ -9,7 +9,7 @@
     </obsoletedBys>
     <crossRefs>
       <crossRef>https://www.gnu.org/licenses/agpl.txt</crossRef>
-      <crossRef>http://www.opensource.org/licenses/AGPL-3.0</crossRef>
+      <crossRef>https://opensource.org/licenses/AGPL-3.0</crossRef>
     </crossRefs>
     <standardLicenseHeader>
       Copyright (C) <alt name="copyright" match=".+">[year] [name of author]</alt>

--- a/src/APL-1.0.xml
+++ b/src/APL-1.0.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="APL-1.0" name="Adaptive Public License 1.0">
       <crossRefs>
-         <crossRef>http://www.opensource.org/licenses/APL-1.0</crossRef>
+         <crossRef>https://opensource.org/licenses/APL-1.0</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/Apache-1.1.xml
+++ b/src/Apache-1.1.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="true" licenseId="Apache-1.1" name="Apache License 1.1">
       <crossRefs>
          <crossRef>http://apache.org/licenses/LICENSE-1.1</crossRef>
-         <crossRef>http://opensource.org/licenses/Apache-1.1</crossRef>
+         <crossRef>https://opensource.org/licenses/Apache-1.1</crossRef>
       </crossRefs>
       <notes>This license has been superseded by Apache License 2.0</notes>
     <text>

--- a/src/Apache-2.0.xml
+++ b/src/Apache-2.0.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="true" licenseId="Apache-2.0" name="Apache License 2.0">
       <crossRefs>
          <crossRef>http://www.apache.org/licenses/LICENSE-2.0</crossRef>
-         <crossRef>http://www.opensource.org/licenses/Apache-2.0</crossRef>
+         <crossRef>https://opensource.org/licenses/Apache-2.0</crossRef>
       </crossRefs>
       <notes>This license was released January 2004</notes>
     <text>

--- a/src/Artistic-1.0-cl8.xml
+++ b/src/Artistic-1.0-cl8.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="true" licenseId="Artistic-1.0-cl8"
             name="Artistic License 1.0 w/clause 8">
       <crossRefs>
-         <crossRef>http://opensource.org/licenses/Artistic-1.0</crossRef>
+         <crossRef>https://opensource.org/licenses/Artistic-1.0</crossRef>
       </crossRefs>
       <notes>This license was superseded by v2.0. This is Artistic License 1.0 as found on OSI site, including clause
          8.</notes>

--- a/src/Artistic-1.0.xml
+++ b/src/Artistic-1.0.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="Artistic-1.0" name="Artistic License 1.0">
       <crossRefs>
-         <crossRef>http://opensource.org/licenses/Artistic-1.0</crossRef>
+         <crossRef>https://opensource.org/licenses/Artistic-1.0</crossRef>
       </crossRefs>
       <notes>This license was superseded by v2.0. This is Artistic License 1.0 as found on OSI site, excluding clause
          8.</notes>

--- a/src/Artistic-2.0.xml
+++ b/src/Artistic-2.0.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="true" licenseId="Artistic-2.0" name="Artistic License 2.0">
       <crossRefs>
          <crossRef>http://www.perlfoundation.org/artistic_license_2_0</crossRef>
-         <crossRef>http://www.opensource.org/licenses/artistic-license-2.0</crossRef>
+         <crossRef>https://opensource.org/licenses/artistic-license-2.0</crossRef>
       </crossRefs>
       <notes>This license was released: 2006</notes>
     <text>

--- a/src/BSD-2-Clause.xml
+++ b/src/BSD-2-Clause.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="true" licenseId="BSD-2-Clause"
             name="BSD 2-Clause &#34;Simplified&#34; License">
       <crossRefs>
-         <crossRef>http://www.opensource.org/licenses/BSD-2-Clause</crossRef>
+         <crossRef>https://opensource.org/licenses/BSD-2-Clause</crossRef>
       </crossRefs>
     <text>
       <copyrightText>

--- a/src/BSD-3-Clause.xml
+++ b/src/BSD-3-Clause.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="true" licenseId="BSD-3-Clause"
             name="BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License">
       <crossRefs>
-         <crossRef>http://www.opensource.org/licenses/BSD-3-Clause</crossRef>
+         <crossRef>https://opensource.org/licenses/BSD-3-Clause</crossRef>
       </crossRefs>
     <text>
       <copyrightText>

--- a/src/BSL-1.0.xml
+++ b/src/BSL-1.0.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="true" licenseId="BSL-1.0" name="Boost Software License 1.0">
       <crossRefs>
          <crossRef>http://www.boost.org/LICENSE_1_0.txt</crossRef>
-         <crossRef>http://www.opensource.org/licenses/BSL-1.0</crossRef>
+         <crossRef>https://opensource.org/licenses/BSL-1.0</crossRef>
       </crossRefs>
       <notes>This license was released: 17 August 2003</notes>
     <text>

--- a/src/CATOSL-1.1.xml
+++ b/src/CATOSL-1.1.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="true" licenseId="CATOSL-1.1"
             name="Computer Associates Trusted Open Source License 1.1">
       <crossRefs>
-         <crossRef>http://opensource.org/licenses/CATOSL-1.1</crossRef>
+         <crossRef>https://opensource.org/licenses/CATOSL-1.1</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/CC-BY-1.0.xml
+++ b/src/CC-BY-1.0.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="false" licenseId="CC-BY-1.0"
             name="Creative Commons Attribution 1.0 Generic">
       <crossRefs>
-         <crossRef>http://creativecommons.org/licenses/by/1.0/legalcode</crossRef>
+         <crossRef>https://creativecommons.org/licenses/by/1.0/legalcode</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/CC-BY-2.0.xml
+++ b/src/CC-BY-2.0.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="false" licenseId="CC-BY-2.0"
             name="Creative Commons Attribution 2.0 Generic">
       <crossRefs>
-         <crossRef>http://creativecommons.org/licenses/by/2.0/legalcode</crossRef>
+         <crossRef>https://creativecommons.org/licenses/by/2.0/legalcode</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/CC-BY-2.5.xml
+++ b/src/CC-BY-2.5.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="false" licenseId="CC-BY-2.5"
             name="Creative Commons Attribution 2.5 Generic">
       <crossRefs>
-         <crossRef>http://creativecommons.org/licenses/by/2.5/legalcode</crossRef>
+         <crossRef>https://creativecommons.org/licenses/by/2.5/legalcode</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/CC-BY-3.0.xml
+++ b/src/CC-BY-3.0.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="false" licenseId="CC-BY-3.0"
             name="Creative Commons Attribution 3.0 Unported">
       <crossRefs>
-         <crossRef>http://creativecommons.org/licenses/by/3.0/legalcode</crossRef>
+         <crossRef>https://creativecommons.org/licenses/by/3.0/legalcode</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/CC-BY-4.0.xml
+++ b/src/CC-BY-4.0.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="false" licenseId="CC-BY-4.0"
             name="Creative Commons Attribution 4.0 International">
       <crossRefs>
-         <crossRef>http://creativecommons.org/licenses/by/4.0/legalcode</crossRef>
+         <crossRef>https://creativecommons.org/licenses/by/4.0/legalcode</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/CC-BY-NC-1.0.xml
+++ b/src/CC-BY-NC-1.0.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="false" licenseId="CC-BY-NC-1.0"
             name="Creative Commons Attribution Non Commercial 1.0 Generic">
       <crossRefs>
-         <crossRef>http://creativecommons.org/licenses/by-nc/1.0/legalcode</crossRef>
+         <crossRef>https://creativecommons.org/licenses/by-nc/1.0/legalcode</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/CC-BY-NC-2.0.xml
+++ b/src/CC-BY-NC-2.0.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="false" licenseId="CC-BY-NC-2.0"
             name="Creative Commons Attribution Non Commercial 2.0 Generic">
       <crossRefs>
-         <crossRef>http://creativecommons.org/licenses/by-nc/2.0/legalcode</crossRef>
+         <crossRef>https://creativecommons.org/licenses/by-nc/2.0/legalcode</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/CC-BY-NC-2.5.xml
+++ b/src/CC-BY-NC-2.5.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="false" licenseId="CC-BY-NC-2.5"
             name="Creative Commons Attribution Non Commercial 2.5 Generic">
       <crossRefs>
-         <crossRef>http://creativecommons.org/licenses/by-nc/2.5/legalcode</crossRef>
+         <crossRef>https://creativecommons.org/licenses/by-nc/2.5/legalcode</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/CC-BY-NC-3.0.xml
+++ b/src/CC-BY-NC-3.0.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="false" licenseId="CC-BY-NC-3.0"
             name="Creative Commons Attribution Non Commercial 3.0 Unported">
       <crossRefs>
-         <crossRef>http://creativecommons.org/licenses/by-nc/3.0/legalcode</crossRef>
+         <crossRef>https://creativecommons.org/licenses/by-nc/3.0/legalcode</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/CC-BY-NC-4.0.xml
+++ b/src/CC-BY-NC-4.0.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="false" licenseId="CC-BY-NC-4.0"
             name="Creative Commons Attribution Non Commercial 4.0 International">
       <crossRefs>
-         <crossRef>http://creativecommons.org/licenses/by-nc/4.0/legalcode</crossRef>
+         <crossRef>https://creativecommons.org/licenses/by-nc/4.0/legalcode</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/CC-BY-NC-ND-1.0.xml
+++ b/src/CC-BY-NC-ND-1.0.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="false" licenseId="CC-BY-NC-ND-1.0"
             name="Creative Commons Attribution Non Commercial No Derivatives 1.0 Generic">
       <crossRefs>
-         <crossRef>http://creativecommons.org/licenses/by-nd-nc/1.0/legalcode</crossRef>
+         <crossRef>https://creativecommons.org/licenses/by-nd-nc/1.0/legalcode</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/CC-BY-NC-ND-2.0.xml
+++ b/src/CC-BY-NC-ND-2.0.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="false" licenseId="CC-BY-NC-ND-2.0"
             name="Creative Commons Attribution Non Commercial No Derivatives 2.0 Generic">
       <crossRefs>
-         <crossRef>http://creativecommons.org/licenses/by-nc-nd/2.0/legalcode</crossRef>
+         <crossRef>https://creativecommons.org/licenses/by-nc-nd/2.0/legalcode</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/CC-BY-NC-ND-2.5.xml
+++ b/src/CC-BY-NC-ND-2.5.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="false" licenseId="CC-BY-NC-ND-2.5"
             name="Creative Commons Attribution Non Commercial No Derivatives 2.5 Generic">
       <crossRefs>
-         <crossRef>http://creativecommons.org/licenses/by-nc-nd/2.5/legalcode</crossRef>
+         <crossRef>https://creativecommons.org/licenses/by-nc-nd/2.5/legalcode</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/CC-BY-NC-ND-3.0.xml
+++ b/src/CC-BY-NC-ND-3.0.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="false" licenseId="CC-BY-NC-ND-3.0"
             name="Creative Commons Attribution Non Commercial No Derivatives 3.0 Unported">
       <crossRefs>
-         <crossRef>http://creativecommons.org/licenses/by-nc-nd/3.0/legalcode</crossRef>
+         <crossRef>https://creativecommons.org/licenses/by-nc-nd/3.0/legalcode</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/CC-BY-NC-ND-4.0.xml
+++ b/src/CC-BY-NC-ND-4.0.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="false" licenseId="CC-BY-NC-ND-4.0"
             name="Creative Commons Attribution Non Commercial No Derivatives 4.0 International">
       <crossRefs>
-         <crossRef>http://creativecommons.org/licenses/by-nc-nd/4.0/legalcode</crossRef>
+         <crossRef>https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/CC-BY-NC-SA-1.0.xml
+++ b/src/CC-BY-NC-SA-1.0.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="false" licenseId="CC-BY-NC-SA-1.0"
             name="Creative Commons Attribution Non Commercial Share Alike 1.0 Generic">
       <crossRefs>
-         <crossRef>http://creativecommons.org/licenses/by-nc-sa/1.0/legalcode</crossRef>
+         <crossRef>https://creativecommons.org/licenses/by-nc-sa/1.0/legalcode</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/CC-BY-NC-SA-2.0.xml
+++ b/src/CC-BY-NC-SA-2.0.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="false" licenseId="CC-BY-NC-SA-2.0"
             name="Creative Commons Attribution Non Commercial Share Alike 2.0 Generic">
       <crossRefs>
-         <crossRef>http://creativecommons.org/licenses/by-nc-sa/2.0/legalcode</crossRef>
+         <crossRef>https://creativecommons.org/licenses/by-nc-sa/2.0/legalcode</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/CC-BY-NC-SA-2.5.xml
+++ b/src/CC-BY-NC-SA-2.5.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="false" licenseId="CC-BY-NC-SA-2.5"
             name="Creative Commons Attribution Non Commercial Share Alike 2.5 Generic">
       <crossRefs>
-         <crossRef>http://creativecommons.org/licenses/by-nc-sa/2.5/legalcode</crossRef>
+         <crossRef>https://creativecommons.org/licenses/by-nc-sa/2.5/legalcode</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/CC-BY-NC-SA-3.0.xml
+++ b/src/CC-BY-NC-SA-3.0.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="false" licenseId="CC-BY-NC-SA-3.0"
             name="Creative Commons Attribution Non Commercial Share Alike 3.0 Unported">
       <crossRefs>
-         <crossRef>http://creativecommons.org/licenses/by-nc-sa/3.0/legalcode</crossRef>
+         <crossRef>https://creativecommons.org/licenses/by-nc-sa/3.0/legalcode</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/CC-BY-NC-SA-4.0.xml
+++ b/src/CC-BY-NC-SA-4.0.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="false" licenseId="CC-BY-NC-SA-4.0"
             name="Creative Commons Attribution Non Commercial Share Alike 4.0 International">
       <crossRefs>
-         <crossRef>http://creativecommons.org/licenses/by-nc-sa/4.0/legalcode</crossRef>
+         <crossRef>https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/CC-BY-ND-1.0.xml
+++ b/src/CC-BY-ND-1.0.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="false" licenseId="CC-BY-ND-1.0"
             name="Creative Commons Attribution No Derivatives 1.0 Generic">
       <crossRefs>
-         <crossRef>http://creativecommons.org/licenses/by-nd/1.0/legalcode</crossRef>
+         <crossRef>https://creativecommons.org/licenses/by-nd/1.0/legalcode</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/CC-BY-ND-2.5.xml
+++ b/src/CC-BY-ND-2.5.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="false" licenseId="CC-BY-ND-2.5"
             name="Creative Commons Attribution No Derivatives 2.5 Generic">
       <crossRefs>
-         <crossRef>http://creativecommons.org/licenses/by-nd/2.5/legalcode</crossRef>
+         <crossRef>https://creativecommons.org/licenses/by-nd/2.5/legalcode</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/CC-BY-ND-3.0.xml
+++ b/src/CC-BY-ND-3.0.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="false" licenseId="CC-BY-ND-3.0"
             name="Creative Commons Attribution No Derivatives 3.0 Unported">
       <crossRefs>
-         <crossRef>http://creativecommons.org/licenses/by-nd/3.0/legalcode</crossRef>
+         <crossRef>https://creativecommons.org/licenses/by-nd/3.0/legalcode</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/CC-BY-ND-4.0.xml
+++ b/src/CC-BY-ND-4.0.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="false" licenseId="CC-BY-ND-4.0"
             name="Creative Commons Attribution No Derivatives 4.0 International">
       <crossRefs>
-         <crossRef>http://creativecommons.org/licenses/by-nd/4.0/legalcode</crossRef>
+         <crossRef>https://creativecommons.org/licenses/by-nd/4.0/legalcode</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/CC-BY-SA-1.0.xml
+++ b/src/CC-BY-SA-1.0.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="false" licenseId="CC-BY-SA-1.0"
             name="Creative Commons Attribution Share Alike 1.0 Generic">
       <crossRefs>
-         <crossRef>http://creativecommons.org/licenses/by-sa/1.0/legalcode</crossRef>
+         <crossRef>https://creativecommons.org/licenses/by-sa/1.0/legalcode</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/CC-BY-SA-2.0.xml
+++ b/src/CC-BY-SA-2.0.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="false" licenseId="CC-BY-SA-2.0"
             name="Creative Commons Attribution Share Alike 2.0 Generic">
       <crossRefs>
-         <crossRef>http://creativecommons.org/licenses/by-sa/2.0/legalcode</crossRef>
+         <crossRef>https://creativecommons.org/licenses/by-sa/2.0/legalcode</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/CC-BY-SA-2.5.xml
+++ b/src/CC-BY-SA-2.5.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="false" licenseId="CC-BY-SA-2.5"
             name="Creative Commons Attribution Share Alike 2.5 Generic">
       <crossRefs>
-         <crossRef>http://creativecommons.org/licenses/by-sa/2.5/legalcode</crossRef>
+         <crossRef>https://creativecommons.org/licenses/by-sa/2.5/legalcode</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/CC-BY-SA-3.0.xml
+++ b/src/CC-BY-SA-3.0.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="false" licenseId="CC-BY-SA-3.0"
             name="Creative Commons Attribution Share Alike 3.0 Unported">
       <crossRefs>
-         <crossRef>http://creativecommons.org/licenses/by-sa/3.0/legalcode</crossRef>
+         <crossRef>https://creativecommons.org/licenses/by-sa/3.0/legalcode</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/CC-BY-SA-4.0.xml
+++ b/src/CC-BY-SA-4.0.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="false" licenseId="CC-BY-SA-4.0"
             name="Creative Commons Attribution Share Alike 4.0 International">
       <crossRefs>
-         <crossRef>http://creativecommons.org/licenses/by-sa/4.0/legalcode</crossRef>
+         <crossRef>https://creativecommons.org/licenses/by-sa/4.0/legalcode</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/CC0-1.0.xml
+++ b/src/CC0-1.0.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="false" licenseId="CC0-1.0"
             name="Creative Commons Zero v1.0 Universal">
       <crossRefs>
-         <crossRef>http://creativecommons.org/publicdomain/zero/1.0/legalcode</crossRef>
+         <crossRef>https://creativecommons.org/publicdomain/zero/1.0/legalcode</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/CDDL-1.0.xml
+++ b/src/CDDL-1.0.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="true" licenseId="CDDL-1.0"
             name="Common Development and Distribution License 1.0">
       <crossRefs>
-         <crossRef>http://www.opensource.org/licenses/cddl1</crossRef>
+         <crossRef>https://opensource.org/licenses/cddl1</crossRef>
       </crossRefs>
       <notes>This license was released: 24 January 2004.</notes>
     <text>

--- a/src/CNRI-Python.xml
+++ b/src/CNRI-Python.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="CNRI-Python" name="CNRI Python License">
       <crossRefs>
-         <crossRef>http://www.opensource.org/licenses/CNRI-Python</crossRef>
+         <crossRef>https://opensource.org/licenses/CNRI-Python</crossRef>
       </crossRefs>
       <notes>CNRI portion of the multi-part Python License (Python-2.0)</notes>
     <text>

--- a/src/CPAL-1.0.xml
+++ b/src/CPAL-1.0.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="true" licenseId="CPAL-1.0"
             name="Common Public Attribution License 1.0">
       <crossRefs>
-         <crossRef>http://www.opensource.org/licenses/CPAL-1.0</crossRef>
+         <crossRef>https://opensource.org/licenses/CPAL-1.0</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/CPL-1.0.xml
+++ b/src/CPL-1.0.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="CPL-1.0" name="Common Public License 1.0">
       <crossRefs>
-         <crossRef>http://opensource.org/licenses/CPL-1.0</crossRef>
+         <crossRef>https://opensource.org/licenses/CPL-1.0</crossRef>
       </crossRefs>
       <notes>This license was superseded by Eclipse Public License</notes>
     <text>

--- a/src/CUA-OPL-1.0.xml
+++ b/src/CUA-OPL-1.0.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="true" licenseId="CUA-OPL-1.0"
             name="CUA Office Public License v1.0">
       <crossRefs>
-         <crossRef>http://opensource.org/licenses/CUA-OPL-1.0</crossRef>
+         <crossRef>https://opensource.org/licenses/CUA-OPL-1.0</crossRef>
       </crossRefs>
       <notes>The CUA Office Project has ceased to use or recommend this license. This license is essentially a rebranded version of MPL-1.1, but was included on the SPDX License List due to its OSI-approved status. </notes>
     <text>

--- a/src/ECL-1.0.xml
+++ b/src/ECL-1.0.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="true" licenseId="ECL-1.0"
             name="Educational Community License v1.0">
       <crossRefs>
-         <crossRef>http://opensource.org/licenses/ECL-1.0</crossRef>
+         <crossRef>https://opensource.org/licenses/ECL-1.0</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/ECL-2.0.xml
+++ b/src/ECL-2.0.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="true" licenseId="ECL-2.0"
             name="Educational Community License v2.0">
       <crossRefs>
-         <crossRef>http://opensource.org/licenses/ECL-2.0</crossRef>
+         <crossRef>https://opensource.org/licenses/ECL-2.0</crossRef>
       </crossRefs>
       <notes>The Educational Community License version 2.0 ("ECL") consists of the Apache 2.0 license, modified
          to change the scope of the patent grant in section 3 to be specific to the needs of the education

--- a/src/EFL-1.0.xml
+++ b/src/EFL-1.0.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="true" licenseId="EFL-1.0" name="Eiffel Forum License v1.0">
       <crossRefs>
          <crossRef>http://www.eiffel-nice.org/license/forum.txt</crossRef>
-         <crossRef>http://opensource.org/licenses/EFL-1.0</crossRef>
+         <crossRef>https://opensource.org/licenses/EFL-1.0</crossRef>
       </crossRefs>
       <notes>This license has been superseded by v2.0</notes>
     <text>

--- a/src/EFL-2.0.xml
+++ b/src/EFL-2.0.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="true" licenseId="EFL-2.0" name="Eiffel Forum License v2.0">
       <crossRefs>
          <crossRef>http://www.eiffel-nice.org/license/eiffel-forum-license-2.html</crossRef>
-         <crossRef>http://opensource.org/licenses/EFL-2.0</crossRef>
+         <crossRef>https://opensource.org/licenses/EFL-2.0</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/EPL-1.0.xml
+++ b/src/EPL-1.0.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="true" licenseId="EPL-1.0" name="Eclipse Public License 1.0">
       <crossRefs>
          <crossRef>http://www.eclipse.org/legal/epl-v10.html</crossRef>
-         <crossRef>http://www.opensource.org/licenses/EPL-1.0</crossRef>
+         <crossRef>https://opensource.org/licenses/EPL-1.0</crossRef>
       </crossRefs>
       <notes>EPL replaced the CPL on 28 June 2005.</notes>
     <text>

--- a/src/EUDatagrid.xml
+++ b/src/EUDatagrid.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="true" licenseId="EUDatagrid" name="EU DataGrid Software License">
       <crossRefs>
          <crossRef>http://eu-datagrid.web.cern.ch/eu-datagrid/license.html</crossRef>
-         <crossRef>http://www.opensource.org/licenses/EUDatagrid</crossRef>
+         <crossRef>https://opensource.org/licenses/EUDatagrid</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/EUPL-1.1.xml
+++ b/src/EUPL-1.1.xml
@@ -5,7 +5,7 @@
       <crossRefs>
          <crossRef>https://joinup.ec.europa.eu/software/page/eupl/licence-eupl</crossRef>
          <crossRef>https://joinup.ec.europa.eu/sites/default/files/custom-page/attachment/eupl1.1.-licence-en_0.pdf</crossRef>
-         <crossRef>http://www.opensource.org/licenses/EUPL-1.1</crossRef>
+         <crossRef>https://opensource.org/licenses/EUPL-1.1</crossRef>
       </crossRefs>
       <notes>This license was released: 16 May 2008 This license is available in the 22 official languages of the EU. The
          English version is included here.</notes>

--- a/src/EUPL-1.2.xml
+++ b/src/EUPL-1.2.xml
@@ -7,7 +7,7 @@
       <crossRef>https://joinup.ec.europa.eu/sites/default/files/custom-page/attachment/eupl_v1.2_en.pdf</crossRef>
       <crossRef>https://joinup.ec.europa.eu/sites/default/files/inline-files/EUPL%20v1_2%20EN(1).txt</crossRef>
       <crossRef>http://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32017D0863</crossRef>
-      <crossRef>http://www.opensource.org/licenses/EUPL-1.1</crossRef>
+      <crossRef>https://opensource.org/licenses/EUPL-1.1</crossRef>
     </crossRefs>
     <notes>
       This license was released: 19 May 2016. This license is available in the

--- a/src/Entessa.xml
+++ b/src/Entessa.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="Entessa" name="Entessa Public License v1.0">
       <crossRefs>
-         <crossRef>http://opensource.org/licenses/Entessa</crossRef>
+         <crossRef>https://opensource.org/licenses/Entessa</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/FSFAP.xml
+++ b/src/FSFAP.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="false" licenseId="FSFAP" name="FSF All Permissive License">
       <crossRefs>
-         <crossRef>http://www.gnu.org/prep/maintain/html_node/License-Notices-for-Other-Files.html</crossRef>
+         <crossRef>https://www.gnu.org/prep/maintain/html_node/License-Notices-for-Other-Files.html</crossRef>
       </crossRefs>
     <text>
       <p>Copying and distribution of this file, with or without

--- a/src/Fair.xml
+++ b/src/Fair.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="true" licenseId="Fair" name="Fair License">
       <crossRefs>
          <crossRef>http://fairlicense.org/</crossRef>
-         <crossRef>http://www.opensource.org/licenses/Fair</crossRef>
+         <crossRef>https://opensource.org/licenses/Fair</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/Frameworx-1.0.xml
+++ b/src/Frameworx-1.0.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="true" licenseId="Frameworx-1.0"
             name="Frameworx Open License 1.0">
       <crossRefs>
-         <crossRef>http://www.opensource.org/licenses/Frameworx-1.0</crossRef>
+         <crossRef>https://opensource.org/licenses/Frameworx-1.0</crossRef>
       </crossRefs>
       <notes>The url included in the license does not work. (15/10/10)</notes>
     <text>

--- a/src/GFDL-1.1-only.xml
+++ b/src/GFDL-1.1-only.xml
@@ -3,7 +3,7 @@
   <license licenseId="GFDL-1.1-only" isOsiApproved="false"
   name="GNU Free Documentation License v1.1 only">
     <crossRefs>
-      <crossRef>http://www.gnu.org/licenses/old-licenses/fdl-1.1.txt</crossRef>
+      <crossRef>https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt</crossRef>
     </crossRefs>
     <standardLicenseHeader>
       Copyright (c) <alt name="copyright" match=".+">YEAR YOUR NAME</alt>

--- a/src/GFDL-1.1-or-later.xml
+++ b/src/GFDL-1.1-or-later.xml
@@ -3,7 +3,7 @@
   <license licenseId="GFDL-1.1-or-later" isOsiApproved="false"
   name="GNU Free Documentation License v1.1 or later">
     <crossRefs>
-      <crossRef>http://www.gnu.org/licenses/old-licenses/fdl-1.1.txt</crossRef>
+      <crossRef>https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt</crossRef>
     </crossRefs>
     <notes>
       This license was released March 2000

--- a/src/GFDL-1.1.xml
+++ b/src/GFDL-1.1.xml
@@ -8,7 +8,7 @@
       <obsoletedBy expression="GFDL-1.1+">GFDL-1.1-or-later</obsoletedBy>
     </obsoletedBys>
     <crossRefs>
-      <crossRef>http://www.gnu.org/licenses/old-licenses/fdl-1.1.txt</crossRef>
+      <crossRef>https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt</crossRef>
     </crossRefs>
     <standardLicenseHeader>
       Copyright (c) <alt name="copyright" match=".+">YEAR YOUR NAME</alt>

--- a/src/GFDL-1.2-only.xml
+++ b/src/GFDL-1.2-only.xml
@@ -3,7 +3,7 @@
   <license licenseId="GFDL-1.2-only" isOsiApproved="false"
   name="GNU Free Documentation License v1.2 only">
     <crossRefs>
-      <crossRef>http://www.gnu.org/licenses/old-licenses/fdl-1.2.txt</crossRef>
+      <crossRef>https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt</crossRef>
     </crossRefs>
     <standardLicenseHeader>
       Copyright (c) <alt name="copyright" match=".+">YEAR YOUR NAME</alt>

--- a/src/GFDL-1.2-or-later.xml
+++ b/src/GFDL-1.2-or-later.xml
@@ -3,7 +3,7 @@
   <license licenseId="GFDL-1.2-or-later" isOsiApproved="false"
   name="GNU Free Documentation License v1.2 or later">
     <crossRefs>
-      <crossRef>http://www.gnu.org/licenses/old-licenses/fdl-1.2.txt</crossRef>
+      <crossRef>https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt</crossRef>
     </crossRefs>
     <notes>
       This license was released November 2002

--- a/src/GFDL-1.2.xml
+++ b/src/GFDL-1.2.xml
@@ -8,7 +8,7 @@
       <obsoletedBy expression="GFDL-1.2+">GFDL-1.2-or-later</obsoletedBy>
     </obsoletedBys>
     <crossRefs>
-      <crossRef>http://www.gnu.org/licenses/old-licenses/fdl-1.2.txt</crossRef>
+      <crossRef>https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt</crossRef>
     </crossRefs>
     <standardLicenseHeader>
       Copyright (c) <alt name="copyright" match=".+">YEAR YOUR NAME</alt>

--- a/src/GFDL-1.3-only.xml
+++ b/src/GFDL-1.3-only.xml
@@ -3,7 +3,7 @@
   <license licenseId="GFDL-1.3-only" isOsiApproved="false"
   name="GNU Free Documentation License v1.3 only">
     <crossRefs>
-      <crossRef>http://www.gnu.org/licenses/fdl-1.3.txt</crossRef>
+      <crossRef>https://www.gnu.org/licenses/fdl-1.3.txt</crossRef>
     </crossRefs>
     <standardLicenseHeader>
       Copyright (c) <alt name="copyright" match=".+">YEAR YOUR NAME</alt>

--- a/src/GFDL-1.3-or-later.xml
+++ b/src/GFDL-1.3-or-later.xml
@@ -3,7 +3,7 @@
   <license licenseId="GFDL-1.3-or-later" isOsiApproved="false"
   name="GNU Free Documentation License v1.3 or later">
     <crossRefs>
-      <crossRef>http://www.gnu.org/licenses/fdl-1.3.txt</crossRef>
+      <crossRef>https://www.gnu.org/licenses/fdl-1.3.txt</crossRef>
     </crossRefs>
     <notes>
       This license was released 3 November 2008.

--- a/src/GFDL-1.3.xml
+++ b/src/GFDL-1.3.xml
@@ -8,7 +8,7 @@
       <obsoletedBy expression="GFDL-1.3+">GFDL-1.3-or-later</obsoletedBy>
     </obsoletedBys>
     <crossRefs>
-      <crossRef>http://www.gnu.org/licenses/fdl-1.3.txt</crossRef>
+      <crossRef>https://www.gnu.org/licenses/fdl-1.3.txt</crossRef>
     </crossRefs>
     <standardLicenseHeader>
       Copyright (c) <alt name="copyright" match=".+">YEAR YOUR NAME</alt>

--- a/src/GPL-1.0+.xml
+++ b/src/GPL-1.0+.xml
@@ -6,7 +6,7 @@
          <obsoletedBy>GPL-1.0-or-later</obsoletedBy>
       </obsoletedBys>
       <crossRefs>
-         <crossRef>http://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html</crossRef>
+         <crossRef>https://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/GPL-1.0-only.xml
+++ b/src/GPL-1.0-only.xml
@@ -3,7 +3,7 @@
   <license licenseId="GPL-1.0-only" isOsiApproved="false"
   name="GNU General Public License v1.0 only">
     <crossRefs>
-      <crossRef>http://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html</crossRef>
+      <crossRef>https://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html</crossRef>
     </crossRefs>
     <standardLicenseHeader>
       Copyright (C) <alt name="copyright" match=".+">19xx name of author</alt>

--- a/src/GPL-1.0-or-later.xml
+++ b/src/GPL-1.0-or-later.xml
@@ -3,7 +3,7 @@
   <license licenseId="GPL-1.0-or-later" isOsiApproved="false"
   name="GNU General Public License v1.0 or later">
     <crossRefs>
-      <crossRef>http://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html</crossRef>
+      <crossRef>https://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html</crossRef>
     </crossRefs>
     <notes>
       This license was released: February 1989. This license

--- a/src/GPL-1.0.xml
+++ b/src/GPL-1.0.xml
@@ -8,7 +8,7 @@
       <obsoletedBy expression="GPL-1.0+">GPL-1.0-or-later</obsoletedBy>
     </obsoletedBys>
     <crossRefs>
-      <crossRef>http://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html</crossRef>
+      <crossRef>https://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html</crossRef>
     </crossRefs>
     <standardLicenseHeader>
       Copyright (C) <alt name="copyright" match=".+">19xx name of author</alt>

--- a/src/GPL-2.0+.xml
+++ b/src/GPL-2.0+.xml
@@ -7,7 +7,7 @@
       </obsoletedBys>
       <crossRefs>
          <crossRef>https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html</crossRef>
-         <crossRef>http://www.opensource.org/licenses/GPL-2.0</crossRef>
+         <crossRef>https://opensource.org/licenses/GPL-2.0</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/GPL-2.0+.xml
+++ b/src/GPL-2.0+.xml
@@ -6,7 +6,7 @@
          <obsoletedBy>GPL-2.0-or-later</obsoletedBy>
       </obsoletedBys>
       <crossRefs>
-         <crossRef>http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html</crossRef>
+         <crossRef>https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html</crossRef>
          <crossRef>http://www.opensource.org/licenses/GPL-2.0</crossRef>
       </crossRefs>
     <text>

--- a/src/GPL-2.0-only.xml
+++ b/src/GPL-2.0-only.xml
@@ -4,7 +4,7 @@
   name="GNU General Public License v2.0 only">
     <crossRefs>
       <crossRef>https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html</crossRef>
-      <crossRef>http://www.opensource.org/licenses/GPL-2.0</crossRef>
+      <crossRef>https://opensource.org/licenses/GPL-2.0</crossRef>
     </crossRefs>
     <standardLicenseHeader>
       Copyright (C) <alt name="copyright" match=".+">yyyy name of author</alt>

--- a/src/GPL-2.0-only.xml
+++ b/src/GPL-2.0-only.xml
@@ -3,7 +3,7 @@
   <license licenseId="GPL-2.0-only" isOsiApproved="true"
   name="GNU General Public License v2.0 only">
     <crossRefs>
-      <crossRef>http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html</crossRef>
+      <crossRef>https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html</crossRef>
       <crossRef>http://www.opensource.org/licenses/GPL-2.0</crossRef>
     </crossRefs>
     <standardLicenseHeader>

--- a/src/GPL-2.0-or-later.xml
+++ b/src/GPL-2.0-or-later.xml
@@ -3,7 +3,7 @@
   <license licenseId="GPL-2.0-or-later" isOsiApproved="true"
   name="GNU General Public License v2.0 or later">
     <crossRefs>
-      <crossRef>http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html</crossRef>
+      <crossRef>https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html</crossRef>
       <crossRef>http://www.opensource.org/licenses/GPL-2.0</crossRef>
     </crossRefs>
     <notes>

--- a/src/GPL-2.0-or-later.xml
+++ b/src/GPL-2.0-or-later.xml
@@ -4,7 +4,7 @@
   name="GNU General Public License v2.0 or later">
     <crossRefs>
       <crossRef>https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html</crossRef>
-      <crossRef>http://www.opensource.org/licenses/GPL-2.0</crossRef>
+      <crossRef>https://opensource.org/licenses/GPL-2.0</crossRef>
     </crossRefs>
     <notes>
       This license was released: June 1991

--- a/src/GPL-2.0-with-classpath-exception.xml
+++ b/src/GPL-2.0-with-classpath-exception.xml
@@ -7,7 +7,7 @@
          <obsoletedBy expression="GPL-2.0-with-classpath-exception+">GPL-2.0-or-later WITH Classpath-exception-2.0</obsoletedBy>
       </obsoletedBys>
       <crossRefs>
-         <crossRef>http://www.gnu.org/software/classpath/license.html</crossRef>
+         <crossRef>https://www.gnu.org/software/classpath/license.html</crossRef>
       </crossRefs>
      
     <text>

--- a/src/GPL-2.0-with-font-exception.xml
+++ b/src/GPL-2.0-with-font-exception.xml
@@ -7,7 +7,7 @@
          <obsoletedBy expression="GPL-2.0-with-font-exception+">GPL-2.0-or-later+ WITH Font-exception-2.0</obsoletedBy>
       </obsoletedBys>
       <crossRefs>
-         <crossRef>http://www.gnu.org/licenses/gpl-faq.html#FontException</crossRef>
+         <crossRef>https://www.gnu.org/licenses/gpl-faq.html#FontException</crossRef>
       </crossRefs>
      
     <text>

--- a/src/GPL-2.0.xml
+++ b/src/GPL-2.0.xml
@@ -8,7 +8,7 @@
       <obsoletedBy expression="GPL-2.0+">GPL-2.0-or-later</obsoletedBy>
     </obsoletedBys>
     <crossRefs>
-      <crossRef>http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html</crossRef>
+      <crossRef>https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html</crossRef>
       <crossRef>http://www.opensource.org/licenses/GPL-2.0</crossRef>
     </crossRefs>
     <standardLicenseHeader>

--- a/src/GPL-2.0.xml
+++ b/src/GPL-2.0.xml
@@ -9,7 +9,7 @@
     </obsoletedBys>
     <crossRefs>
       <crossRef>https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html</crossRef>
-      <crossRef>http://www.opensource.org/licenses/GPL-2.0</crossRef>
+      <crossRef>https://opensource.org/licenses/GPL-2.0</crossRef>
     </crossRefs>
     <standardLicenseHeader>
       Copyright (C) <alt name="copyright" match=".+">yyyy name of author</alt>

--- a/src/GPL-3.0+.xml
+++ b/src/GPL-3.0+.xml
@@ -6,7 +6,7 @@
          <obsoletedBy>GPL-3.0-or-later</obsoletedBy>
       </obsoletedBys>
       <crossRefs>
-         <crossRef>http://www.gnu.org/licenses/gpl-3.0-standalone.html</crossRef>
+         <crossRef>https://www.gnu.org/licenses/gpl-3.0-standalone.html</crossRef>
          <crossRef>http://www.opensource.org/licenses/GPL-3.0</crossRef>
       </crossRefs>
     <text>

--- a/src/GPL-3.0+.xml
+++ b/src/GPL-3.0+.xml
@@ -7,7 +7,7 @@
       </obsoletedBys>
       <crossRefs>
          <crossRef>https://www.gnu.org/licenses/gpl-3.0-standalone.html</crossRef>
-         <crossRef>http://www.opensource.org/licenses/GPL-3.0</crossRef>
+         <crossRef>https://opensource.org/licenses/GPL-3.0</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/GPL-3.0-only.xml
+++ b/src/GPL-3.0-only.xml
@@ -3,7 +3,7 @@
   <license licenseId="GPL-3.0-only" isOsiApproved="true"
   name="GNU General Public License v3.0 only">
     <crossRefs>
-      <crossRef>http://www.gnu.org/licenses/gpl-3.0-standalone.html</crossRef>
+      <crossRef>https://www.gnu.org/licenses/gpl-3.0-standalone.html</crossRef>
       <crossRef>http://www.opensource.org/licenses/GPL-3.0</crossRef>
     </crossRefs>
     <standardLicenseHeader>

--- a/src/GPL-3.0-only.xml
+++ b/src/GPL-3.0-only.xml
@@ -4,7 +4,7 @@
   name="GNU General Public License v3.0 only">
     <crossRefs>
       <crossRef>https://www.gnu.org/licenses/gpl-3.0-standalone.html</crossRef>
-      <crossRef>http://www.opensource.org/licenses/GPL-3.0</crossRef>
+      <crossRef>https://opensource.org/licenses/GPL-3.0</crossRef>
     </crossRefs>
     <standardLicenseHeader>
       Copyright (C) <alt name="copyright"

--- a/src/GPL-3.0-or-later.xml
+++ b/src/GPL-3.0-or-later.xml
@@ -4,7 +4,7 @@
   name="GNU General Public License v3.0 or later">
     <crossRefs>
       <crossRef>https://www.gnu.org/licenses/gpl-3.0-standalone.html</crossRef>
-      <crossRef>http://www.opensource.org/licenses/GPL-3.0</crossRef>
+      <crossRef>https://opensource.org/licenses/GPL-3.0</crossRef>
     </crossRefs>
     <notes>
       This license was released: 29 June 2007

--- a/src/GPL-3.0-or-later.xml
+++ b/src/GPL-3.0-or-later.xml
@@ -3,7 +3,7 @@
   <license licenseId="GPL-3.0-or-later" isOsiApproved="true"
   name="GNU General Public License v3.0 or later">
     <crossRefs>
-      <crossRef>http://www.gnu.org/licenses/gpl-3.0-standalone.html</crossRef>
+      <crossRef>https://www.gnu.org/licenses/gpl-3.0-standalone.html</crossRef>
       <crossRef>http://www.opensource.org/licenses/GPL-3.0</crossRef>
     </crossRefs>
     <notes>

--- a/src/GPL-3.0-with-GCC-exception.xml
+++ b/src/GPL-3.0-with-GCC-exception.xml
@@ -7,7 +7,7 @@
          <obsoletedBy expression="GPL-3.0-with-GCC-exception+">GPL-3.0-or-later WITH GCC-exception-3.1</obsoletedBy>
       </obsoletedBys>
       <crossRefs>
-         <crossRef>http://www.gnu.org/licenses/gcc-exception-3.1.html</crossRef>
+         <crossRef>https://www.gnu.org/licenses/gcc-exception-3.1.html</crossRef>
       </crossRefs>
     <text>
 	  <p>﻿insert GPL v3 text here</p>

--- a/src/GPL-3.0-with-autoconf-exception.xml
+++ b/src/GPL-3.0-with-autoconf-exception.xml
@@ -7,7 +7,7 @@
          <obsoletedBy expression="GPL-3.0-with-autoconf-exception+">GPL-3.0-or-later WITH Autoconf-exception-3.0</obsoletedBy>
       </obsoletedBys>
       <crossRefs>
-         <crossRef>http://www.gnu.org/licenses/autoconf-exception-3.0.html</crossRef>
+         <crossRef>https://www.gnu.org/licenses/autoconf-exception-3.0.html</crossRef>
       </crossRefs>
      
     <text>

--- a/src/GPL-3.0.xml
+++ b/src/GPL-3.0.xml
@@ -8,7 +8,7 @@
       <obsoletedBy expression="GPL-3.0+">GPL-3.0-or-later</obsoletedBy>
     </obsoletedBys>
     <crossRefs>
-      <crossRef>http://www.gnu.org/licenses/gpl-3.0-standalone.html</crossRef>
+      <crossRef>https://www.gnu.org/licenses/gpl-3.0-standalone.html</crossRef>
       <crossRef>http://www.opensource.org/licenses/GPL-3.0</crossRef>
     </crossRefs>
     <standardLicenseHeader>

--- a/src/GPL-3.0.xml
+++ b/src/GPL-3.0.xml
@@ -9,7 +9,7 @@
     </obsoletedBys>
     <crossRefs>
       <crossRef>https://www.gnu.org/licenses/gpl-3.0-standalone.html</crossRef>
-      <crossRef>http://www.opensource.org/licenses/GPL-3.0</crossRef>
+      <crossRef>https://opensource.org/licenses/GPL-3.0</crossRef>
     </crossRefs>
     <standardLicenseHeader>
       Copyright (C) <alt name="copyright"

--- a/src/HPND.xml
+++ b/src/HPND.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="true" licenseId="HPND"
             name="Historical Permission Notice and Disclaimer">
       <crossRefs>
-         <crossRef>http://www.opensource.org/licenses/HPND</crossRef>
+         <crossRef>https://opensource.org/licenses/HPND</crossRef>
       </crossRefs>
       <notes>
     This license has been voluntarily deprecated by its author.

--- a/src/IPA.xml
+++ b/src/IPA.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="IPA" name="IPA Font License">
       <crossRefs>
-         <crossRef>http://www.opensource.org/licenses/IPA</crossRef>
+         <crossRef>https://opensource.org/licenses/IPA</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/IPL-1.0.xml
+++ b/src/IPL-1.0.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="IPL-1.0" name="IBM Public License v1.0">
       <crossRefs>
-         <crossRef>http://www.opensource.org/licenses/IPL-1.0</crossRef>
+         <crossRef>https://opensource.org/licenses/IPL-1.0</crossRef>
       </crossRefs>
       <notes>This license was superseded by CPL.</notes>
     <text>

--- a/src/ISC.xml
+++ b/src/ISC.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="true" licenseId="ISC" name="ISC License">
       <crossRefs>
          <crossRef>https://www.isc.org/downloads/software-support-policy/isc-license/</crossRef>
-         <crossRef>http://www.opensource.org/licenses/ISC</crossRef>
+         <crossRef>https://opensource.org/licenses/ISC</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/Intel.xml
+++ b/src/Intel.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="Intel" name="Intel Open Source License">
       <crossRefs>
-         <crossRef>http://opensource.org/licenses/Intel</crossRef>
+         <crossRef>https://opensource.org/licenses/Intel</crossRef>
       </crossRefs>
       <notes>This license has been deprecated. A note at the top of the OSI license page states, "The Intel Open
          Source License for CDSA/CSSM Implementation (BSD License with Export Notice) (Intel has ceased to use

--- a/src/LGPL-2.0+.xml
+++ b/src/LGPL-2.0+.xml
@@ -6,7 +6,7 @@
          <obsoletedBy>LGPL-2.0-or-later</obsoletedBy>
       </obsoletedBys>
       <crossRefs>
-         <crossRef>http://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html</crossRef>
+         <crossRef>https://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/LGPL-2.0-only.xml
+++ b/src/LGPL-2.0-only.xml
@@ -3,7 +3,7 @@
   <license licenseId="LGPL-2.0-only" isOsiApproved="true"
   name="GNU Library General Public License v2 only">
     <crossRefs>
-      <crossRef>http://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html</crossRef>
+      <crossRef>https://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html</crossRef>
     </crossRefs>
     <standardLicenseHeader>
       Copyright (C) <alt name="copyright" match=".+">year name of author</alt>

--- a/src/LGPL-2.0-or-later.xml
+++ b/src/LGPL-2.0-or-later.xml
@@ -3,7 +3,7 @@
   <license licenseId="LGPL-2.0-or-later" isOsiApproved="true"
   name="GNU Library General Public License v2 or later">
     <crossRefs>
-      <crossRef>http://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html</crossRef>
+      <crossRef>https://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html</crossRef>
     </crossRefs>
     <notes>
       This license was released: June 1991. This license has

--- a/src/LGPL-2.0.xml
+++ b/src/LGPL-2.0.xml
@@ -8,7 +8,7 @@
       <obsoletedBy expression="LGPL-2.0+">LGPL-2.0-or-later</obsoletedBy>
     </obsoletedBys>
     <crossRefs>
-      <crossRef>http://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html</crossRef>
+      <crossRef>https://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html</crossRef>
     </crossRefs>
     <standardLicenseHeader>
       Copyright (C) <alt name="copyright" match=".+">year name of author</alt>

--- a/src/LGPL-2.1+.xml
+++ b/src/LGPL-2.1+.xml
@@ -7,7 +7,7 @@
       </obsoletedBys>
       <crossRefs>
          <crossRef>https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</crossRef>
-         <crossRef>http://www.opensource.org/licenses/LGPL-2.1</crossRef>
+         <crossRef>https://opensource.org/licenses/LGPL-2.1</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/LGPL-2.1+.xml
+++ b/src/LGPL-2.1+.xml
@@ -6,7 +6,7 @@
          <obsoletedBy>LGPL-2.1-or-later</obsoletedBy>
       </obsoletedBys>
       <crossRefs>
-         <crossRef>http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</crossRef>
+         <crossRef>https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</crossRef>
          <crossRef>http://www.opensource.org/licenses/LGPL-2.1</crossRef>
       </crossRefs>
     <text>

--- a/src/LGPL-2.1-only.xml
+++ b/src/LGPL-2.1-only.xml
@@ -4,7 +4,7 @@
   name="GNU Lesser General Public License v2.1 only">
     <crossRefs>
       <crossRef>https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</crossRef>
-      <crossRef>http://www.opensource.org/licenses/LGPL-2.1</crossRef>
+      <crossRef>https://opensource.org/licenses/LGPL-2.1</crossRef>
     </crossRefs>
     <standardLicenseHeader>
       Copyright (C) <alt name="copyright" match=".+">year name of author</alt>

--- a/src/LGPL-2.1-only.xml
+++ b/src/LGPL-2.1-only.xml
@@ -3,7 +3,7 @@
   <license licenseId="LGPL-2.1-only" isOsiApproved="true"
   name="GNU Lesser General Public License v2.1 only">
     <crossRefs>
-      <crossRef>http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</crossRef>
+      <crossRef>https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</crossRef>
       <crossRef>http://www.opensource.org/licenses/LGPL-2.1</crossRef>
     </crossRefs>
     <standardLicenseHeader>

--- a/src/LGPL-2.1-or-later.xml
+++ b/src/LGPL-2.1-or-later.xml
@@ -3,7 +3,7 @@
   <license licenseId="LGPL-2.1-or-later" isOsiApproved="true"
   name="GNU Lesser General Public License v2.1 or later">
     <crossRefs>
-      <crossRef>http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</crossRef>
+      <crossRef>https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</crossRef>
       <crossRef>http://www.opensource.org/licenses/LGPL-2.1</crossRef>
     </crossRefs>
     <notes>

--- a/src/LGPL-2.1-or-later.xml
+++ b/src/LGPL-2.1-or-later.xml
@@ -4,7 +4,7 @@
   name="GNU Lesser General Public License v2.1 or later">
     <crossRefs>
       <crossRef>https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</crossRef>
-      <crossRef>http://www.opensource.org/licenses/LGPL-2.1</crossRef>
+      <crossRef>https://opensource.org/licenses/LGPL-2.1</crossRef>
     </crossRefs>
     <notes>
       This license was released: February 1999.

--- a/src/LGPL-2.1.xml
+++ b/src/LGPL-2.1.xml
@@ -8,7 +8,7 @@
       <obsoletedBy expression="LGPL-2.1+">LGPL-2.1-or-later</obsoletedBy>
     </obsoletedBys>
     <crossRefs>
-      <crossRef>http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</crossRef>
+      <crossRef>https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</crossRef>
       <crossRef>http://www.opensource.org/licenses/LGPL-2.1</crossRef>
     </crossRefs>
     <standardLicenseHeader>

--- a/src/LGPL-2.1.xml
+++ b/src/LGPL-2.1.xml
@@ -9,7 +9,7 @@
     </obsoletedBys>
     <crossRefs>
       <crossRef>https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</crossRef>
-      <crossRef>http://www.opensource.org/licenses/LGPL-2.1</crossRef>
+      <crossRef>https://opensource.org/licenses/LGPL-2.1</crossRef>
     </crossRefs>
     <standardLicenseHeader>
       Copyright (C) <alt name="copyright" match=".+">year name of author</alt>

--- a/src/LGPL-3.0+.xml
+++ b/src/LGPL-3.0+.xml
@@ -7,7 +7,7 @@
       </obsoletedBys>
       <crossRefs>
          <crossRef>https://www.gnu.org/licenses/lgpl-3.0-standalone.html</crossRef>
-         <crossRef>http://www.opensource.org/licenses/LGPL-3.0</crossRef>
+         <crossRef>https://opensource.org/licenses/LGPL-3.0</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/LGPL-3.0+.xml
+++ b/src/LGPL-3.0+.xml
@@ -6,7 +6,7 @@
          <obsoletedBy>LGPL-3.0-or-later</obsoletedBy>
       </obsoletedBys>
       <crossRefs>
-         <crossRef>http://www.gnu.org/licenses/lgpl-3.0-standalone.html</crossRef>
+         <crossRef>https://www.gnu.org/licenses/lgpl-3.0-standalone.html</crossRef>
          <crossRef>http://www.opensource.org/licenses/LGPL-3.0</crossRef>
       </crossRefs>
     <text>

--- a/src/LGPL-3.0-only.xml
+++ b/src/LGPL-3.0-only.xml
@@ -4,7 +4,7 @@
   name="GNU Lesser General Public License v3.0 only">
     <crossRefs>
       <crossRef>https://www.gnu.org/licenses/lgpl-3.0-standalone.html</crossRef>
-      <crossRef>http://www.opensource.org/licenses/LGPL-3.0</crossRef>
+      <crossRef>https://opensource.org/licenses/LGPL-3.0</crossRef>
     </crossRefs>
     <notes>
       This license was released: 29 June 2007. This refers to when

--- a/src/LGPL-3.0-only.xml
+++ b/src/LGPL-3.0-only.xml
@@ -3,7 +3,7 @@
   <license licenseId="LGPL-3.0-only" isOsiApproved="true"
   name="GNU Lesser General Public License v3.0 only">
     <crossRefs>
-      <crossRef>http://www.gnu.org/licenses/lgpl-3.0-standalone.html</crossRef>
+      <crossRef>https://www.gnu.org/licenses/lgpl-3.0-standalone.html</crossRef>
       <crossRef>http://www.opensource.org/licenses/LGPL-3.0</crossRef>
     </crossRefs>
     <notes>

--- a/src/LGPL-3.0-or-later.xml
+++ b/src/LGPL-3.0-or-later.xml
@@ -3,7 +3,7 @@
   <license licenseId="LGPL-3.0-or-later" isOsiApproved="true"
   name="GNU Lesser General Public License v3.0 or later">
     <crossRefs>
-      <crossRef>http://www.gnu.org/licenses/lgpl-3.0-standalone.html</crossRef>
+      <crossRef>https://www.gnu.org/licenses/lgpl-3.0-standalone.html</crossRef>
       <crossRef>http://www.opensource.org/licenses/LGPL-3.0</crossRef>
     </crossRefs>
     <notes>

--- a/src/LGPL-3.0-or-later.xml
+++ b/src/LGPL-3.0-or-later.xml
@@ -4,7 +4,7 @@
   name="GNU Lesser General Public License v3.0 or later">
     <crossRefs>
       <crossRef>https://www.gnu.org/licenses/lgpl-3.0-standalone.html</crossRef>
-      <crossRef>http://www.opensource.org/licenses/LGPL-3.0</crossRef>
+      <crossRef>https://opensource.org/licenses/LGPL-3.0</crossRef>
     </crossRefs>
     <notes>
       This license was released: 29 June 2007.

--- a/src/LGPL-3.0.xml
+++ b/src/LGPL-3.0.xml
@@ -9,7 +9,7 @@
     </obsoletedBys>
     <crossRefs>
       <crossRef>https://www.gnu.org/licenses/lgpl-3.0-standalone.html</crossRef>
-      <crossRef>http://www.opensource.org/licenses/LGPL-3.0</crossRef>
+      <crossRef>https://opensource.org/licenses/LGPL-3.0</crossRef>
     </crossRefs>
     <text>
     <titleText>

--- a/src/LGPL-3.0.xml
+++ b/src/LGPL-3.0.xml
@@ -8,7 +8,7 @@
       <obsoletedBy expression="LGPL-3.0+">LGPL-3.0-or-later</obsoletedBy>
     </obsoletedBys>
     <crossRefs>
-      <crossRef>http://www.gnu.org/licenses/lgpl-3.0-standalone.html</crossRef>
+      <crossRef>https://www.gnu.org/licenses/lgpl-3.0-standalone.html</crossRef>
       <crossRef>http://www.opensource.org/licenses/LGPL-3.0</crossRef>
     </crossRefs>
     <text>

--- a/src/LPL-1.0.xml
+++ b/src/LPL-1.0.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="true" licenseId="LPL-1.0"
             name="Lucent Public License Version 1.0">
       <crossRefs>
-         <crossRef>http://opensource.org/licenses/LPL-1.0</crossRef>
+         <crossRef>https://opensource.org/licenses/LPL-1.0</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/LPL-1.02.xml
+++ b/src/LPL-1.02.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="true" licenseId="LPL-1.02" name="Lucent Public License v1.02">
       <crossRefs>
          <crossRef>http://plan9.bell-labs.com/plan9/license.html</crossRef>
-         <crossRef>http://www.opensource.org/licenses/LPL-1.02</crossRef>
+         <crossRef>https://opensource.org/licenses/LPL-1.02</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/LPPL-1.3c.xml
+++ b/src/LPPL-1.3c.xml
@@ -4,7 +4,7 @@
             name="LaTeX Project Public License v1.3c">
       <crossRefs>
          <crossRef>http://www.latex-project.org/lppl/lppl-1-3c.txt</crossRef>
-         <crossRef>http://www.opensource.org/licenses/LPPL-1.3c</crossRef>
+         <crossRef>https://opensource.org/licenses/LPPL-1.3c</crossRef>
       </crossRefs>
       <notes>This license was released: 4 May 2008</notes>
     <text>

--- a/src/MIT.xml
+++ b/src/MIT.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="MIT" name="MIT License">
       <crossRefs>
-         <crossRef>http://www.opensource.org/licenses/MIT</crossRef>
+         <crossRef>https://opensource.org/licenses/MIT</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/MPL-1.0.xml
+++ b/src/MPL-1.0.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="true" licenseId="MPL-1.0" name="Mozilla Public License 1.0">
       <crossRefs>
          <crossRef>http://www.mozilla.org/MPL/MPL-1.0.html</crossRef>
-         <crossRef>http://opensource.org/licenses/MPL-1.0</crossRef>
+         <crossRef>https://opensource.org/licenses/MPL-1.0</crossRef>
       </crossRefs>
       <notes>This license has been superseded by v1.1</notes>
     <text>

--- a/src/MPL-1.1.xml
+++ b/src/MPL-1.1.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="true" licenseId="MPL-1.1" name="Mozilla Public License 1.1">
       <crossRefs>
          <crossRef>http://www.mozilla.org/MPL/MPL-1.1.html</crossRef>
-         <crossRef>http://www.opensource.org/licenses/MPL-1.1</crossRef>
+         <crossRef>https://opensource.org/licenses/MPL-1.1</crossRef>
       </crossRefs>
       <notes>This license has been superseded by v2.0</notes>
     <text>

--- a/src/MPL-2.0-no-copyleft-exception.xml
+++ b/src/MPL-2.0-no-copyleft-exception.xml
@@ -4,7 +4,7 @@
             name="Mozilla Public License 2.0 (no copyleft exception)">
       <crossRefs>
          <crossRef>http://www.mozilla.org/MPL/2.0/</crossRef>
-         <crossRef>http://opensource.org/licenses/MPL-2.0</crossRef>
+         <crossRef>https://opensource.org/licenses/MPL-2.0</crossRef>
       </crossRefs>
       <notes>This license was released in January 2012. This license list entry is for use when the MPL's Exhibit B,
          which removes the Sec 3.3 copyleft exception.</notes>

--- a/src/MPL-2.0.xml
+++ b/src/MPL-2.0.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="true" licenseId="MPL-2.0" name="Mozilla Public License 2.0">
       <crossRefs>
          <crossRef>http://www.mozilla.org/MPL/2.0/</crossRef>
-         <crossRef>http://opensource.org/licenses/MPL-2.0</crossRef>
+         <crossRef>https://opensource.org/licenses/MPL-2.0</crossRef>
       </crossRefs>
       <notes>This license was released in January 2012. This license list entry is for use when the standard MPL 2.0 is
          used, as indicated by the standard header (Exhibit A but no Exhibit B).</notes>

--- a/src/MS-PL.xml
+++ b/src/MS-PL.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="true" licenseId="MS-PL" name="Microsoft Public License">
       <crossRefs>
          <crossRef>http://www.microsoft.com/opensource/licenses.mspx</crossRef>
-         <crossRef>http://www.opensource.org/licenses/MS-PL</crossRef>
+         <crossRef>https://opensource.org/licenses/MS-PL</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/MS-RL.xml
+++ b/src/MS-RL.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="true" licenseId="MS-RL" name="Microsoft Reciprocal License">
       <crossRefs>
          <crossRef>http://www.microsoft.com/opensource/licenses.mspx</crossRef>
-         <crossRef>http://www.opensource.org/licenses/MS-RL</crossRef>
+         <crossRef>https://opensource.org/licenses/MS-RL</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/MirOS.xml
+++ b/src/MirOS.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="MirOS" name="MirOS License">
       <crossRefs>
-         <crossRef>http://www.opensource.org/licenses/MirOS</crossRef>
+         <crossRef>https://opensource.org/licenses/MirOS</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/Motosoto.xml
+++ b/src/Motosoto.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="Motosoto" name="Motosoto License">
       <crossRefs>
-         <crossRef>http://www.opensource.org/licenses/Motosoto</crossRef>
+         <crossRef>https://opensource.org/licenses/Motosoto</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/Multics.xml
+++ b/src/Multics.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="Multics" name="Multics License">
       <crossRefs>
-         <crossRef>http://www.opensource.org/licenses/Multics</crossRef>
+         <crossRef>https://opensource.org/licenses/Multics</crossRef>
       </crossRefs>
       <notes>
      

--- a/src/NASA-1.3.xml
+++ b/src/NASA-1.3.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="true" licenseId="NASA-1.3" name="NASA Open Source Agreement 1.3">
       <crossRefs>
          <crossRef>http://ti.arc.nasa.gov/opensource/nosa/</crossRef>
-         <crossRef>http://www.opensource.org/licenses/NASA-1.3</crossRef>
+         <crossRef>https://opensource.org/licenses/NASA-1.3</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/NCSA.xml
+++ b/src/NCSA.xml
@@ -4,7 +4,7 @@
             name="University of Illinois/NCSA Open Source License">
       <crossRefs>
          <crossRef>http://otm.illinois.edu/uiuc_openSource</crossRef>
-         <crossRef>http://www.opensource.org/licenses/NCSA</crossRef>
+         <crossRef>https://opensource.org/licenses/NCSA</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/NGPL.xml
+++ b/src/NGPL.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="NGPL" name="Nethack General Public License">
       <crossRefs>
-         <crossRef>http://www.opensource.org/licenses/NGPL</crossRef>
+         <crossRef>https://opensource.org/licenses/NGPL</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/NPOSL-3.0.xml
+++ b/src/NPOSL-3.0.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="true" licenseId="NPOSL-3.0"
             name="Non-Profit Open Software License 3.0">
       <crossRefs>
-         <crossRef>http://www.opensource.org/licenses/NOSL3.0</crossRef>
+         <crossRef>https://opensource.org/licenses/NOSL3.0</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/NTP.xml
+++ b/src/NTP.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="NTP" name="NTP License">
       <crossRefs>
-         <crossRef>http://www.opensource.org/licenses/NTP</crossRef>
+         <crossRef>https://opensource.org/licenses/NTP</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/Naumen.xml
+++ b/src/Naumen.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="Naumen" name="Naumen Public License">
       <crossRefs>
-         <crossRef>http://www.opensource.org/licenses/Naumen</crossRef>
+         <crossRef>https://opensource.org/licenses/Naumen</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/Nokia.xml
+++ b/src/Nokia.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="Nokia" name="Nokia Open Source License">
       <crossRefs>
-         <crossRef>http://www.opensource.org/licenses/nokia</crossRef>
+         <crossRef>https://opensource.org/licenses/nokia</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/OCLC-2.0.xml
+++ b/src/OCLC-2.0.xml
@@ -4,7 +4,7 @@
             name="OCLC Research Public License 2.0">
       <crossRefs>
          <crossRef>http://www.oclc.org/research/activities/software/license/v2final.htm</crossRef>
-         <crossRef>http://www.opensource.org/licenses/OCLC-2.0</crossRef>
+         <crossRef>https://opensource.org/licenses/OCLC-2.0</crossRef>
       </crossRefs>
       <notes>This license was released: May 2002</notes>
     <text>

--- a/src/OFL-1.1.xml
+++ b/src/OFL-1.1.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="true" licenseId="OFL-1.1" name="SIL Open Font License 1.1">
       <crossRefs>
          <crossRef>http://scripts.sil.org/cms/scripts/page.php?item_id=OFL_web</crossRef>
-         <crossRef>http://www.opensource.org/licenses/OFL-1.1</crossRef>
+         <crossRef>https://opensource.org/licenses/OFL-1.1</crossRef>
       </crossRefs>
       <notes>This license was released: 26 February 2007.</notes>
     <text>

--- a/src/OGTSL.xml
+++ b/src/OGTSL.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="true" licenseId="OGTSL" name="Open Group Test Suite License">
       <crossRefs>
          <crossRef>http://www.opengroup.org/testing/downloads/The_Open_Group_TSL.txt</crossRef>
-         <crossRef>http://www.opensource.org/licenses/OGTSL</crossRef>
+         <crossRef>https://opensource.org/licenses/OGTSL</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/OSET-PL-2.1.xml
+++ b/src/OSET-PL-2.1.xml
@@ -4,7 +4,7 @@
             name="OSET Public License version 2.1">
       <crossRefs>
          <crossRef>http://www.osetfoundation.org/public-license</crossRef>
-         <crossRef>http://opensource.org/licenses/OPL-2.1</crossRef>
+         <crossRef>https://opensource.org/licenses/OPL-2.1</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/OSL-1.0.xml
+++ b/src/OSL-1.0.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="OSL-1.0" name="Open Software License 1.0">
       <crossRefs>
-         <crossRef>http://opensource.org/licenses/OSL-1.0</crossRef>
+         <crossRef>https://opensource.org/licenses/OSL-1.0</crossRef>
       </crossRefs>
       <notes>This license has been superseded.</notes>
     <text>

--- a/src/OSL-2.1.xml
+++ b/src/OSL-2.1.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="true" licenseId="OSL-2.1" name="Open Software License 2.1">
       <crossRefs>
          <crossRef>http://web.archive.org/web/20050212003940/http://www.rosenlaw.com/osl21.htm</crossRef>
-         <crossRef>http://opensource.org/licenses/OSL-2.1</crossRef>
+         <crossRef>https://opensource.org/licenses/OSL-2.1</crossRef>
       </crossRefs>
       <notes>Same as version 2.0 of this license except with changes to section 10</notes>
     <text>

--- a/src/OSL-3.0.xml
+++ b/src/OSL-3.0.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="true" licenseId="OSL-3.0" name="Open Software License 3.0">
       <crossRefs>
          <crossRef>https://web.archive.org/web/20120101081418/http://rosenlaw.com:80/OSL3.0.htm</crossRef>
-         <crossRef>http://www.opensource.org/licenses/OSL-3.0</crossRef>
+         <crossRef>https://opensource.org/licenses/OSL-3.0</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/PHP-3.0.xml
+++ b/src/PHP-3.0.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="true" licenseId="PHP-3.0" name="PHP License v3.0">
       <crossRefs>
          <crossRef>http://www.php.net/license/3_0.txt</crossRef>
-         <crossRef>http://www.opensource.org/licenses/PHP-3.0</crossRef>
+         <crossRef>https://opensource.org/licenses/PHP-3.0</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/PostgreSQL.xml
+++ b/src/PostgreSQL.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="true" licenseId="PostgreSQL" name="PostgreSQL License">
       <crossRefs>
          <crossRef>http://www.postgresql.org/about/licence</crossRef>
-         <crossRef>http://www.opensource.org/licenses/PostgreSQL</crossRef>
+         <crossRef>https://opensource.org/licenses/PostgreSQL</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/Python-2.0.xml
+++ b/src/Python-2.0.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="Python-2.0" name="Python License 2.0">
       <crossRefs>
-         <crossRef>http://www.opensource.org/licenses/Python-2.0</crossRef>
+         <crossRef>https://opensource.org/licenses/Python-2.0</crossRef>
       </crossRefs>
       <notes>This is the overall Python license, which is comprised of several licenses.</notes>
     <text>

--- a/src/QPL-1.0.xml
+++ b/src/QPL-1.0.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="true" licenseId="QPL-1.0" name="Q Public License 1.0">
       <crossRefs>
          <crossRef>http://doc.qt.nokia.com/3.3/license.html</crossRef>
-         <crossRef>http://www.opensource.org/licenses/QPL-1.0</crossRef>
+         <crossRef>https://opensource.org/licenses/QPL-1.0</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/RPL-1.1.xml
+++ b/src/RPL-1.1.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="RPL-1.1" name="Reciprocal Public License 1.1">
       <crossRefs>
-         <crossRef>http://opensource.org/licenses/RPL-1.1</crossRef>
+         <crossRef>https://opensource.org/licenses/RPL-1.1</crossRef>
       </crossRefs>
       <notes>This license has been superseded by the Reciprocal Public License, version 1.5</notes>
     <text>

--- a/src/RPL-1.5.xml
+++ b/src/RPL-1.5.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="RPL-1.5" name="Reciprocal Public License 1.5">
       <crossRefs>
-         <crossRef>http://www.opensource.org/licenses/RPL-1.5</crossRef>
+         <crossRef>https://opensource.org/licenses/RPL-1.5</crossRef>
       </crossRefs>
       <notes>This license was released: 15 July 2007</notes>
     <text>

--- a/src/RPSL-1.0.xml
+++ b/src/RPSL-1.0.xml
@@ -4,7 +4,7 @@
             name="RealNetworks Public Source License v1.0">
       <crossRefs>
          <crossRef>https://helixcommunity.org/content/rpsl</crossRef>
-         <crossRef>http://www.opensource.org/licenses/RPSL-1.0</crossRef>
+         <crossRef>https://opensource.org/licenses/RPSL-1.0</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/RSCPL.xml
+++ b/src/RSCPL.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="true" licenseId="RSCPL" name="Ricoh Source Code Public License">
       <crossRefs>
          <crossRef>http://wayback.archive.org/web/20060715140826/http://www.risource.org/RPL/RPL-1.0A.shtml</crossRef>
-         <crossRef>http://www.opensource.org/licenses/RSCPL</crossRef>
+         <crossRef>https://opensource.org/licenses/RSCPL</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/SISSL.xml
+++ b/src/SISSL.xml
@@ -4,7 +4,7 @@
             name="Sun Industry Standards Source License v1.1">
       <crossRefs>
          <crossRef>http://www.openoffice.org/licenses/sissl_license.html</crossRef>
-         <crossRef>http://opensource.org/licenses/SISSL</crossRef>
+         <crossRef>https://opensource.org/licenses/SISSL</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/SPL-1.0.xml
+++ b/src/SPL-1.0.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="SPL-1.0" name="Sun Public License v1.0">
       <crossRefs>
-         <crossRef>http://www.opensource.org/licenses/SPL-1.0</crossRef>
+         <crossRef>https://opensource.org/licenses/SPL-1.0</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/SimPL-2.0.xml
+++ b/src/SimPL-2.0.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="SimPL-2.0" name="Simple Public License 2.0">
       <crossRefs>
-         <crossRef>http://www.opensource.org/licenses/SimPL-2.0</crossRef>
+         <crossRef>https://opensource.org/licenses/SimPL-2.0</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/Sleepycat.xml
+++ b/src/Sleepycat.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="Sleepycat" name="Sleepycat License">
       <crossRefs>
-         <crossRef>http://www.opensource.org/licenses/Sleepycat</crossRef>
+         <crossRef>https://opensource.org/licenses/Sleepycat</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/UPL-1.0.xml
+++ b/src/UPL-1.0.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="true" licenseId="UPL-1.0"
             name="Universal Permissive License v1.0">
       <crossRefs>
-         <crossRef>http://opensource.org/licenses/UPL</crossRef>
+         <crossRef>https://opensource.org/licenses/UPL</crossRef>
       </crossRefs>
     <text>
       <copyrightText>

--- a/src/VSL-1.0.xml
+++ b/src/VSL-1.0.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="VSL-1.0" name="Vovida Software License v1.0">
       <crossRefs>
-         <crossRef>http://www.opensource.org/licenses/VSL-1.0</crossRef>
+         <crossRef>https://opensource.org/licenses/VSL-1.0</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/W3C.xml
+++ b/src/W3C.xml
@@ -4,7 +4,7 @@
             name="W3C Software Notice and License (2002-12-31)">
       <crossRefs>
          <crossRef>http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231.html</crossRef>
-         <crossRef>http://www.opensource.org/licenses/W3C</crossRef>
+         <crossRef>https://opensource.org/licenses/W3C</crossRef>
       </crossRefs>
       <standardLicenseHeader>
          <copyrightText>Copyright (C) <alt match=".+" name="year">[$date-of-software]</alt> World Wide Web Consortium, 

--- a/src/Watcom-1.0.xml
+++ b/src/Watcom-1.0.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="true" licenseId="Watcom-1.0"
             name="Sybase Open Watcom Public License 1.0">
       <crossRefs>
-         <crossRef>http://www.opensource.org/licenses/Watcom-1.0</crossRef>
+         <crossRef>https://opensource.org/licenses/Watcom-1.0</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/Xnet.xml
+++ b/src/Xnet.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="Xnet" name="X.Net License">
       <crossRefs>
-         <crossRef>http://opensource.org/licenses/Xnet</crossRef>
+         <crossRef>https://opensource.org/licenses/Xnet</crossRef>
       </crossRefs>
       <notes>This license is the same as MIT, but with a choice of law clause. This License has been voluntarily
          deprecated by its author.</notes>

--- a/src/ZPL-2.0.xml
+++ b/src/ZPL-2.0.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="true" licenseId="ZPL-2.0" name="Zope Public License 2.0">
       <crossRefs>
          <crossRef>http://old.zope.org/Resources/License/ZPL-2.0</crossRef>
-         <crossRef>http://opensource.org/licenses/ZPL-2.0</crossRef>
+         <crossRef>https://opensource.org/licenses/ZPL-2.0</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/Zlib.xml
+++ b/src/Zlib.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="true" licenseId="Zlib" name="zlib License">
       <crossRefs>
          <crossRef>http://www.zlib.net/zlib_license.html</crossRef>
-         <crossRef>http://www.opensource.org/licenses/Zlib</crossRef>
+         <crossRef>https://opensource.org/licenses/Zlib</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/eCos-2.0.xml
+++ b/src/eCos-2.0.xml
@@ -5,7 +5,7 @@
           <obsoletedBy>GPL-2.0-or-later WITH eCos-exception-2.0</obsoletedBy>
       </obsoletedBys>
       <crossRefs>
-         <crossRef>http://www.gnu.org/licenses/ecos-license.html</crossRef>
+         <crossRef>https://www.gnu.org/licenses/ecos-license.html</crossRef>
       </crossRefs>
     <text>
       <titleText>The eCos license version 2.0</titleText>

--- a/src/wxWindows.xml
+++ b/src/wxWindows.xml
@@ -5,7 +5,7 @@
          <obsoletedBy>GPL-2.0-or-later WITH WxWindows-exception-3.1</obsoletedBy>
       </obsoletedBys>
       <crossRefs>
-         <crossRef>http://www.opensource.org/licenses/WXwindows</crossRef>
+         <crossRef>https://opensource.org/licenses/WXwindows</crossRef>
       </crossRefs>
     <text>
       <p>EXCEPTION NOTICE</p>


### PR DESCRIPTION
<http://gnu.org>, <http://creativecommons.org> and <http://opensource.org> all redirect to their respective HTTPS counterparts. This pull request updates these URLs (only in `crossRefs`, never in license text) to redirect targets.