### PR TITLE
Fix typo in MIT-0

### DIFF
--- a/src/MIT-0.xml
+++ b/src/MIT-0.xml
@@ -16,7 +16,7 @@
       </titleText>
       <copyrightText>
         <p>
-          Copyright <alt name="copyright" match="(c)|"/> <alt match=".+" name="copyright">&lt;YEARr&gt; &lt;COPYRIGHT HOLDER&gt;</alt>
+          Copyright <alt name="copyright" match="(c)|"/> <alt match=".+" name="copyright">&lt;YEAR&gt; &lt;COPYRIGHT HOLDER&gt;</alt>
         </p>
       </copyrightText>
 


### PR DESCRIPTION
Fixing the optional copyright text in MIT-0 which said "YEARr", should be "YEAR"

Signed-off-by: Steve Winslow <swinslow@gmail.com>