### PR TITLE
Blue Oak Model License 1.0.0

### DIFF
--- a/src/BlueOak-1.0.0.xml
+++ b/src/BlueOak-1.0.0.xml
@@ -7,25 +7,25 @@
     <notes>This license was released on March 6, 2019.</notes>
     <text>
       <titleText>
-        <p># Blue Oak Model License</p>
+        <p><optional># </optional>Blue Oak Model License</p>
       </titleText>
       <p>Version 1.0.0</p>
-      <p>## Purpose</p>
+      <p><optional>## </optional>Purpose</p>
       <p>This license gives everyone as much permission to work with this software as possible, while protecting contributors from liability.</p>
-      <p>## Acceptance</p>
-      <p>In order to receive this license, you must agree to its rules.  The rules of this license are both obligations under that agreement and conditions to your license. You must not do anything with this software that triggers a rule that you cannot or will not follow.</p>
-      <p>## Copyright</p>
+      <p><optional>## </optional>Acceptance</p>
+      <p>In order to receive this license, you must agree to its rules. The rules of this license are both obligations under that agreement and conditions to your license. You must not do anything with this software that triggers a rule that you cannot or will not follow.</p>
+      <p><optional>## </optional>Copyright</p>
       <p>Each contributor licenses you to do everything with this software that would otherwise infringe that contributor's copyright in it.</p>
-      <p>## Notices</p>
-      <p>You must ensure that everyone who gets a copy of any part of this software from you, with or without changes, also gets the text of this license or a link to &lt;https://blueoakcouncil.org/license/1.0.0&gt;.</p>
-      <p>## Excuse</p>
-      <p>If anyone notifies you in writing that you have not complied with [Notices](#notices), you can keep your license by taking all practical steps to comply within 30 days after the notice.  If you do not do so, your license ends immediately.</p>
-      <p>## Patent</p>
+      <p><optional>## </optional>Notices</p>
+      <p>You must ensure that everyone who gets a copy of any part of this software from you, with or without changes, also gets the text of this license or a link to <optional>&lt;</optional>https://blueoakcouncil.org/license/1.0.0<optional>&gt;</optional>.</p>
+      <p><optional>## </optional>Excuse</p>
+      <p>If anyone notifies you in writing that you have not complied with <alt match="Notices">[Notices](#notices)</alt>, you can keep your license by taking all practical steps to comply within 30 days after the notice. If you do not do so, your license ends immediately.</p>
+      <p><optional>## </optional>Patent</p>
       <p>Each contributor licenses you to do everything with this software that would otherwise infringe any patent claims they can license or become able to license.</p>
-      <p>## Reliability</p>
+      <p><optional>## </optional>Reliability</p>
       <p>No contributor can revoke this license.</p>
-      <p>## No Liability</p>
-      <p>***As far as the law allows, this software comes as is, without any warranty or condition, and no contributor will be liable to anyone for any damages related to this software or this license, under any kind of legal claim.***</p>
+      <p><optional>## </optional>No Liability</p>
+      <p><optional>***</optional>As far as the law allows, this software comes as is, without any warranty or condition, and no contributor will be liable to anyone for any damages related to this software or this license, under any kind of legal claim.<optional>***</optional></p>
     </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/BlueOak-1.0.0.xml
+++ b/src/BlueOak-1.0.0.xml
@@ -17,15 +17,15 @@
       <p><optional>## </optional>Copyright</p>
       <p>Each contributor licenses you to do everything with this software that would otherwise infringe that contributor's copyright in it.</p>
       <p><optional>## </optional>Notices</p>
-      <p>You must ensure that everyone who gets a copy of any part of this software from you, with or without changes, also gets the text of this license or a link to <optional>&lt;</optional>https://blueoakcouncil.org/license/1.0.0<optional>&gt;</optional>.</p>
+      <p>You must ensure that everyone who gets a copy of any part of this software from you, with or without changes, also gets the text of this license or a link to &lt;https://blueoakcouncil.org/license/1.0.0&gt;.</p>
       <p><optional>## </optional>Excuse</p>
-      <p>If anyone notifies you in writing that you have not complied with <alt name="noticesRef" match="Notices">[Notices](#notices)</alt>, you can keep your license by taking all practical steps to comply within 30 days after the notice. If you do not do so, your license ends immediately.</p>
+      <p>If anyone notifies you in writing that you have not complied with <alt name="noticesRef" match="\[Notices\]\(\#notices\)|Notices">[Notices](#notices)</alt>, you can keep your license by taking all practical steps to comply within 30 days after the notice. If you do not do so, your license ends immediately.</p>
       <p><optional>## </optional>Patent</p>
       <p>Each contributor licenses you to do everything with this software that would otherwise infringe any patent claims they can license or become able to license.</p>
       <p><optional>## </optional>Reliability</p>
       <p>No contributor can revoke this license.</p>
       <p><optional>## </optional>No Liability</p>
-      <p><optional>***</optional>As far as the law allows, this software comes as is, without any warranty or condition, and no contributor will be liable to anyone for any damages related to this software or this license, under any kind of legal claim.<optional>***</optional></p>
+      <p>***As far as the law allows, this software comes as is, without any warranty or condition, and no contributor will be liable to anyone for any damages related to this software or this license, under any kind of legal claim.***</p>
     </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/BlueOak-1.0.0.xml
+++ b/src/BlueOak-1.0.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-  <license isOsiApproved="false" licenseId="BlueOak-1.0.0" name="Blue Oak Model License 1.0.0">
+  <license isOsiApproved="false" licenseId="BlueOak-1.0.0" name="Blue Oak Model License 1.0.0" listVersionAdded="3.6">
     <crossRefs>
       <crossRef>https://blueoakcouncil.org/license/1.0.0</crossRef>
     </crossRefs>

--- a/src/BlueOak-1.0.0.xml
+++ b/src/BlueOak-1.0.0.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SPDXLicenseCollection xmlns="http://www.spdx.org/license">
+  <license isOsiApproved="false" licenseId="BlueOak-1.0.0" name="Blue Oak Model License 1.0.0">
+    <crossRefs>
+      <crossRef>https://blueoakcouncil.org/license/1.0.0</crossRef>
+    </crossRefs>
+    <notes>This license was released on March 6, 2019.</notes>
+    <text>
+      <titleText>
+        <p># Blue Oak Model License</p>
+      </titleText>
+      <p>Version 1.0.0</p>
+      <p>## Purpose</p>
+      <p>This license gives everyone as much permission to work with this software as possible, while protecting contributors from liability.</p>
+      <p>## Acceptance</p>
+      <p>In order to receive this license, you must agree to its rules.  The rules of this license are both obligations under that agreement and conditions to your license. You must not do anything with this software that triggers a rule that you cannot or will not follow.</p>
+      <p>## Copyright</p>
+      <p>Each contributor licenses you to do everything with this software that would otherwise infringe that contributor's copyright in it.</p>
+      <p>## Notices</p>
+      <p>You must ensure that everyone who gets a copy of any part of this software from you, with or without changes, also gets the text of this license or a link to &lt;https://blueoakcouncil.org/license/1.0.0&gt;.</p>
+      <p>## Excuse</p>
+      <p>If anyone notifies you in writing that you have not complied with [Notices](#notices), you can keep your license by taking all practical steps to comply within 30 days after the notice.  If you do not do so, your license ends immediately.</p>
+      <p>## Patent</p>
+      <p>Each contributor licenses you to do everything with this software that would otherwise infringe any patent claims they can license or become able to license.</p>
+      <p>## Reliability</p>
+      <p>No contributor can revoke this license.</p>
+      <p>## No Liability</p>
+      <p>***As far as the law allows, this software comes as is, without any warranty or condition, and no contributor will be liable to anyone for any damages related to this software or this license, under any kind of legal claim.***</p>
+    </text>
+  </license>
+</SPDXLicenseCollection>

--- a/src/BlueOak-1.0.0.xml
+++ b/src/BlueOak-1.0.0.xml
@@ -19,7 +19,7 @@
       <p><optional>## </optional>Notices</p>
       <p>You must ensure that everyone who gets a copy of any part of this software from you, with or without changes, also gets the text of this license or a link to <optional>&lt;</optional>https://blueoakcouncil.org/license/1.0.0<optional>&gt;</optional>.</p>
       <p><optional>## </optional>Excuse</p>
-      <p>If anyone notifies you in writing that you have not complied with <alt match="Notices">[Notices](#notices)</alt>, you can keep your license by taking all practical steps to comply within 30 days after the notice. If you do not do so, your license ends immediately.</p>
+      <p>If anyone notifies you in writing that you have not complied with <alt name="noticesRef" match="Notices">[Notices](#notices)</alt>, you can keep your license by taking all practical steps to comply within 30 days after the notice. If you do not do so, your license ends immediately.</p>
       <p><optional>## </optional>Patent</p>
       <p>Each contributor licenses you to do everything with this software that would otherwise infringe any patent claims they can license or become able to license.</p>
       <p><optional>## </optional>Reliability</p>

--- a/test/simpleTestForGenerator/BlueOak-1.0.0.txt
+++ b/test/simpleTestForGenerator/BlueOak-1.0.0.txt
@@ -1,0 +1,55 @@
+# Blue Oak Model License
+
+Version 1.0.0
+
+## Purpose
+
+This license gives everyone as much permission to work with
+this software as possible, while protecting contributors
+from liability.
+
+## Acceptance
+
+In order to receive this license, you must agree to its
+rules.  The rules of this license are both obligations
+under that agreement and conditions to your license.
+You must not do anything with this software that triggers
+a rule that you cannot or will not follow.
+
+## Copyright
+
+Each contributor licenses you to do everything with this
+software that would otherwise infringe that contributor's
+copyright in it.
+
+## Notices
+
+You must ensure that everyone who gets a copy of
+any part of this software from you, with or without
+changes, also gets the text of this license or a link to
+<https://blueoakcouncil.org/license/1.0.0>.
+
+## Excuse
+
+If anyone notifies you in writing that you have not
+complied with [Notices](#notices), you can keep your
+license by taking all practical steps to comply within 30
+days after the notice.  If you do not do so, your license
+ends immediately.
+
+## Patent
+
+Each contributor licenses you to do everything with this
+software that would otherwise infringe any patent claims
+they can license or become able to license.
+
+## Reliability
+
+No contributor can revoke this license.
+
+## No Liability
+
+***As far as the law allows, this software comes as is,
+without any warranty or condition, and no contributor
+will be liable to anyone for any damages related to this
+software or this license, under any kind of legal claim.***


### PR DESCRIPTION
This draft PR for #800 was another chance for me to do an XML file.

The interesting part of this one was the Markdown syntax.  I'm not aware of another license on the list that uses that kind of formatting. Fortunately, Blue Oak doesn't do anything fancy, and it was straightforward to mark all of the Markdown syntax characters optional.

As an aside, we _do_ recommend copying the Markdown plain text from blueoakcouncil.org verbatim, even into plain-text files without Markdown extensions.