### PR TITLE
Add variable text around all copyright elements when producing the matching templates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: CC0-1.0
 
-TOOL_VERSION = 2.1.18
+TOOL_VERSION = 2.1.20
 TEST_DATA = test/simpleTestForGenerator
 GIT_AUTHOR = License Publisher (maintained by Gary O'Neall) <gary@sourceauditor.com>
 LICENSE_DATA_REPO_NO_SCHEME = github.com/spdx/license-list-data.git

--- a/src/0BSD.xml
+++ b/src/0BSD.xml
@@ -6,9 +6,7 @@
       </crossRefs>
     <text>
       <copyrightText>
-         <p>Copyright (C)
-            <alt match=".+" name="copyright">2006 by Rob Landley &lt;rob@landley.net&gt;</alt>
-         </p>
+         <p>Copyright (C) 2006 by Rob Landley &lt;rob@landley.net&gt;</p>
       </copyrightText>
 
       <p>Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is

--- a/src/AAL.xml
+++ b/src/AAL.xml
@@ -17,9 +17,7 @@
          <p>Attribution Assurance License</p>
       </titleText>
       <copyrightText>
-         <p>Copyright (c)
-        <alt match=".+" name="copyright">2002 by AUTHOR PROFESSIONAL IDENTIFICATION * URL "PROMOTIONAL SLOGAN
-        FOR AUTHOR'S PROFESSIONAL PRACTICE"</alt>
+         <p>Copyright (c) 2002 by AUTHOR PROFESSIONAL IDENTIFICATION * URL "PROMOTIONAL SLOGAN FOR AUTHOR'S PROFESSIONAL PRACTICE"
          </p>
          <p>All Rights Reserved</p>
       </copyrightText>

--- a/src/Apache-1.1.xml
+++ b/src/Apache-1.1.xml
@@ -11,7 +11,7 @@
          <p>Apache License 1.1</p>
       </titleText>
       <copyrightText>
-         <p>Copyright (c) <alt name="copyright" match=".+">2000 The Apache Software Foundation</alt>. All rights reserved.</p>
+         <p>Copyright (c) 2000 The Apache Software Foundation. All rights reserved.</p>
       </copyrightText>
       <p>Redistribution and use in source and binary forms, with or without modification, are permitted provided
        that the following conditions are met:</p>

--- a/src/BSD-1-Clause.xml
+++ b/src/BSD-1-Clause.xml
@@ -7,8 +7,7 @@
     <text>
     <copyrightText>
       <p>
-        Copyright (c) <alt name="copyright" match=".+">&lt;year&gt; &lt;owner&gt;</alt>
-        All rights reserved.
+        Copyright (c) &lt;year&gt; &lt;owner&gt; All rights reserved.
       </p>
     </copyrightText>
     <p>

--- a/src/BSD-2-Clause-Patent.xml
+++ b/src/BSD-2-Clause-Patent.xml
@@ -17,8 +17,7 @@
     <text>
     <copyrightText>
       <p>
-        Copyright (c) <alt name="copyright"
-        match=".+">&lt;YEAR&gt; &lt;COPYRIGHT HOLDERS&gt;</alt>
+        Copyright (c) &lt;YEAR&gt; &lt;COPYRIGHT HOLDERS&gt;
       </p>
     </copyrightText>
     <p>

--- a/src/BSD-2-Clause.xml
+++ b/src/BSD-2-Clause.xml
@@ -7,8 +7,7 @@
       </crossRefs>
     <text>
       <copyrightText>
-         <p>Copyright (c)
-        <alt match=".+" name="copyright">&lt;year&gt; &lt;owner&gt;</alt><optional>. All rights reserved.</optional>
+         <p>Copyright (c) &lt;year&gt; &lt;owner&gt;. All rights reserved.
       </p>
       </copyrightText>
 

--- a/src/BSD-3-Clause-Clear.xml
+++ b/src/BSD-3-Clause-Clear.xml
@@ -12,9 +12,8 @@
          <p>The Clear BSD License</p>
       </titleText>
       <copyrightText>
-         <p>Copyright (c)
-        <alt match=".+" name="copyright">[xxxx]-[xxxx] [Owner Organization]</alt>
-            <br/>All rights reserved.
+         <p>Copyright (c) [xxxx]-[xxxx] [Owner Organization]
+            <br/>All rights reserved. 
       </p>
       </copyrightText>
 

--- a/src/BSD-3-Clause.xml
+++ b/src/BSD-3-Clause.xml
@@ -7,7 +7,7 @@
       </crossRefs>
     <text>
       <copyrightText>
-        <p>Copyright (c) <alt match=".+" name="copyright"> &lt;year&gt; &lt;owner&gt;</alt>. All rights reserved.</p>
+        <p>Copyright (c) &lt;year&gt; &lt;owner&gt;. All rights reserved.</p>
       </copyrightText>
 
         <p>Redistribution and use in source and binary forms, with or without modification, are permitted provided

--- a/src/BSD-4-Clause.xml
+++ b/src/BSD-4-Clause.xml
@@ -8,8 +8,7 @@
       <notes>This license was rescinded by the author on 22 July 1999.</notes>
     <text>
       <copyrightText>
-         <p>Copyright (c)
-        <alt match=".+" name="copyright">&lt;year&gt; &lt;owner&gt;</alt>. All rights reserved.
+         <p>Copyright (c) &lt;year&gt; &lt;owner&gt;. All rights reserved. 
       </p>
       </copyrightText>
 

--- a/src/BSD-Source-Code.xml
+++ b/src/BSD-Source-Code.xml
@@ -7,8 +7,7 @@
       </crossRefs>
     <text>
       <copyrightText>
-         <p>Copyright (c)
-        <alt match=".+" name="copyright">2011, Deusty, LLC</alt>
+         <p>Copyright (c) 2011, Deusty, LLC
             <br/>All rights reserved.
       </p>
       </copyrightText>

--- a/src/HPND-sell-variant.xml
+++ b/src/HPND-sell-variant.xml
@@ -10,7 +10,7 @@
   </notes>
     <text>
       <copyrightText>
-         <p><alt match=".+" name="copyright">&lt;copyright notice&gt;</alt></p>
+         <p>&lt;copyright notice&gt;</p>
       </copyrightText>
 
       <p>Permission to use, copy, modify, distribute, and sell this software and its documentation for any purpose

--- a/src/ISC.xml
+++ b/src/ISC.xml
@@ -10,8 +10,8 @@
          <p><alt name="title" match="(The )?ISC License( \(ISC[L]?\))?:?">ISC License</alt></p>
       </titleText>
       <copyrightText>
-         <p>Copyright (c) <alt match=".+" name="copyright">2004-2010 by Internet Systems Consortium, Inc. ("ISC")
-        <br/>Copyright (c) 1995-2003 by Internet Software Consortium</alt>
+         <p>Copyright (c) 2004-2010 by Internet Systems Consortium, Inc. ("ISC")
+        <br/>Copyright (c) 1995-2003 by Internet Software Consortium
          </p>
       </copyrightText>
 

--- a/src/JPNIC.xml
+++ b/src/JPNIC.xml
@@ -9,7 +9,7 @@
         <p>Japan Network Information Center License</p>
       </titleText>
       <copyrightText>
-        <p>Copyright (c) <alt name="copyright" match=".+">2000-2002 Japan Network Information Center</alt>. All rights reserved.</p>
+        <p>Copyright (c) 2000-2002 Japan Network Information Center. All rights reserved.</p>
       </copyrightText>
       <p>By using this file, you agree to the terms and conditions set forth <alt match="bellow|below" name="bellow">bellow</alt>.</p>
       <p>LICENSE TERMS AND CONDITIONS</p>

--- a/src/MIT-0.xml
+++ b/src/MIT-0.xml
@@ -16,7 +16,7 @@
       </titleText>
       <copyrightText>
         <p>
-          Copyright <alt name="copyright" match="(c)|"/> <alt match=".+" name="copyright">&lt;YEAR&gt; &lt;COPYRIGHT HOLDER&gt;</alt>
+          Copyright &lt;YEARr&gt; &lt;COPYRIGHT HOLDER&gt;
         </p>
       </copyrightText>
 

--- a/src/MIT.xml
+++ b/src/MIT.xml
@@ -9,8 +9,7 @@
          <p>MIT License</p>
       </titleText>
       <copyrightText>
-         <p>Copyright (c)
-           <alt match=".+" name="copyright">&lt;year&gt; &lt;copyright holders&gt;</alt>
+         <p>Copyright (c) &lt;year&gt; &lt;copyright holders&gt;
          </p>
       </copyrightText>
 

--- a/src/NCSA.xml
+++ b/src/NCSA.xml
@@ -11,8 +11,8 @@
          <p>University of Illinois/NCSA Open Source License</p>
       </titleText>
       <copyrightText>
-         <p>Copyright (c)
-        <alt match=".+" name="copyright"> &lt;Year&gt; &lt;Owner Organization Name&gt;</alt>. All rights reserved.
+
+         <p>Copyright (c) &lt;Year&gt; &lt;Owner Organization Name&gt;. All rights reserved. 
       </p>
       </copyrightText>
 

--- a/src/NTP.xml
+++ b/src/NTP.xml
@@ -9,8 +9,7 @@
          <p>NTP License (NTP)</p>
       </titleText>
       <copyrightText>
-         <p>Copyright (c)
-        <alt match=".+" name="copyright">(CopyrightHoldersName) (From 4-digit-year)-(To 4-digit-year)</alt>
+         <p>Copyright (c) (CopyrightHoldersName) (From 4-digit-year)-(To 4-digit-year)
          </p>
       </copyrightText>
 

--- a/src/OFL-1.1.xml
+++ b/src/OFL-1.1.xml
@@ -7,8 +7,8 @@
       </crossRefs>
       <notes>This license was released: 26 February 2007.</notes>
     <text>
-      <copyrightText><optional><p>Copyright (c) &lt;dates&gt;, &lt;Copyright Holder&gt; (&lt;URL|email&gt;),
-         <br/>with Reserved Font Name &lt;Reserved Font Name&gt;.</p></optional></copyrightText>
+      <copyrightText><p>Copyright (c) &lt;dates&gt;, &lt;Copyright Holder&gt; (&lt;URL|email&gt;),
+         <br/>with Reserved Font Name &lt;Reserved Font Name&gt;.</p></copyrightText>
       <optional>
          <p>This Font Software is licensed under the SIL Open Font License, Version 1.1.</p>
          <p>This license is copied below, and is also available with a FAQ at: http://scripts.sil.org/OFL</p>

--- a/src/Plexus.xml
+++ b/src/Plexus.xml
@@ -7,8 +7,7 @@
       <notes>dom4j uses this same license.</notes>
     <text>
       <copyrightText>
-         <p>Copyright
-        <alt match=".+" name="copyright">2002 (C) The Codehaus</alt>. All Rights Reserved.
+         <p>Copyright 2002 (C) The Codehaus. All Rights Reserved. 
       </p>
       </copyrightText>
 

--- a/src/TCL.xml
+++ b/src/TCL.xml
@@ -6,12 +6,15 @@
          <crossRef>https://fedoraproject.org/wiki/Licensing/TCL</crossRef>
       </crossRefs>
     <text>
-      <copyrightText>
-         <p>This software is copyrighted by the Regents of the University of California, Sun Microsystems, Inc.,
-        Scriptics Corporation, ActiveState Corporation and other parties. The following terms apply to all
+	  <p>
+         <copyrightText>
+            This software is copyrighted by the Regents of the University of California, Sun Microsystems, Inc.,
+            Scriptics Corporation, ActiveState Corporation and other parties. 
+	     </copyrightText>  
+		The following terms apply to all
         files associated with the software unless explicitly disclaimed in individual files. 
       </p>
-      </copyrightText>
+
 
       <p>The authors hereby grant permission to use, copy, modify, distribute, and license this software and its
          documentation for any purpose, provided that existing copyright notices are retained in all copies and

--- a/src/TCL.xml
+++ b/src/TCL.xml
@@ -7,10 +7,9 @@
       </crossRefs>
     <text>
       <copyrightText>
-         <p>This software is copyrighted by
-        <alt match=".+" name="authors">the Regents of the University of California, Sun Microsystems, Inc.,
-        Scriptics Corporation, ActiveState Corporation</alt> and other parties. The following terms apply to all
-        files associated with the software unless explicitly disclaimed in individual files.
+         <p>This software is copyrighted by the Regents of the University of California, Sun Microsystems, Inc.,
+        Scriptics Corporation, ActiveState Corporation and other parties. The following terms apply to all
+        files associated with the software unless explicitly disclaimed in individual files. 
       </p>
       </copyrightText>
 

--- a/src/TU-Berlin-1.0.xml
+++ b/src/TU-Berlin-1.0.xml
@@ -6,8 +6,7 @@
     </crossRefs>
     <text>
       <copyrightText>
-        <p>Copyright
-		      <alt match=".+" name="copyrightYears">1992, 1993, 1994</alt> by Jutta Degener and Carsten Bormann,
+        <p>Copyright 1992, 1993, 1994 by Jutta Degener and Carsten Bormann,
 	      </p>
         <p>Technische Universitaet Berlin</p>
       </copyrightText>

--- a/src/TU-Berlin-2.0.xml
+++ b/src/TU-Berlin-2.0.xml
@@ -6,8 +6,7 @@
     </crossRefs>
     <text>
       <copyrightText>
-        <p>Copyright
-		      <alt match=".+" name="copyrightYears">1992, 1993, 1994</alt> by Jutta Degener and Carsten Bormann,
+        <p>Copyright 1992, 1993, 1994 by Jutta Degener and Carsten Bormann,
 	      </p>
         <p>Technische Universitaet Berlin</p>
       </copyrightText>

--- a/src/Zlib.xml
+++ b/src/Zlib.xml
@@ -10,7 +10,7 @@
          <p>zlib License</p>
       </titleText>
       <copyrightText>
-         <optional><p>Copyright (c) &lt;year&gt; &lt;copyright holders&gt;</p></optional>
+         <p>Copyright (c) &lt;year&gt; &lt;copyright holders&gt;</p>
       </copyrightText>
       <p>This software is provided 'as-is', without any express or implied warranty. In no event will the authors
          be held liable for any damages arising from the use of this software.</p>


### PR DESCRIPTION
This requires an update to the tools and removing any optional and alternate text elements currently inside copyright text.