### PR TITLE
Add three new templated OpenSSL exceptions

### DIFF
--- a/src/exceptions/debian-openssl-exception.xml
+++ b/src/exceptions/debian-openssl-exception.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SPDXLicenseCollection xmlns="http://www.spdx.org/license">
+   <exception licenseId="debian-openssl-exception" name="Debian OpenSSL Exception" listVersionAdded="3.5">
+      <crossRefs>
+         <crossRef>https://people.gnome.org/~markmc/openssl-and-the-gpl.html</crossRef>
+      </crossRefs>
+    <text>
+      <p>In addition, as a special exception, the copyright holders give
+         permission to link the code of portions of this program with the
+         OpenSSL library under certain conditions as described in each
+         individual source file, and distribute linked combinations
+         including the two.</p>
+      <p>You must obey <alt match=".+" name="underlyingLicense">the underlying license</alt> in all respects
+         for all of the code used other than OpenSSL.  If you modify
+         file(s) with this exception, you may extend this exception to your
+         version of the file(s), but you are not obligated to do so.  If you
+         do not wish to do so, delete this exception statement from your
+         version.  If you delete this exception statement from all source
+         files in the program, then also delete it here.</p>
+    </text>
+  </exception>
+</SPDXLicenseCollection>

--- a/src/exceptions/deluge-openssl-exception.xml
+++ b/src/exceptions/deluge-openssl-exception.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SPDXLicenseCollection xmlns="http://www.spdx.org/license">
+   <exception licenseId="deluge-openssl-exception" name="Deluge OpenSSL Exception" listVersionAdded="3.5">
+      <crossRefs>
+         <crossRef>https://git.deluge-torrent.org/deluge/tree/LICENSE</crossRef>
+      </crossRefs>
+      <notes>Generally identical to debian-openssl-exception, but some language from the end of its first sentence is omitted here.</notes>
+    <text>
+      <p>In addition, as a special exception, the copyright holders give
+         permission to link the code of portions of this program with the
+         OpenSSL library.</p>
+      <p>You must obey <alt match=".+" name="underlyingLicense">the underlying license</alt> in all respects
+         for all of the code used other than OpenSSL.  If you modify
+         file(s) with this exception, you may extend this exception to your
+         version of the file(s), but you are not obligated to do so.  If you
+         do not wish to do so, delete this exception statement from your
+         version.  If you delete this exception statement from all source
+         files in the program, then also delete it here.</p>
+    </text>
+  </exception>
+</SPDXLicenseCollection>

--- a/src/exceptions/mongodb-openssl-exception.xml
+++ b/src/exceptions/mongodb-openssl-exception.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SPDXLicenseCollection xmlns="http://www.spdx.org/license">
+   <exception licenseId="mongodb-openssl-exception" name="MongoDB OpenSSL Exception" listVersionAdded="3.5">
+      <crossRefs>
+         <crossRef>https://github.com/mongodb/mongo/blob/d6a77a0135db56972b2626a08e20a240a770f66f/src/mongo/db/query/parsed_projection.cpp</crossRef>
+      </crossRefs>
+    <text>
+      <p>As a special exception, the copyright holders give permission to link the
+         code of portions of this program with the OpenSSL library under certain
+         conditions as described in each individual source file and distribute
+         linked combinations including the program with the OpenSSL library. You
+         must comply with <alt match=".+" name="underlyingLicense">the underlying license</alt> in all respects for
+         all of the code used other than as permitted herein. If you modify file(s)
+         with this exception, you may extend this exception to your version of the
+         file(s), but you are not obligated to do so. If you do not wish to do so,
+         delete this exception statement from your version. If you delete this
+         exception statement from all source files in the program, then also delete
+         it in the license file.</p>
+    </text>
+  </exception>
+</SPDXLicenseCollection>

--- a/test/simpleTestForGenerator/debian-openssl-exception.txt
+++ b/test/simpleTestForGenerator/debian-openssl-exception.txt
@@ -1,0 +1,3 @@
+In addition, as a special exception, the copyright holders give permission to link the code of portions of this program with the OpenSSL library under certain conditions as described in each individual source file, and distribute linked combinations including the two.
+
+You must obey the underlying license in all respects for all of the code used other than OpenSSL.  If you modify file(s) with this exception, you may extend this exception to your version of the file(s), but you are not obligated to do so.  If you do not wish to do so, delete this exception statement from your version.  If you delete this exception statement from all source files in the program, then also delete it here.

--- a/test/simpleTestForGenerator/deluge-openssl-exception.txt
+++ b/test/simpleTestForGenerator/deluge-openssl-exception.txt
@@ -1,0 +1,3 @@
+In addition, as a special exception, the copyright holders give permission to link the code of portions of this program with the OpenSSL library.
+
+You must obey the underlying license in all respects for all of the code used other than OpenSSL. If you modify file(s) with this exception, you may extend this exception to your version of the file(s), but you are not obligated to do so. If you do not wish to do so, delete this exception statement from your version. If you delete this exception statement from all source files in the program, then also delete it here.

--- a/test/simpleTestForGenerator/mongodb-openssl-exception.txt
+++ b/test/simpleTestForGenerator/mongodb-openssl-exception.txt
@@ -1,0 +1,11 @@
+As a special exception, the copyright holders give permission to link the
+code of portions of this program with the OpenSSL library under certain
+conditions as described in each individual source file and distribute
+linked combinations including the program with the OpenSSL library. You
+must comply with the underlying license in all respects for
+all of the code used other than as permitted herein. If you modify file(s)
+with this exception, you may extend this exception to your version of the
+file(s), but you are not obligated to do so. If you do not wish to do so,
+delete this exception statement from your version. If you delete this
+exception statement from all source files in the program, then also delete
+it in the license file.


### PR DESCRIPTION
This commit addresses issue #720 by adding templated versions of
three different variants of OpenSSL exceptions found in the wild.
It allows these variants to be used with different licensors and
with different underlying licenses. It does not modify existing
openvpn-openssl-exception, which is specific to OpenVPN and GPLv2.

Fixes #720

Signed-off-by: Steve Winslow <swinslow@gmail.com>