### PR TITLE
Add PIL license

### DIFF
--- a/src/PIL.xml
+++ b/src/PIL.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SPDXLicenseCollection xmlns="http://www.spdx.org/license">
+   <license isOsiApproved="false" licenseId="PIL" name="PIL Software License">
+      <crossRefs>
+         <crossRef>http://www.pythonware.com/products/pil/license.htm</crossRef>
+         <crossRef>https://github.com/python-pillow/Pillow/blob/fffb426092c8db24a5f4b6df243a8a3c01fb63cd/LICENSE</crossRef>
+      </crossRefs>
+      <notes>This license is used for PIL (Python Imaging Library) and Pillow. It is similar to MIT-CMU with a few potentially substantive changes.</notes>
+    <text>
+      <p>By obtaining, using, and/or copying this software and/or its associated documentation, you agree that you have read, understood, and will comply with the following terms and conditions:</p>
+    
+      <p>Permission to use, copy, modify, and distribute this software and its associated documentation for any purpose and
+         without fee is hereby granted, provided that the above copyright notice appears in all copies, and that
+         both that copyright notice and this permission notice appear in supporting documentation, and that the
+         name of Secret Labs AB or the author not be used in advertising or publicity
+         pertaining to distribution of the software without specific, written prior permission.</p>
+      <p>SECRET LABS AB AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
+         INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL SECRET LABS AB OR THE AUTHOR BE LIABLE FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY
+         DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+         NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+         THIS SOFTWARE.</p>
+    </text>
+  </license>
+</SPDXLicenseCollection>

--- a/test/simpleTestForGenerator/PIL.txt
+++ b/test/simpleTestForGenerator/PIL.txt
@@ -1,0 +1,5 @@
+By obtaining, using, and/or copying this software and/or its associated documentation, you agree that you have read, understood, and will comply with the following terms and conditions:
+
+Permission to use, copy, modify, and distribute this software and its associated documentation for any purpose and without fee is hereby granted, provided that the above copyright notice appears in all copies, and that both that copyright notice and this permission notice appear in supporting documentation, and that the name of Secret Labs AB or the author not be used in advertising or publicity pertaining to distribution of the software without specific, written prior permission.
+
+SECRET LABS AB AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL SECRET LABS AB OR THE AUTHOR BE LIABLE FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.


### PR DESCRIPTION
This commit adds PIL as a variant of MIT-CMU. Most notably,
it includes a custom "you agree" statement as the first line,
and it requires that written permission for use of the names
of the authors be "prior".

Fixes #750 

Signed-off-by: Steve Winslow <swinslow@gmail.com>