### PR TITLE
add explanatory text re: -only and -or-later

### DIFF
--- a/src/AGPL-3.0-only.xml
+++ b/src/AGPL-3.0-only.xml
@@ -24,7 +24,11 @@
 	      &lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;</p>
     </standardLicenseHeader>
     <notes>
-      This version was released: 19 November 2007
+      This version was released: 19 November 2007. This license identifier refers to the choice 
+      to use the code under AGPL-3.0-only, as distinguished from use of code under AGPL-3.0-or-later
+      (i.e., AGPL-3.0 or some later version). The license notice (as seen in the Standard License 
+      Header field below)  states which of these applies to the code in the file. The example 
+      in the exhibit to the license shows the license notice for the "or later" approach.
     </notes>
     <text>
     <titleText>

--- a/src/AGPL-3.0-or-later.xml
+++ b/src/AGPL-3.0-or-later.xml
@@ -7,7 +7,12 @@
       <crossRef>https://opensource.org/licenses/AGPL-3.0</crossRef>
     </crossRefs>
     <notes>
-      This version was released: 19 November 2007
+      This version was released: 19 November 2007. This license identifier refers to the 
+      choice to use code under AGPL-3.0-or-later (i.e., AGPL-3.0 or some later version),
+      as distinguished from use of code under AGPL-3.0-only. The license notice (as seen 
+      in the Standard License Header field below)  states which of these applies 
+      the code in the file. The example in the exhibit to the license shows the license 
+      notice for the "or later" approach.
     </notes>
     <text>
     <titleText>

--- a/src/GPL-1.0-only.xml
+++ b/src/GPL-1.0-only.xml
@@ -25,8 +25,12 @@
       </p>
     </standardLicenseHeader>
     <notes>
-      This license was released: February 1989. This refers to when this GPL version
-      1.0 only is being used (as opposed to "or later").
+      This license was released: February 1989. This license identifier refers to the choice 
+      to use the code under GPL-1.0-only, as distinguished from use of code under GPL-1.0-or-later
+      (i.e., GPL-1.0 or some later version). The license notice (as seen in the Standard License 
+      Header field below)  states which of these applies to the code in the file. The example 
+      in the exhibit to the license shows the license notice for the "or later" approach.
+
     </notes>
     <text>
     <titleText>

--- a/src/GPL-1.0-or-later.xml
+++ b/src/GPL-1.0-or-later.xml
@@ -6,8 +6,12 @@
       <crossRef>https://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html</crossRef>
     </crossRefs>
     <notes>
-      This license was released: February 1989. This license
-      has been deprecated by its authors.
+      This license was released: February 1989. This license identifier refers to the 
+      choice to use code under GPL-1.0-or-later (i.e., GPL-1.0 or some later version),
+      as distinguished from use of code under GPL-1.0-only. The license notice (as seen 
+      in the Standard License Header field below)  states which of these applies 
+      the code in the file. The example in the exhibit to the license shows the license 
+      notice for the "or later" approach.
     </notes>
     <text>
     <titleText>

--- a/src/GPL-2.0-only.xml
+++ b/src/GPL-2.0-only.xml
@@ -31,7 +31,7 @@
       to use the code under GPL-2.0-only, as distinguished from use of code under GPL-2.0-or-later
       (i.e., GPL-2.0 or some later version). The license notice (as seen in the Standard License 
       Header field below)  states which of these applies to the code in the file. The example 
-      in the exhibit to the license shows the license notice for the "or later" approach.</p>
+      in the exhibit to the license shows the license notice for the "or later" approach.
     </notes>
     <text>
     <titleText>

--- a/src/GPL-2.0-only.xml
+++ b/src/GPL-2.0-only.xml
@@ -27,8 +27,11 @@
       </p>
     </standardLicenseHeader>
     <notes>
-      This license was released: June 1991 This refers to when this
-      GPL 2.0 only is being used (as opposed to GPLv2 or later).
+      This license was released: June 1991. This license identifier refers to when 
+      GPL-2.0-only is being used as opposed to GPL-2.0-or-later. The option to use either that
+      version of the license only or to make it available under any later version of that license
+      is denoted in the standard license header. (The standard license header in the license 
+      itself includes the default "or (at your option) any later version" language.)
     </notes>
     <text>
     <titleText>

--- a/src/GPL-2.0-only.xml
+++ b/src/GPL-2.0-only.xml
@@ -27,11 +27,12 @@
       </p>
     </standardLicenseHeader>
     <notes>
-      This license was released: June 1991. This license identifier refers to when 
-      GPL-2.0-only is being used as opposed to GPL-2.0-or-later. The option to use either that
-      version of the license only or to make it available under any later version of that license
-      is denoted in the standard license header. (The standard license header in the license 
-      itself includes the default "or (at your option) any later version" language.)
+      This license was released: June 1991. This license identifier refers to the choice 
+      to use the code under GPL-2.0-only, as distinguished from use of code under GPL-2.0-or-later
+      (i.e., GPL-2.0 or some later version such as GPL 3, a possible future GPL 4,
+      and so on). The license notice (usually at the head of the file) states which of these
+      applies to the code in the file.
+      <p>The example in the exhibit to the license shows the license notice for the "or later" approach.</p>
     </notes>
     <text>
     <titleText>

--- a/src/GPL-2.0-only.xml
+++ b/src/GPL-2.0-only.xml
@@ -29,10 +29,9 @@
     <notes>
       This license was released: June 1991. This license identifier refers to the choice 
       to use the code under GPL-2.0-only, as distinguished from use of code under GPL-2.0-or-later
-      (i.e., GPL-2.0 or some later version such as GPL 3, a possible future GPL 4,
-      and so on). The license notice (usually at the head of the file) states which of these
-      applies to the code in the file.
-      <p>The example in the exhibit to the license shows the license notice for the "or later" approach.</p>
+      (i.e., GPL-2.0 or some later version). The license notice (as seen in the Standard License 
+      Header field below)  states which of these applies to the code in the file. The example 
+      in the exhibit to the license shows the license notice for the "or later" approach.</p>
     </notes>
     <text>
     <titleText>

--- a/src/GPL-2.0-or-later.xml
+++ b/src/GPL-2.0-or-later.xml
@@ -7,11 +7,13 @@
       <crossRef>https://opensource.org/licenses/GPL-2.0</crossRef>
     </crossRefs>
     <notes>
-      This license was released: June 1991. This license identifier refers to when 
-      GPL-2.0-or-later is being used as opposed to GPL-2.0-only. The option to use either that
-      version of the license only or to make it available under any later version of that license
-      is denoted in the standard license header. (The standard license header in the license 
-      itself includes the default "or (at your option) any later version" language.)
+      This license was released: June 1991. This license identifier refers to the 
+      choice to use code under GPL-2.0-or-later (such as GPL 3, a possible future GPL 4,
+      and so on), as distinguished from use of code under GPL-2.0-only. The license
+      notice (usually at the head of the file) states which of these applies to the 
+      code in the file.
+
+     <p>The example in the exhibit to the license shows the license notice for the "or later" approach.</p>
 
     </notes>
     <text>

--- a/src/GPL-2.0-or-later.xml
+++ b/src/GPL-2.0-or-later.xml
@@ -8,13 +8,11 @@
     </crossRefs>
     <notes>
       This license was released: June 1991. This license identifier refers to the 
-      choice to use code under GPL-2.0-or-later (such as GPL 3, a possible future GPL 4,
-      and so on), as distinguished from use of code under GPL-2.0-only. The license
-      notice (usually at the head of the file) states which of these applies to the 
-      code in the file.
-
-     <p>The example in the exhibit to the license shows the license notice for the "or later" approach.</p>
-
+      choice to use code under GPL-2.0-or-later (i.e., GPL-2.0 or some later version),
+      as distinguished from use of code under GPL-2.0-only. The license notice (as seen 
+      in the Standard License Header field below)  states which of these applies 
+      the code in the file. The example in the exhibit to the license shows the license 
+      notice for the "or later" approach.
     </notes>
     <text>
     <titleText>

--- a/src/GPL-2.0-or-later.xml
+++ b/src/GPL-2.0-or-later.xml
@@ -7,7 +7,12 @@
       <crossRef>https://opensource.org/licenses/GPL-2.0</crossRef>
     </crossRefs>
     <notes>
-      This license was released: June 1991
+      This license was released: June 1991. This license identifier refers to when 
+      GPL-2.0-or-later is being used as opposed to GPL-2.0-only. The option to use either that
+      version of the license only or to make it available under any later version of that license
+      is denoted in the standard license header. (The standard license header in the license 
+      itself includes the default "or (at your option) any later version" language.)
+
     </notes>
     <text>
     <titleText>

--- a/src/GPL-3.0-only.xml
+++ b/src/GPL-3.0-only.xml
@@ -27,8 +27,11 @@
       </p>
     </standardLicenseHeader>
     <notes>
-      This license was released: 29 June 2007 This refers to when
-      this GPL 3.0 only is being used (as opposed to "or later).
+      This license was released: 29 June 2007. This license identifier refers to the choice 
+      to use the code under GPL-3.0-only, as distinguished from use of code under GPL-3.0-or-later
+      (i.e., GPL-3.0 or some later version). The license notice (as seen in the Standard License 
+      Header field below)  states which of these applies to the code in the file. The example 
+      in the exhibit to the license shows the license notice for the "or later" approach.
     </notes>
     <text>
     <titleText>

--- a/src/GPL-3.0-or-later.xml
+++ b/src/GPL-3.0-or-later.xml
@@ -7,7 +7,12 @@
       <crossRef>https://opensource.org/licenses/GPL-3.0</crossRef>
     </crossRefs>
     <notes>
-      This license was released: 29 June 2007
+      This license was released: 29 June 2007. This license identifier refers to the 
+      choice to use code under GPL-3.0-or-later (i.e., GPL-3.0 or some later version),
+      as distinguished from use of code under GPL-3.0-only. The license notice (as seen 
+      in the Standard License Header field below)  states which of these applies 
+      the code in the file. The example in the exhibit to the license shows the license 
+      notice for the "or later" approach.
     </notes>
     <text>
     <titleText>

--- a/src/LGPL-2.0-only.xml
+++ b/src/LGPL-2.0-only.xml
@@ -21,8 +21,12 @@
     </standardLicenseHeader>
     <notes>
       This license was released: June 1991. This license has
-      been superseded by LGPL v2.1 This refers to when this
-      LGPL 2.0 only is being used (as opposed to "or later).
+      been superseded by LGPL-2.1. This license identifier refers to the 
+      choice to use the code under LGPL-2.0-only, as distinguished from use of 
+      code under LGPL-2.0-or-later (i.e., LGPL-2.0 or some later version). The 
+      license notice (as seen in the Standard License Header field below)  states 
+      which of these applies to the code in the file. The example in the exhibit
+      to the license shows the license notice for the "or later" approach.
     </notes>
     <text>
     <titleText>

--- a/src/LGPL-2.0-or-later.xml
+++ b/src/LGPL-2.0-or-later.xml
@@ -7,7 +7,12 @@
     </crossRefs>
     <notes>
       This license was released: June 1991. This license has
-      been superseded by LGPL v2.1
+      been superseded by LGPL-2.1. This license identifier refers to the 
+      choice to use code under LGPL-2.0-or-later (i.e., LGPL-2.0 or some later version),
+      as distinguished from use of code under LGPL-2.0-only. The license notice (as seen 
+      in the Standard License Header field below)  states which of these applies 
+      the code in the file. The example in the exhibit to the license shows the license 
+      notice for the "or later" approach.
     </notes>
     <text>
     <titleText>

--- a/src/LGPL-2.1-only.xml
+++ b/src/LGPL-2.1-only.xml
@@ -26,8 +26,11 @@
       </p>
     </standardLicenseHeader>
     <notes>
-      This license was released: February 1999. This refers to when
-      this LGPL 2.1 only is being used (as opposed to "or later).
+      This license was released: February 1999. This license identifier refers to the choice 
+      to use the code under LGPL-2.1-only, as distinguished from use of code under LGPL-2.1-or-later
+      (i.e., LGPL-2.1 or some later version). The license notice (as seen in the Standard License 
+      Header field below)  states which of these applies to the code in the file. The example 
+      in the exhibit to the license shows the license notice for the "or later" approach.
     </notes>
     <text>
     <titleText>

--- a/src/LGPL-2.1-or-later.xml
+++ b/src/LGPL-2.1-or-later.xml
@@ -7,7 +7,12 @@
       <crossRef>https://opensource.org/licenses/LGPL-2.1</crossRef>
     </crossRefs>
     <notes>
-      This license was released: February 1999.
+      This license was released: February 1999. This license identifier refers to the 
+      choice to use code under LGPL-2.1-or-later (i.e., LGPL-2.1 or some later version),
+      as distinguished from use of code under LGPL-2.1-only. The license notice (as seen 
+      in the Standard License Header field below)  states which of these applies 
+      the code in the file. The example in the exhibit to the license shows the license 
+      notice for the "or later" approach.
     </notes>
     <text>
     <titleText>


### PR DESCRIPTION
add explanatory text re: -only and -or-later delineation in standard license header (versus default text in full copy of license). proposed solution to #617