### PR TITLE
Correct 0BSD License Title

### DIFF
--- a/src/0BSD.xml
+++ b/src/0BSD.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isOsiApproved="true" licenseId="0BSD" name="BSD Zero Clause License">
+   <license isOsiApproved="true" licenseId="0BSD" name="Zero Clause BSD License">
       <crossRefs>
          <crossRef>http://landley.net/toybox/license.html</crossRef>
       </crossRefs>


### PR DESCRIPTION
https://github.com/github/choosealicense.com/issues/464#issuecomment-438718643

<img width="783" alt="screen shot 2019-02-11 at 6 36 32 pm" src="https://user-images.githubusercontent.com/440298/52558005-0f33c300-2e2c-11e9-9512-193fad53a215.png">

**Edit:** The OSI recognizes it as the "Zero-Clause BSD" license which you may confirm here: http://lists.opensource.org/pipermail/license-review_lists.opensource.org/2018-November/003830.html