### PR TITLE
fix broken links in docs

### DIFF
--- a/DOCS/README.md
+++ b/DOCS/README.md
@@ -1,10 +1,10 @@
 This folder contains documentation that is critical for understanding the SPDX License List.  
 
 Included here is:
-* [About the SPDX License List](DOCS/what-why-how.md): the what, why and how. Start here!
-* [Explanation of the fields](DOCS/license-fields.md) used on the SPDX License List
-* [Inclusion principles](DOCS/license-inclusion-principles.md) for new licenses or exceptions
-* [Matching Guidelines](DOCS/matching-guidelines): the editable HTML* used on https://spdx.org/spdx-license-list/matching-guidelines which contains the guidelines to determine what is a license match
-* [Overview](DOCS/license-list-overview): the editable HTML* used on https://spdx.org/spdx-license-list/license-list-overview which provides an overview of information related to the SPDX License List. NOTE: the info on this page is in the process of being updated and moved to some of the pages here, mentioned on the top of this list
+* [About the SPDX License List](what-why-how.md): the what, why and how. Start here!
+* [Explanation of the fields](license-fields.md) used on the SPDX License List
+* [Inclusion principles](license-inclusion-principles.md) for new licenses or exceptions
+* [Matching Guidelines](matching-guidelines): the editable HTML* used on https://spdx.org/spdx-license-list/matching-guidelines which contains the guidelines to determine what is a license match
+* [Overview](license-list-overview): the editable HTML* used on https://spdx.org/spdx-license-list/license-list-overview which provides an overview of information related to the SPDX License List. NOTE: the info on this page is in the process of being updated and moved to some of the pages here, mentioned on the top of this list
 
 *The purpose of storing the HTML here is to enable review, comment, and tracking of changes made to these pages. Changes will be tracked here via issues, comments and PRs, and then posted to the appropriate webpage at SPDX.org by someone who has webpage edit privileges (i.e., member of core leadership team)


### PR DESCRIPTION
Removing extra `DOCS/` from broken links to documentation files

Signed-off-by: Steve Winslow <swinslow@gmail.com>