### PR TITLE
Remove optional 's' from URLs

### DIFF
--- a/src/AGPL-3.0-only.xml
+++ b/src/AGPL-3.0-only.xml
@@ -21,7 +21,7 @@
       <p>
         You should have received a copy of the GNU Affero General Public License
         along with this program. If not, see
-	      &lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;</p>
+	      &lt;https://www.gnu.org/licenses/&gt;</p>
     </standardLicenseHeader>
     <notes>
       This version was released: 19 November 2007. This license identifier refers to the choice
@@ -39,7 +39,7 @@
     </titleText>
     <p>
       Copyright (C) 2007 Free Software Foundation, Inc.
-      &lt;http<optional>s</optional>://fsf.org/&gt;
+      &lt;https://fsf.org/&gt;
     </p>
     <p>
       Everyone is permitted to copy and distribute verbatim copies
@@ -832,7 +832,7 @@
       <p>
         You should have received a copy of the GNU Affero General
 	Public License along with this program. If not, see
-	&lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.
+	&lt;https://www.gnu.org/licenses/&gt;.
       </p>
       <p>
         Also add information on how to contact you by electronic and paper mail.
@@ -851,7 +851,7 @@
         or school, if any, to sign a "copyright disclaimer" for
         the program, if necessary. For more information on this,
 	and how to apply and follow the GNU AGPL, see
-	&lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.
+	&lt;https://www.gnu.org/licenses/&gt;.
       </p>
     </optional>
     </text>

--- a/src/AGPL-3.0-or-later.xml
+++ b/src/AGPL-3.0-or-later.xml
@@ -23,7 +23,7 @@
     </titleText>
     <p>
       Copyright (C) 2007 Free Software Foundation, Inc.
-      &lt;http<optional>s</optional>://fsf.org/&gt;
+      &lt;https://fsf.org/&gt;
     </p>
     <p>
       Everyone is permitted to copy and distribute verbatim copies
@@ -817,7 +817,7 @@
       <p>
         You should have received a copy of the GNU Affero General
 	Public License along with this program. If not, see
-	&lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.
+	&lt;https://www.gnu.org/licenses/&gt;.
       </p>
       </standardLicenseHeader>
       <p>
@@ -837,7 +837,7 @@
         or school, if any, to sign a "copyright disclaimer" for
         the program, if necessary. For more information on this,
 	and how to apply and follow the GNU AGPL, see
-	&lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.
+	&lt;https://www.gnu.org/licenses/&gt;.
       </p>
     </optional>
     </text>

--- a/src/AGPL-3.0.xml
+++ b/src/AGPL-3.0.xml
@@ -21,7 +21,7 @@
       PURPOSE. See the GNU Affero General Public License for more details.
       You should have received a copy of the GNU Affero General Public License
       along with this program. If not, see
-      &lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;
+      &lt;https://www.gnu.org/licenses/&gt;
     </standardLicenseHeader>
     <text>
     <titleText>
@@ -32,7 +32,7 @@
     </titleText>
     <p>
       Copyright (C) 2007 Free Software Foundation, Inc.
-      &lt;http<optional>s</optional>://fsf.org/&gt;
+      &lt;https://fsf.org/&gt;
     </p>
     <p>
       Everyone is permitted to copy and distribute verbatim copies
@@ -825,7 +825,7 @@
       <p>
         You should have received a copy of the GNU Affero General
 	Public License along with this program. If not, see
-	&lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.
+	&lt;https://www.gnu.org/licenses/&gt;.
       </p>
       <p>
         Also add information on how to contact you by electronic and paper mail.
@@ -844,7 +844,7 @@
         or school, if any, to sign a "copyright disclaimer" for
         the program, if necessary. For more information on this,
 	and how to apply and follow the GNU AGPL, see
-	&lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.
+	&lt;https://www.gnu.org/licenses/&gt;.
       </p>
     </optional>
     </text>

--- a/src/CC-BY-ND-2.0.xml
+++ b/src/CC-BY-ND-2.0.xml
@@ -258,7 +258,7 @@
          Creative Commons without the prior written consent of Creative Commons. Any permitted use will
          be in compliance with Creative Commons' then-current trademark usage guidelines, as may be
          published on its website or otherwise made available upon request from time to time.</p>
-      <p>Creative Commons may be contacted at http<optional>s</optional>://creativecommons.org/.</p>
+      <p>Creative Commons may be contacted at https://creativecommons.org/.</p>
     </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/GPL-3.0+.xml
+++ b/src/GPL-3.0+.xml
@@ -15,7 +15,7 @@
         <br/>Version 3, 29 June 2007
       </p>
       </titleText>
-      <p>Copyright © 2007 Free Software Foundation, Inc. &lt;http<optional>s</optional>://fsf.org/&gt;</p>
+      <p>Copyright © 2007 Free Software Foundation, Inc. &lt;https://fsf.org/&gt;</p>
       <p>Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is
          not allowed.</p>
       <p>Preamble</p>
@@ -568,7 +568,7 @@
          the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
          Public License for more details.</p>
          <p>You should have received a copy of the GNU General Public License along with this program. If not, see
-         &lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.</p>
+         &lt;https://www.gnu.org/licenses/&gt;.</p>
          </standardLicenseHeader>
          <p>Also add information on how to contact you by electronic and paper mail.</p>
          <p>If the program does terminal interaction, make it output a short notice like this when it starts in an
@@ -583,12 +583,12 @@
          interface, you would use an “about box”.</p>
          <p>You should also get your employer (if you work as a programmer) or school, if any, to sign a
          “copyright disclaimer” for the program, if necessary. For more information on this, and
-         how to apply and follow the GNU GPL, see &lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.</p>
+         how to apply and follow the GNU GPL, see &lt;https://www.gnu.org/licenses/&gt;.</p>
          <p>The GNU General Public License does not permit incorporating your program into proprietary programs. If
          your program is a subroutine library, you may consider it more useful to permit linking proprietary
          applications with the library. If this is what you want to do, use the GNU Lesser General Public
          License instead of this License. But first, please read
-         &lt;http<optional>s</optional>://www.gnu.org/<alt match="philosophy|licenses" name="philicenses">licenses</alt>/why-not-lgpl.html&gt;.</p>
+         &lt;https://www.gnu.org/<alt match="philosophy|licenses" name="philicenses">licenses</alt>/why-not-lgpl.html&gt;.</p>
       </optional>
     </text>
   </license>

--- a/src/GPL-3.0-only.xml
+++ b/src/GPL-3.0-only.xml
@@ -23,7 +23,7 @@
       <p>
         You should have received a copy of the GNU General
         Public License along with this program. If not, see
-        &lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.
+        &lt;https://www.gnu.org/licenses/&gt;.
       </p>
     </standardLicenseHeader>
     <notes>
@@ -42,7 +42,7 @@
     </titleText>
     <p>
       Copyright © 2007 Free Software Foundation, Inc.
-      &lt;http<optional>s</optional>://fsf.org/&gt;
+      &lt;https://fsf.org/&gt;
     </p>
     <p>
       Everyone is permitted to copy and distribute verbatim copies
@@ -815,7 +815,7 @@
       <p>
         You should have received a copy of the GNU General
 	Public License along with this program. If not, see
-	&lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.
+	&lt;https://www.gnu.org/licenses/&gt;.
       </p>
       <p>
         Also add information on how to contact you by electronic and paper mail.
@@ -843,7 +843,7 @@
         programmer) or school, if any, to sign a “copyright disclaimer”
         for the program, if necessary. For more information on
 	this, and how to apply and follow the GNU GPL, see
-	&lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.
+	&lt;https://www.gnu.org/licenses/&gt;.
       </p>
       <p>
         The GNU General Public License does not permit incorporating
@@ -852,7 +852,7 @@
         linking proprietary applications with the library. If this
         is what you want to do, use the GNU Lesser General Public
 	License instead of this License. But first, please read
-	&lt;http<optional>s</optional>://www.gnu.org/<alt match="philosophy|licenses" name="philicenses">licenses</alt>/why-not-lgpl.html&gt;.
+	&lt;https://www.gnu.org/<alt match="philosophy|licenses" name="philicenses">licenses</alt>/why-not-lgpl.html&gt;.
       </p>
     </optional>
     </text>

--- a/src/GPL-3.0-or-later.xml
+++ b/src/GPL-3.0-or-later.xml
@@ -23,7 +23,7 @@
     </titleText>
     <p>
       Copyright © 2007 Free Software Foundation, Inc.
-      &lt;http<optional>s</optional>://fsf.org/&gt;
+      &lt;https://fsf.org/&gt;
     </p>
     <p>
       Everyone is permitted to copy and distribute verbatim copies
@@ -797,7 +797,7 @@
       <p>
         You should have received a copy of the GNU General
 	Public License along with this program. If not, see
-	&lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.
+	&lt;https://www.gnu.org/licenses/&gt;.
       </p>
       </standardLicenseHeader>
       <p>
@@ -826,7 +826,7 @@
         programmer) or school, if any, to sign a “copyright disclaimer”
         for the program, if necessary. For more information on
 	this, and how to apply and follow the GNU GPL, see
-	&lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.
+	&lt;https://www.gnu.org/licenses/&gt;.
       </p>
       <p>
         The GNU General Public License does not permit incorporating
@@ -835,7 +835,7 @@
         linking proprietary applications with the library. If this
         is what you want to do, use the GNU Lesser General Public
 	License instead of this License. But first, please read
-	&lt;http<optional>s</optional>://www.gnu.org/<alt match="philosophy|licenses" name="philicenses">licenses</alt>/why-not-lgpl.html&gt;.
+	&lt;https://www.gnu.org/<alt match="philosophy|licenses" name="philicenses">licenses</alt>/why-not-lgpl.html&gt;.
       </p>
     </optional>
     </text>

--- a/src/GPL-3.0.xml
+++ b/src/GPL-3.0.xml
@@ -28,7 +28,7 @@
       <p>
         You should have received a copy of the GNU General
         Public License along with this program. If not, see
-        &lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.
+        &lt;https://www.gnu.org/licenses/&gt;.
       </p>
     </standardLicenseHeader>
     <text>
@@ -40,7 +40,7 @@
     </titleText>
     <p>
       Copyright © 2007 Free Software Foundation, Inc.
-      &lt;http<optional>s</optional>://fsf.org/&gt;
+      &lt;https://fsf.org/&gt;
     </p>
     <p>
       Everyone is permitted to copy and distribute verbatim copies
@@ -813,7 +813,7 @@
       <p>
         You should have received a copy of the GNU General
 	Public License along with this program. If not, see
-	&lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.
+	&lt;https://www.gnu.org/licenses/&gt;.
       </p>
       <p>
         Also add information on how to contact you by electronic and paper mail.
@@ -841,7 +841,7 @@
         programmer) or school, if any, to sign a “copyright disclaimer”
         for the program, if necessary. For more information on
 	this, and how to apply and follow the GNU GPL, see
-	&lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.
+	&lt;https://www.gnu.org/licenses/&gt;.
       </p>
       <p>
         The GNU General Public License does not permit incorporating
@@ -850,7 +850,7 @@
         linking proprietary applications with the library. If this
         is what you want to do, use the GNU Lesser General Public
 	License instead of this License. But first, please read
-	&lt;http<optional>s</optional>://www.gnu.org/<alt match="philosophy|licenses" name="philicenses">licenses</alt>/why-not-lgpl.html&gt;.
+	&lt;https://www.gnu.org/<alt match="philosophy|licenses" name="philicenses">licenses</alt>/why-not-lgpl.html&gt;.
       </p>
     </optional>
     </text>

--- a/src/LGPL-3.0+.xml
+++ b/src/LGPL-3.0+.xml
@@ -15,7 +15,7 @@
         <br/>Version 3, 29 June 2007
       </p>
       </titleText>
-      <p>Copyright (C) 2007 Free Software Foundation, Inc. &lt;http<optional>s</optional>://fsf.org/&gt;</p>
+      <p>Copyright (C) 2007 Free Software Foundation, Inc. &lt;https://fsf.org/&gt;</p>
       <p>Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is
          not allowed.</p>
       <p>This version of the GNU Lesser General Public License incorporates the terms and conditions of version 3

--- a/src/LGPL-3.0-only.xml
+++ b/src/LGPL-3.0-only.xml
@@ -19,7 +19,7 @@
     </titleText>
     <p>
       Copyright (C) 2007 Free Software Foundation, Inc.
-      &lt;http<optional>s</optional>://fsf.org/&gt;
+      &lt;https://fsf.org/&gt;
     </p>
     <p>
       Everyone is permitted to copy and distribute verbatim copies

--- a/src/LGPL-3.0-or-later.xml
+++ b/src/LGPL-3.0-or-later.xml
@@ -18,7 +18,7 @@
     </titleText>
     <p>
       Copyright (C) 2007 Free Software Foundation, Inc.
-      &lt;http<optional>s</optional>://fsf.org/&gt;
+      &lt;https://fsf.org/&gt;
     </p>
     <p>
       Everyone is permitted to copy and distribute verbatim copies

--- a/src/LGPL-3.0.xml
+++ b/src/LGPL-3.0.xml
@@ -20,7 +20,7 @@
     </titleText>
     <p>
       Copyright (C) 2007 Free Software Foundation, Inc.
-      &lt;http<optional>s</optional>://fsf.org/&gt;
+      &lt;https://fsf.org/&gt;
     </p>
     <p>
       Everyone is permitted to copy and distribute verbatim copies


### PR DESCRIPTION
The `http<optional>s</optional>://...` are causing formatting issues in JSON and plain text output.  Although we could add the spacing attribute to fix this, I believe it would be easier for humans to read and for computers to match if we adopted the matching guidelines suggested in issue #892 and removed these optional elements.



Signed-off-by: Gary O'Neall <gary@sourceauditor.com>

