### PR TITLE
Add an attribute spacing to the schema.  

### DIFF
--- a/schema/ListedLicense.xsd
+++ b/schema/ListedLicense.xsd
@@ -287,6 +287,15 @@
 	</complexType>
 	<complexType name="optionalStandardLicenseHeaderType" mixed="true">
 		<group ref="tns:formattedAltStandardLicenseHeaderTextGroup" minOccurs="0" maxOccurs="unbounded"/>
+				<attribute name="spacing" type="string" default="before">
+			<annotation>
+				<documentation xml:lang="en">
+					<xhtml:p>
+						<xhtml:code>spacing</xhtml:code> defines how spacing is handled around the optional text.  Since XML does not preserve white space, to render the text from the license XML we need to provide hints to the tools that translate the XML to text (or other formats).  Valid values are <xhtml:code>none</xhtml:code> for no spaces before or after the optional text; <xhtml:code>before</xhtml:code> (default) for a space before, but not after the optional text; <xhtml:code>after</xhtml:code> for a space after, but not before the optional text; <xhtml:code>both</xhtml:code>a space before and after the optional text.
+					</xhtml:p>
+				</documentation>
+			</annotation>
+		</attribute>
 	</complexType>
 	<complexType name="listType">
 		<annotation>

--- a/schema/ListedLicense.xsd
+++ b/schema/ListedLicense.xsd
@@ -275,11 +275,11 @@
 			</documentation>
 		</annotation>
 		<group ref="tns:formattedAltTextGroup" minOccurs="0" maxOccurs="unbounded"/>
-		<attribute name="spacing" type="string" default="both">
+		<attribute name="spacing" type="string" default="before">
 			<annotation>
 				<documentation xml:lang="en">
 					<xhtml:p>
-						<xhtml:code>spacing</xhtml:code> defines how spacing is handled around the optional text.  Since XML does not preserve white space, to render the text from the license XML we need to provide hints to the tools that translate the XML to text (or other formats).  Valid values are <xhtml:code>none</xhtml:code> for no spaces before or after the optional text; <xhtml:code>before</xhtml:code> for a space before, but not after the optional text; <xhtml:code>after</xhtml:code> for a space after, but not before the optional text; <xhtml:code>both</xhtml:code> (default) a space before and after the optional text.
+						<xhtml:code>spacing</xhtml:code> defines how spacing is handled around the optional text.  Since XML does not preserve white space, to render the text from the license XML we need to provide hints to the tools that translate the XML to text (or other formats).  Valid values are <xhtml:code>none</xhtml:code> for no spaces before or after the optional text; <xhtml:code>before</xhtml:code> (default) for a space before, but not after the optional text; <xhtml:code>after</xhtml:code> for a space after, but not before the optional text; <xhtml:code>both</xhtml:code>a space before and after the optional text.
 					</xhtml:p>
 				</documentation>
 			</annotation>

--- a/schema/ListedLicense.xsd
+++ b/schema/ListedLicense.xsd
@@ -275,6 +275,15 @@
 			</documentation>
 		</annotation>
 		<group ref="tns:formattedAltTextGroup" minOccurs="0" maxOccurs="unbounded"/>
+		<attribute name="spacing" type="string" default="both">
+			<annotation>
+				<documentation xml:lang="en">
+					<xhtml:p>
+						<xhtml:code>spacing</xhtml:code> defines how spacing is handled around the optional text.  Since XML does not preserve white space, to render the text from the license XML we need to provide hints to the tools that translate the XML to text (or other formats).  Valid values are <xhtml:code>none</xhtml:code> for no spaces before or after the optional text; <xhtml:code>before</xhtml:code> for a space before, but not after the optional text; <xhtml:code>after</xhtml:code> for a space after, but not before the optional text; <xhtml:code>both</xhtml:code> (default) a space before and after the optional text.
+					</xhtml:p>
+				</documentation>
+			</annotation>
+		</attribute>		
 	</complexType>
 	<complexType name="optionalStandardLicenseHeaderType" mixed="true">
 		<group ref="tns:formattedAltStandardLicenseHeaderTextGroup" minOccurs="0" maxOccurs="unbounded"/>


### PR DESCRIPTION
This is necessary to to resolve licenseListPublisher[ issue #48](https://github.com/spdx/LicenseListPublisher/issues/42) where extra spaces are being added around optional text (e.g. `http s :\\...`

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>