### PR TITLE
further updates to license inclusion principles

### DIFF
--- a/DOCS/license-inclusion-principles.md
+++ b/DOCS/license-inclusion-principles.md
@@ -1,6 +1,22 @@
-## License Inclusion Principles
+# License Inclusion Principles
 
-### Background Principles 
+
+## Candidate License Analysis
+
+Determining whether a candidate license should be included on the SPDX License List requires the SPDX Legal Team to engage in a case-by-case evaluation of each candidate license based on a number of factors. No one factor is dispositive and factors may weight differently. The ultimate decision will be based on the totality of the factors and SPDX's goals and objectives. Factors include:
+* Does the license substantially comply with one of the open source definitions:
+  * Open Source Definition (OSD) from the Open Source Initiative (OSI) - https://opensource.org/osd
+  * Free Software Definition from the Free Software Foundation (FSF) - https://www.gnu.org/philosophy/free-sw.en.html
+  * Open Source Hardware Definition from the Open Source Hardware Association (OSHWA) - https://www.oshwa.org/definition/
+  * Open Definition from the Open Knowledge Foundation (for open data) - http://opendefinition.org/od/2.1/en/
+* Consider existing use of the license in wild (e.g., wide use of license or use of license in prominent projects)
+* If it is a newly drafted license, it is drafted such that it can be used by anyone (e.g., it is not company-specific or a "vanity" license)
+* Relevant input from the license steward (e.g., regarding name or if the license steward does not want the license added)
+* Relevant open source community factors
+
+Comments on license inclusion will be noted in the Github issue for the license (or reference to meeting minutes, as necessary). Some license requests may be decided solely via comments in the Github issue and some may involve discussion on the bi-weekly legal call. Thus it is recommended that requestors join the mailing list and calls to fully participate. 
+
+## Background Principles 
 The Software Package Data Exchange® (SPDX®) specification is a standard format for communicating, among other things, the components, licenses, and copyrights associated with open source software packages. Use of this standard streamlines license identification across the supply chain while reducing redundant work.
 
 The goal of SPDX is not to evaluate licensing information or to provide legal interpretations. The only goal is to reliably and consistently communicate and share objective factual information so that organizations using software components will have the information necessary to conduct their independent analysis and evaluation. Establishing a consistent, reliable, and reusable way to communicate license information for software components will facilitate open source license compliance along the supply chain.
@@ -9,26 +25,4 @@ Although SPDX has traditionally focused on open source licensing, software may c
 
 Because the present focus of SPDX is the collection and presentation of the open-source software licenses contained in a software package, any license that is a candidate for inclusion on the SPDX License List must have the general attributes of an "open source" license.
 
-### Open Source Definition and similar definitions
-
-The terms "free software," "open source software," or their variants (FOSS, FLOSS, libre software, etc.) are defined differently by different organizations. At a minimum, all definitions of open source or free software include the characteristic that the source code be made available for inspection and modification and that the source code may be freely distributed. 
-
-The SPDX Legal Team uses the following definitions as the basis for analyzing candidate licenses for inclusion on the SPDX License List.
-* Open Source Definition (OSD) from the Open Source Initiative (OSI) - https://opensource.org/osd
-* Free Software Definition from the Free Software Foundation - https://www.gnu.org/philosophy/free-sw.en.html
-* Open Source Hardware Definition from the Open Source Hardware Association - https://www.oshwa.org/definition/
-* Open Definition from the Open Knowledge Foundation (for open data) - http://opendefinition.org/od/2.1/en/
-
 Note: SPDX has always endeavored to ensure all OSI-approved licenses are included on the SPDX License List and have a short identifier, which is also used on the OSI website. 
-
-### Candidate License Analysis
-
-Determining whether a candidate license is deemed to be open source for purpose of inclusion on the SPDX License List requires the SPDX Legal Team to engage in a case-by-case evaluation of each candidate license based on a number of factors. No one factor is dispositive and factors may weight differently. The ultimate decision will be based on the totality of the factors and SPDX's goals and objectives. Factors include:
-* does the license substantially comply with one of the open source definitions noted above
-* existing use of the license in wild (e.g., wide use of license or use of license in prominent projects)
-* if it is a newly drafted license, it is drafted such that it can be used by anyone (e.g., it is not company-specific or a "vanity" license)
-* relevant input from the license steward (e.g., regarding name or if the license steward does not want the license added)
-* relevant open source community factors
-
-Comments on license inclusion will be noted in the Github issue for the license (or reference to meeting minutes, as necessary). Some license requests may be decided solely via comments in the Github issue and some may involve discussion on the bi-weekly legal call. Thus it is recommended that requestors join the mailing list and calls to fully participate. 
-

--- a/DOCS/license-inclusion-principles.md
+++ b/DOCS/license-inclusion-principles.md
@@ -9,6 +9,7 @@ Determining whether a candidate license should be included on the SPDX License L
   * Free Software Definition from the Free Software Foundation (FSF) - https://www.gnu.org/philosophy/free-sw.en.html
   * Open Source Hardware Definition from the Open Source Hardware Association (OSHWA) - https://www.oshwa.org/definition/
   * Open Definition from the Open Knowledge Foundation (for open data) - http://opendefinition.org/od/2.1/en/
+  * Note: licenses that these organizations consider to meet their definition are presumptively appropriate for inclusion on the SPDX License List. Specifically, SPDX aims to ensure all OSI-approved licenses are included on the SPDX License List and have a short identifier, which is also used on the OSI website. 
 * Consider existing use of the license in wild (e.g., wide use of license or use of license in prominent projects)
 * If it is a newly drafted license, it is drafted such that it can be used by anyone (e.g., it is not company-specific or a "vanity" license)
 * Relevant input from the license steward (e.g., regarding name or if the license steward does not want the license added)
@@ -25,4 +26,4 @@ Although SPDX has traditionally focused on open source licensing, software may c
 
 Because the present focus of SPDX is the collection and presentation of the open-source software licenses contained in a software package, any license that is a candidate for inclusion on the SPDX License List must have the general attributes of an "open source" license.
 
-Note: SPDX has always endeavored to ensure all OSI-approved licenses are included on the SPDX License List and have a short identifier, which is also used on the OSI website. 
+


### PR DESCRIPTION
move open source definitions into list of inclusion principles to make whole page shorter and move background info to bottom of page