### PR TITLE
Add HPND-sell-variant license

### DIFF
--- a/src/HPND-sell-variant.xml
+++ b/src/HPND-sell-variant.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SPDXLicenseCollection xmlns="http://www.spdx.org/license">
+   <license isOsiApproved="false" licenseId="HPND-sell-variant"
+            name="Historical Permission Notice and Disclaimer - sell variant">
+      <crossRefs>
+         <crossRef>https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/net/sunrpc/auth_gss/gss_generic_token.c?h=v4.19</crossRef>
+      </crossRefs>
+      <notes>
+    This license is a variant of HPND (https://spdx.org/licenses/HPND.html). This variant explicitly includes the permission to "sell" the software, which is not explicitly referenced in the HPND template, and makes a few other minor changes. It otherwise retains the optional templated formatting from HPND.
+  </notes>
+    <text>
+      <copyrightText>
+         <p><alt match=".+" name="copyright">&lt;copyright notice&gt;</alt></p>
+      </copyrightText>
+    
+      <p>Permission to use, copy, modify, distribute, and sell this software and its documentation for any purpose
+         is hereby granted without fee, provided that the above copyright notice appears in all copies<optional>,</optional> 
+         <optional>and</optional> that both <optional>that</optional> 
+         <optional>the</optional> copyright notice 
+         and this permission notice appear in supporting documentation<optional>, and that the name <optional>of</optional> 
+            <alt match=".*" name="copyrightHolder0">&lt;copyright holder&gt;</alt> 
+            <alt match=".*" name="orRelated">&lt;or related entities&gt;</alt>
+         not be used in advertising or publicity pertaining to distribution of the software without specific, written
+         prior permission</optional>. <optional>
+            <alt match=".*" name="copyrightHolder1">&lt;copyright holder&gt;</alt> makes no representations 
+         about the suitability of this software for any purpose. It is provided "as is" without express or implied warranty.</optional>
+      </p>
+      <optional>
+        <p>
+            <alt match=".*" name="copyrightHolder2">&lt;copyright holder&gt;</alt> DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE, INCLUDING 
+           ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS<alt match="[.,]?" name="period">.</alt> IN NO EVENT SHALL 
+           <alt match=".*" name="copyrightHolder3">&lt;copyright holder&gt;</alt> BE LIABLE FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES 
+           OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, 
+           NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.</p>
+      </optional>
+    </text>
+  </license>
+</SPDXLicenseCollection>

--- a/src/HPND-sell-variant.xml
+++ b/src/HPND-sell-variant.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="false" licenseId="HPND-sell-variant"
-            name="Historical Permission Notice and Disclaimer - sell variant">
+            name="Historical Permission Notice and Disclaimer - sell variant" listVersionAdded="3.5">
       <crossRefs>
          <crossRef>https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/net/sunrpc/auth_gss/gss_generic_token.c?h=v4.19</crossRef>
       </crossRefs>

--- a/test/simpleTestForGenerator/HPND-sell-variant.txt
+++ b/test/simpleTestForGenerator/HPND-sell-variant.txt
@@ -1,0 +1,19 @@
+Copyright 1993 by OpenVision Technologies, Inc.
+
+Permission to use, copy, modify, distribute, and sell this software
+and its documentation for any purpose is hereby granted without fee,
+provided that the above copyright notice appears in all copies and
+that both that copyright notice and this permission notice appear in
+supporting documentation, and that the name of OpenVision not be used
+in advertising or publicity pertaining to distribution of the software
+without specific, written prior permission. OpenVision makes no
+representations about the suitability of this software for any
+purpose.  It is provided "as is" without express or implied warranty.
+
+OPENVISION DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
+INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS, IN NO
+EVENT SHALL OPENVISION BE LIABLE FOR ANY SPECIAL, INDIRECT OR
+CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF
+USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.


### PR DESCRIPTION
This commit adds a variant of HPND, which includes a few changes
from the HPND template. Most notable, it explicitly includes
"and sell" in the license grant language in the first sentence.

Fixes #753 

Signed-off-by: Steve Winslow <swinslow@gmail.com>