### PR TITLE
Add spacing to fix formatting issues for JSON and plain text files

### DIFF
--- a/src/AFL-1.1.xml
+++ b/src/AFL-1.1.xml
@@ -16,7 +16,7 @@
          (the "Licensor") has placed the following notice immediately following the copyright notice for the
          Original Work:</p>
          <standardLicenseHeader>
-         <p><optional>"</optional>Licensed under the Academic Free License version 1.1.<optional>"</optional></p>
+         <p><optional spacing="none">"</optional>Licensed under the Academic Free License version 1.1.<optional spacing="none">"</optional></p>
          </standardLicenseHeader>
       </optional>
 

--- a/src/AGPL-3.0-only.xml
+++ b/src/AGPL-3.0-only.xml
@@ -21,7 +21,7 @@
       <p>
         You should have received a copy of the GNU Affero General Public License
         along with this program. If not, see
-	      &lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;</p>
+	      &lt;http<optional spacing="none">s</optional>://www.gnu.org/licenses/&gt;</p>
     </standardLicenseHeader>
     <notes>
       This version was released: 19 November 2007. This license identifier refers to the choice
@@ -39,7 +39,7 @@
     </titleText>
     <p>
       Copyright (C) 2007 Free Software Foundation, Inc.
-      &lt;http<optional>s</optional>://fsf.org/&gt;
+      &lt;http<optional spacing="none">s</optional>://fsf.org/&gt;
     </p>
     <p>
       Everyone is permitted to copy and distribute verbatim copies
@@ -832,7 +832,7 @@
       <p>
         You should have received a copy of the GNU Affero General
 	Public License along with this program. If not, see
-	&lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.
+	&lt;http<optional spacing="none">s</optional>://www.gnu.org/licenses/&gt;.
       </p>
       <p>
         Also add information on how to contact you by electronic and paper mail.
@@ -851,7 +851,7 @@
         or school, if any, to sign a "copyright disclaimer" for
         the program, if necessary. For more information on this,
 	and how to apply and follow the GNU AGPL, see
-	&lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.
+	&lt;http<optional spacing="none">s</optional>://www.gnu.org/licenses/&gt;.
       </p>
     </optional>
     </text>

--- a/src/AGPL-3.0-or-later.xml
+++ b/src/AGPL-3.0-or-later.xml
@@ -23,7 +23,7 @@
     </titleText>
     <p>
       Copyright (C) 2007 Free Software Foundation, Inc.
-      &lt;http<optional>s</optional>://fsf.org/&gt;
+      &lt;http<optional spacing="none">s</optional>://fsf.org/&gt;
     </p>
     <p>
       Everyone is permitted to copy and distribute verbatim copies
@@ -817,7 +817,7 @@
       <p>
         You should have received a copy of the GNU Affero General
 	Public License along with this program. If not, see
-	&lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.
+	&lt;http<optional spacing="none">s</optional>://www.gnu.org/licenses/&gt;.
       </p>
       </standardLicenseHeader>
       <p>
@@ -837,7 +837,7 @@
         or school, if any, to sign a "copyright disclaimer" for
         the program, if necessary. For more information on this,
 	and how to apply and follow the GNU AGPL, see
-	&lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.
+	&lt;http<optional spacing="none">s</optional>://www.gnu.org/licenses/&gt;.
       </p>
     </optional>
     </text>

--- a/src/AGPL-3.0.xml
+++ b/src/AGPL-3.0.xml
@@ -21,7 +21,7 @@
       PURPOSE. See the GNU Affero General Public License for more details.
       You should have received a copy of the GNU Affero General Public License
       along with this program. If not, see
-      &lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;
+      &lt;http<optional spacing="none">s</optional>://www.gnu.org/licenses/&gt;
     </standardLicenseHeader>
     <text>
     <titleText>
@@ -32,7 +32,7 @@
     </titleText>
     <p>
       Copyright (C) 2007 Free Software Foundation, Inc.
-      &lt;http<optional>s</optional>://fsf.org/&gt;
+      &lt;http<optional spacing="none">s</optional>://fsf.org/&gt;
     </p>
     <p>
       Everyone is permitted to copy and distribute verbatim copies
@@ -825,7 +825,7 @@
       <p>
         You should have received a copy of the GNU Affero General
 	Public License along with this program. If not, see
-	&lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.
+	&lt;http<optional spacing="none">s</optional>://www.gnu.org/licenses/&gt;.
       </p>
       <p>
         Also add information on how to contact you by electronic and paper mail.
@@ -844,7 +844,7 @@
         or school, if any, to sign a "copyright disclaimer" for
         the program, if necessary. For more information on this,
 	and how to apply and follow the GNU AGPL, see
-	&lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.
+	&lt;http<optional spacing="none">s</optional>://www.gnu.org/licenses/&gt;.
       </p>
     </optional>
     </text>

--- a/src/CC-BY-ND-2.0.xml
+++ b/src/CC-BY-ND-2.0.xml
@@ -258,7 +258,7 @@
          Creative Commons without the prior written consent of Creative Commons. Any permitted use will
          be in compliance with Creative Commons' then-current trademark usage guidelines, as may be
          published on its website or otherwise made available upon request from time to time.</p>
-      <p>Creative Commons may be contacted at http<optional>s</optional>://creativecommons.org/.</p>
+      <p>Creative Commons may be contacted at http<optional spacing="none">s</optional>://creativecommons.org/.</p>
     </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/CUA-OPL-1.0.xml
+++ b/src/CUA-OPL-1.0.xml
@@ -499,7 +499,7 @@
       <optional>
          <p>EXHIBIT A - CUA Office Public License.</p>
          <standardLicenseHeader>
-         <p><optional>"</optional>The contents of this file are subject to the CUA Office Public License Version 1.0 (the
+         <p><optional spacing="none">"</optional>The contents of this file are subject to the CUA Office Public License Version 1.0 (the
          "License"); you may not use this file except in compliance with the License. You may obtain
          a copy of the License at http://cuaoffice.sourceforge.net/</p>
          <p>Software distributed under the License is distributed on an "AS IS" basis, WITHOUT WARRANTY OF
@@ -515,7 +515,7 @@
          License and not to allow others to use your version of this file under the CUAPL, indicate your
          decision by deleting the provisions above and replace them with the notice and other provisions
          required by the <alt name="altLicenseShort4" match=".+">[___]</alt> License. If you do not delete the provisions above, a recipient may use your
-         version of this file under either the CUAPL or the <alt name="altLicenseShort5" match=".+">[___]</alt> License.<optional>"</optional></p>
+         version of this file under either the CUAPL or the <alt name="altLicenseShort5" match=".+">[___]</alt> License.<optional spacing="none">"</optional></p>
          </standardLicenseHeader>
          <p>[NOTE: The text of this Exhibit A may differ slightly from the text of the notices in the Source Code
          files of the Original Code. You should use the text of this Exhibit A rather than the text found in

--- a/src/GPL-2.0+.xml
+++ b/src/GPL-2.0+.xml
@@ -16,7 +16,7 @@
       </p>
       </titleText>
       <p>Copyright (C) 1989, 1991 Free Software Foundation, Inc.
-        <br/>51 Franklin Street, Fifth Floor, Boston, MA 02110-1301<optional>,</optional> USA
+        <br/>51 Franklin Street, Fifth Floor, Boston, MA 02110-1301<optional spacing="after">,</optional> USA
       </p>
       <p>Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is
          not allowed.</p>
@@ -280,7 +280,7 @@
          the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
          Public License for more details.</p>
          <p>You should have received a copy of the GNU General Public License along with this program; if not, write
-         to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301<optional>,</optional> USA.</p>
+         to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301<optional spacing="after">,</optional> USA.</p>
          </standardLicenseHeader>
          <p>Also add information on how to contact you by electronic and paper mail.</p>
          <p>If the program is interactive, make it output a short notice like this when it starts in an interactive

--- a/src/GPL-2.0-only.xml
+++ b/src/GPL-2.0-only.xml
@@ -22,7 +22,7 @@
       <p>
         You should have received a copy of the GNU General Public License
         along with this program; if not, write to the Free Software Foundation,
-        Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301<optional>,</optional>
+        Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301<optional spacing="after">,</optional>
         USA.
       </p>
     </standardLicenseHeader>
@@ -42,7 +42,7 @@
     </titleText>
     <p>
       Copyright (C) 1989, 1991 Free Software Foundation, Inc.<alt name="incComma" match=",|"/><br/>
-      51 Franklin Street, Fifth Floor, Boston, MA 02110-1301<optional>,</optional>
+      51 Franklin Street, Fifth Floor, Boston, MA 02110-1301<optional spacing="after">,</optional>
       USA
     </p>
     <p>
@@ -404,11 +404,11 @@
         the "copyright" line and a pointer to where the full notice is found.
       </p>
       <p>
-        <optional>&lt;</optional>one line to give the program's name and <alt name="ideaArticle" match="a brief|an">an</alt> idea of what it does.<optional>&gt;</optional>
+        <optional spacing="none">&lt;</optional>one line to give the program's name and <alt name="ideaArticle" match="a brief|an">an</alt> idea of what it does.<optional spacing="none">&gt;</optional>
         <br></br>
         Copyright (C)
-        <optional>&lt;</optional><alt name="templateYear" match="yyyy|year">yyyy</alt><optional>&gt;</optional>
-        <optional>&lt;</optional>name of author<optional>&gt;</optional>
+        <optional spacing="none">&lt;</optional><alt name="templateYear" match="yyyy|year">yyyy</alt><optional spacing="after">&gt;</optional>
+        <optional spacing="before">&lt;</optional>name of author<optional spacing="none">&gt;</optional>
       </p>
       <p>
         This program is free software; you can redistribute it and/or
@@ -425,7 +425,7 @@
       <p>
         You should have received a copy of the GNU General Public License
         along with this program; if not, write to the Free Software Foundation,
-        Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301<optional>,</optional>
+        Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301<optional spacing="after">,</optional>
         USA.
       </p>
       <p>
@@ -458,7 +458,7 @@
         `Gnomovision' (which makes passes at compilers) written by James Hacker.
       </p>
       <p>
-	<optional>&lt;</optional>signature of Ty Coon<optional>&gt;</optional>,
+	<optional spacing="none">&lt;</optional>signature of Ty Coon<optional spacing="before">&gt;</optional>,
 	1 April 1989 Ty Coon, President of Vice
       </p>
     </optional>

--- a/src/GPL-2.0-or-later.xml
+++ b/src/GPL-2.0-or-later.xml
@@ -23,7 +23,7 @@
     </titleText>
     <p>
       Copyright (C) 1989, 1991 Free Software Foundation, Inc.<alt name="incComma" match=",|"/><br/>
-      51 Franklin Street, Fifth Floor, Boston, MA 02110-1301<optional>,</optional>
+      51 Franklin Street, Fifth Floor, Boston, MA 02110-1301<optional spacing="after">,</optional>
       USA
     </p>
     <p>
@@ -404,7 +404,7 @@
       <p>
         You should have received a copy of the GNU General Public License
         along with this program; if not, write to the Free Software Foundation,
-        Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301<optional>,</optional>
+        Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301<optional spacing="after">,</optional>
         USA.
       </p>
       </standardLicenseHeader>
@@ -438,7 +438,7 @@
         `Gnomovision' (which makes passes at compilers) written by James Hacker.
       </p>
       <p>
-	<optional>&lt;</optional>signature of Ty Coon<optional>&gt;</optional>,
+	<optional spacing="none">&lt;</optional>signature of Ty Coon<optional spacing="none">&gt;</optional>,
 	1 April 1989 Ty Coon, President of Vice
       </p>
     </optional>

--- a/src/GPL-2.0.xml
+++ b/src/GPL-2.0.xml
@@ -27,7 +27,7 @@
       <p>
         You should have received a copy of the GNU General Public License
         along with this program; if not, write to the Free Software Foundation,
-        Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301<optional>,</optional>
+        Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301<optional spacing="after">,</optional>
         USA.
       </p>
     </standardLicenseHeader>
@@ -40,7 +40,7 @@
     </titleText>
     <p>
       Copyright (C) 1989, 1991 Free Software Foundation, Inc.<alt name="incComma" match=",|"/><br/>
-      51 Franklin Street, Fifth Floor, Boston, MA 02110-1301<optional>,</optional>
+      51 Franklin Street, Fifth Floor, Boston, MA 02110-1301<optional spacing="after">,</optional>
       USA
     </p>
     <p>
@@ -402,11 +402,11 @@
         the "copyright" line and a pointer to where the full notice is found.
       </p>
       <p>
-        <optional>&lt;</optional>one line to give the program's name and <alt name="ideaArticle" match="a brief|an">an</alt> idea of what it does.<optional>&gt;</optional>
+        <optional spacing="none">&lt;</optional>one line to give the program's name and <alt name="ideaArticle" match="a brief|an">an</alt> idea of what it does.<optional spacing="none">&gt;</optional>
         <br></br>
         Copyright (C)
-        <optional>&lt;</optional><alt name="templateYear" match="yyyy|year">yyyy</alt><optional>&gt;</optional>
-        <optional>&lt;</optional>name of author<optional>&gt;</optional>
+        <optional spacing="before">&lt;</optional><alt name="templateYear" match="yyyy|year">yyyy</alt><optional spacing="after">&gt;</optional>
+        <optional spacing="before">&lt;</optional>name of author<optional spacing="none">&gt;</optional>
       </p>
       <p>
         This program is free software; you can redistribute it and/or
@@ -423,7 +423,7 @@
       <p>
         You should have received a copy of the GNU General Public License
         along with this program; if not, write to the Free Software Foundation,
-        Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301<optional>,</optional>
+        Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301<optional spacing="after">,</optional>
         USA.
       </p>
       <p>
@@ -456,7 +456,7 @@
         `Gnomovision' (which makes passes at compilers) written by James Hacker.
       </p>
       <p>
-	<optional>&lt;</optional>signature of Ty Coon<optional>&gt;</optional>,
+	<optional spacing="none">&lt;</optional>signature of Ty Coon<optional spacing="none">&gt;</optional>,
 	1 April 1989 Ty Coon, President of Vice
       </p>
     </optional>

--- a/src/GPL-3.0+.xml
+++ b/src/GPL-3.0+.xml
@@ -15,7 +15,7 @@
         <br/>Version 3, 29 June 2007
       </p>
       </titleText>
-      <p>Copyright © 2007 Free Software Foundation, Inc. &lt;http<optional>s</optional>://fsf.org/&gt;</p>
+      <p>Copyright © 2007 Free Software Foundation, Inc. &lt;http<optional spacing="none">s</optional>://fsf.org/&gt;</p>
       <p>Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is
          not allowed.</p>
       <p>Preamble</p>
@@ -568,7 +568,7 @@
          the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
          Public License for more details.</p>
          <p>You should have received a copy of the GNU General Public License along with this program. If not, see
-         &lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.</p>
+         &lt;http<optional spacing="none">s</optional>://www.gnu.org/licenses/&gt;.</p>
          </standardLicenseHeader>
          <p>Also add information on how to contact you by electronic and paper mail.</p>
          <p>If the program does terminal interaction, make it output a short notice like this when it starts in an
@@ -583,12 +583,12 @@
          interface, you would use an “about box”.</p>
          <p>You should also get your employer (if you work as a programmer) or school, if any, to sign a
          “copyright disclaimer” for the program, if necessary. For more information on this, and
-         how to apply and follow the GNU GPL, see &lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.</p>
+         how to apply and follow the GNU GPL, see &lt;http<optional spacing="none">s</optional>://www.gnu.org/licenses/&gt;.</p>
          <p>The GNU General Public License does not permit incorporating your program into proprietary programs. If
          your program is a subroutine library, you may consider it more useful to permit linking proprietary
          applications with the library. If this is what you want to do, use the GNU Lesser General Public
          License instead of this License. But first, please read
-         &lt;http<optional>s</optional>://www.gnu.org/<alt match="philosophy|licenses" name="philicenses">licenses</alt>/why-not-lgpl.html&gt;.</p>
+         &lt;http<optional spacing="none">s</optional>://www.gnu.org/<alt match="philosophy|licenses" name="philicenses">licenses</alt>/why-not-lgpl.html&gt;.</p>
       </optional>
     </text>
   </license>

--- a/src/GPL-3.0-only.xml
+++ b/src/GPL-3.0-only.xml
@@ -23,7 +23,7 @@
       <p>
         You should have received a copy of the GNU General
         Public License along with this program. If not, see
-        &lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.
+        &lt;http<optional spacing="none">s</optional>://www.gnu.org/licenses/&gt;.
       </p>
     </standardLicenseHeader>
     <notes>
@@ -42,7 +42,7 @@
     </titleText>
     <p>
       Copyright © 2007 Free Software Foundation, Inc.
-      &lt;http<optional>s</optional>://fsf.org/&gt;
+      &lt;http<optional spacing="none">s</optional>://fsf.org/&gt;
     </p>
     <p>
       Everyone is permitted to copy and distribute verbatim copies
@@ -815,7 +815,7 @@
       <p>
         You should have received a copy of the GNU General
 	Public License along with this program. If not, see
-	&lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.
+	&lt;http<optional spacing="none">s</optional>://www.gnu.org/licenses/&gt;.
       </p>
       <p>
         Also add information on how to contact you by electronic and paper mail.
@@ -843,7 +843,7 @@
         programmer) or school, if any, to sign a “copyright disclaimer”
         for the program, if necessary. For more information on
 	this, and how to apply and follow the GNU GPL, see
-	&lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.
+	&lt;http<optional spacing="none">s</optional>://www.gnu.org/licenses/&gt;.
       </p>
       <p>
         The GNU General Public License does not permit incorporating
@@ -852,7 +852,7 @@
         linking proprietary applications with the library. If this
         is what you want to do, use the GNU Lesser General Public
 	License instead of this License. But first, please read
-	&lt;http<optional>s</optional>://www.gnu.org/<alt match="philosophy|licenses" name="philicenses">licenses</alt>/why-not-lgpl.html&gt;.
+	&lt;http<optional spacing="none">s</optional>://www.gnu.org/<alt match="philosophy|licenses" name="philicenses">licenses</alt>/why-not-lgpl.html&gt;.
       </p>
     </optional>
     </text>

--- a/src/GPL-3.0-or-later.xml
+++ b/src/GPL-3.0-or-later.xml
@@ -23,7 +23,7 @@
     </titleText>
     <p>
       Copyright © 2007 Free Software Foundation, Inc.
-      &lt;http<optional>s</optional>://fsf.org/&gt;
+      &lt;http<optional spacing="none">s</optional>://fsf.org/&gt;
     </p>
     <p>
       Everyone is permitted to copy and distribute verbatim copies
@@ -797,7 +797,7 @@
       <p>
         You should have received a copy of the GNU General
 	Public License along with this program. If not, see
-	&lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.
+	&lt;http<optional spacing="none">s</optional>://www.gnu.org/licenses/&gt;.
       </p>
       </standardLicenseHeader>
       <p>
@@ -826,7 +826,7 @@
         programmer) or school, if any, to sign a “copyright disclaimer”
         for the program, if necessary. For more information on
 	this, and how to apply and follow the GNU GPL, see
-	&lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.
+	&lt;http<optional spacing="none">s</optional>://www.gnu.org/licenses/&gt;.
       </p>
       <p>
         The GNU General Public License does not permit incorporating
@@ -835,7 +835,7 @@
         linking proprietary applications with the library. If this
         is what you want to do, use the GNU Lesser General Public
 	License instead of this License. But first, please read
-	&lt;http<optional>s</optional>://www.gnu.org/<alt match="philosophy|licenses" name="philicenses">licenses</alt>/why-not-lgpl.html&gt;.
+	&lt;http<optional spacing="none">s</optional>://www.gnu.org/<alt match="philosophy|licenses" name="philicenses">licenses</alt>/why-not-lgpl.html&gt;.
       </p>
     </optional>
     </text>

--- a/src/GPL-3.0.xml
+++ b/src/GPL-3.0.xml
@@ -28,7 +28,7 @@
       <p>
         You should have received a copy of the GNU General
         Public License along with this program. If not, see
-        &lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.
+        &lt;http<optional spacing="none">s</optional>://www.gnu.org/licenses/&gt;.
       </p>
     </standardLicenseHeader>
     <text>
@@ -40,7 +40,7 @@
     </titleText>
     <p>
       Copyright © 2007 Free Software Foundation, Inc.
-      &lt;http<optional>s</optional>://fsf.org/&gt;
+      &lt;http<optional spacing="none">s</optional>://fsf.org/&gt;
     </p>
     <p>
       Everyone is permitted to copy and distribute verbatim copies
@@ -813,7 +813,7 @@
       <p>
         You should have received a copy of the GNU General
 	Public License along with this program. If not, see
-	&lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.
+	&lt;http<optional spacing="none">s</optional>://www.gnu.org/licenses/&gt;.
       </p>
       <p>
         Also add information on how to contact you by electronic and paper mail.
@@ -841,7 +841,7 @@
         programmer) or school, if any, to sign a “copyright disclaimer”
         for the program, if necessary. For more information on
 	this, and how to apply and follow the GNU GPL, see
-	&lt;http<optional>s</optional>://www.gnu.org/licenses/&gt;.
+	&lt;http<optional spacing="none">s</optional>://www.gnu.org/licenses/&gt;.
       </p>
       <p>
         The GNU General Public License does not permit incorporating
@@ -850,7 +850,7 @@
         linking proprietary applications with the library. If this
         is what you want to do, use the GNU Lesser General Public
 	License instead of this License. But first, please read
-	&lt;http<optional>s</optional>://www.gnu.org/<alt match="philosophy|licenses" name="philicenses">licenses</alt>/why-not-lgpl.html&gt;.
+	&lt;http<optional spacing="none">s</optional>://www.gnu.org/<alt match="philosophy|licenses" name="philicenses">licenses</alt>/why-not-lgpl.html&gt;.
       </p>
     </optional>
     </text>

--- a/src/HPND-sell-variant.xml
+++ b/src/HPND-sell-variant.xml
@@ -14,10 +14,10 @@
       </copyrightText>
 
       <p>Permission to use, copy, modify, distribute, and sell this software and its documentation for any purpose
-         is hereby granted without fee, provided that the above copyright notice appears in all copies<optional>,</optional>
+         is hereby granted without fee, provided that the above copyright notice appears in all copies<optional spacing="after">,</optional>
          <optional>and</optional> that both <optional>that</optional>
          <optional>the</optional> copyright notice
-         and this permission notice appear in supporting documentation<optional>, and that the name <optional>of</optional>
+         and this permission notice appear in supporting documentation<optional spacing="after">, and that the name <optional>of</optional>
             <alt match=".*" name="copyrightHolder0">&lt;copyright holder&gt;</alt>
             <alt match=".*" name="orRelated">&lt;or related entities&gt;</alt>
          not be used in advertising or publicity pertaining to distribution of the software without specific, written

--- a/src/HPND.xml
+++ b/src/HPND.xml
@@ -26,7 +26,7 @@
       </copyrightText>
 
       <p>Permission to use, copy, modify and distribute this software and its documentation for any purpose and
-         without fee is hereby granted, provided that the above copyright notice appear in all copies<optional>,</optional>
+         without fee is hereby granted, provided that the above copyright notice appear in all copies<optional spacing="after">,</optional>
          <optional>and</optional> that both <optional>that</optional>
          <optional>the</optional> copyright notice
          and this permission notice appear in supporting documentation<optional>, and that the name <optional>of</optional>

--- a/src/Interbase-1.0.xml
+++ b/src/Interbase-1.0.xml
@@ -520,7 +520,7 @@
              specified by the Initial Developer in the file described in Exhibit A.</p>
             <p>EXHIBIT A - InterBase Public License.</p>
             <standardLicenseHeader>
-            <p><optional>"</optional>The contents of this file are subject to the Interbase Public License Version 1.0 (the
+            <p><optional spacing="none">"</optional>The contents of this file are subject to the Interbase Public License Version 1.0 (the
              "License"); you may not use this file except in compliance with the License. You may
              obtain a copy of the License at http://www.Interbase.com/IPL.html</p>
             <p>Software distributed under the License is distributed on an "AS IS" basis, WITHOUT

--- a/src/LGPL-3.0+.xml
+++ b/src/LGPL-3.0+.xml
@@ -15,7 +15,7 @@
         <br/>Version 3, 29 June 2007
       </p>
       </titleText>
-      <p>Copyright (C) 2007 Free Software Foundation, Inc. &lt;http<optional>s</optional>://fsf.org/&gt;</p>
+      <p>Copyright (C) 2007 Free Software Foundation, Inc. &lt;http<optional spacing="none">s</optional>://fsf.org/&gt;</p>
       <p>Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is
          not allowed.</p>
       <p>This version of the GNU Lesser General Public License incorporates the terms and conditions of version 3

--- a/src/LGPL-3.0-only.xml
+++ b/src/LGPL-3.0-only.xml
@@ -19,7 +19,7 @@
     </titleText>
     <p>
       Copyright (C) 2007 Free Software Foundation, Inc.
-      &lt;http<optional>s</optional>://fsf.org/&gt;
+      &lt;http<optional spacing="none">s</optional>://fsf.org/&gt;
     </p>
     <p>
       Everyone is permitted to copy and distribute verbatim copies

--- a/src/LGPL-3.0-or-later.xml
+++ b/src/LGPL-3.0-or-later.xml
@@ -18,7 +18,7 @@
     </titleText>
     <p>
       Copyright (C) 2007 Free Software Foundation, Inc.
-      &lt;http<optional>s</optional>://fsf.org/&gt;
+      &lt;http<optional spacing="none">s</optional>://fsf.org/&gt;
     </p>
     <p>
       Everyone is permitted to copy and distribute verbatim copies

--- a/src/LGPL-3.0.xml
+++ b/src/LGPL-3.0.xml
@@ -20,7 +20,7 @@
     </titleText>
     <p>
       Copyright (C) 2007 Free Software Foundation, Inc.
-      &lt;http<optional>s</optional>://fsf.org/&gt;
+      &lt;http<optional spacing="none">s</optional>://fsf.org/&gt;
     </p>
     <p>
       Everyone is permitted to copy and distribute verbatim copies

--- a/src/MIT-CMU.xml
+++ b/src/MIT-CMU.xml
@@ -13,11 +13,11 @@
       <optional>By obtaining, using, and/or copying this software and/or its associated documentation, you agree that
       you have read, understood, and will comply with the following terms and conditions:</optional>
 
-      <p>Permission to use, copy, modify<optional>,</optional> and distribute this software and its <optional>associated</optional> documentation for any purpose and
-         without fee is hereby granted, provided that the above copyright notice appears in all copies<optional>,</optional> and that
+      <p>Permission to use, copy, modify<optional spacing="after">,</optional> and distribute this software and its <optional>associated</optional> documentation for any purpose and
+         without fee is hereby granted, provided that the above copyright notice appears in all copies<optional spacing="after">,</optional> and that
          both that copyright notice and this permission notice appear in supporting documentation, and that the
          name of <alt match=".+" name="copyrightHolder1">the copyright holder</alt> not be used in advertising or publicity
-         pertaining to distribution of the software without specific<optional>,</optional> written permission.</p>
+         pertaining to distribution of the software without specific<optional spacing="after">,</optional> written permission.</p>
       <p><alt match=".+" name="copyrightHolder2">THE COPYRIGHT HOLDER</alt> <alt match="DISCLAIM(S)?" name="disclaim">DISCLAIM</alt> ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
          INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL <alt match=".+" name="copyrightHolder3">THE COPYRIGHT HOLDER</alt> BE LIABLE FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY
          DAMAGES WHATSOEVER RESULTING FROM <optional>THE</optional> LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,

--- a/src/MPL-1.0.xml
+++ b/src/MPL-1.0.xml
@@ -429,7 +429,7 @@
       <optional>
          <p>EXHIBIT A.</p>
          <standardLicenseHeader>
-         <p><optional>"</optional>The contents of this file are subject to the Mozilla Public License Version 1.0 (the
+         <p><optional spacing="none">"</optional>The contents of this file are subject to the Mozilla Public License Version 1.0 (the
          "License"); you may not use this file except in compliance with the License. You may obtain
          a copy of the License at http://www.mozilla.org/MPL/</p>
          <p>Software distributed under the License is distributed on an "AS IS" basis, WITHOUT WARRANTY OF
@@ -440,7 +440,7 @@
         <alt match=".+" name="InitialDeveloper">_____</alt>. Portions created by
         <alt match=".+" name="createdby">_____</alt> are Copyright (C)
         <alt match=".+" name="copyright">_____</alt>. All Rights Reserved. Contributor(s):
-        <alt match=".+" name="contributor">_____</alt>.<optional>"</optional>
+        <alt match=".+" name="contributor">_____</alt>.<optional spacing="none">"</optional>
       </p>
         </standardLicenseHeader>
       </optional>

--- a/src/MPL-1.1.xml
+++ b/src/MPL-1.1.xml
@@ -516,7 +516,7 @@
       <optional>
          <p>Exhibit A - Mozilla Public License.</p>
          <standardLicenseHeader>
-         <p><optional>"</optional>The contents of this file are subject to the Mozilla Public License Version 1.1 (the
+         <p><optional spacing="none">"</optional>The contents of this file are subject to the Mozilla Public License Version 1.1 (the
          "License"); you may not use this file except in compliance with the License. You may obtain
          a copy of the License at http://www.mozilla.org/MPL/</p>
          <p>Software distributed under the License is distributed on an "AS IS" basis, WITHOUT WARRANTY OF
@@ -533,7 +533,7 @@
          License and not to allow others to use your version of this file under the MPL, indicate your decision
          by deleting the provisions above and replace them with the notice and other provisions required by the
          <alt name="altLicenseShort4" match=".+">[___]</alt> License. If you do not delete the provisions above, a recipient may use your version of this
-         file under either the MPL or the <alt name="altLicenseShort5" match=".+">[___]</alt> License.<optional>"</optional></p>
+         file under either the MPL or the <alt name="altLicenseShort5" match=".+">[___]</alt> License.<optional spacing="none">"</optional></p>
          </standardLicenseHeader>
          <p>NOTE: The text of this Exhibit A may differ slightly from the text of the notices in the Source Code
          files of the Original Code. You should use the text of this Exhibit A rather than the text found in

--- a/src/OCLC-2.0.xml
+++ b/src/OCLC-2.0.xml
@@ -76,7 +76,7 @@
                source and data file of the Program and any Modification you distribute must contain the
                following notice:
         <standardLicenseHeader>
-        <p><optional>"</optional>Copyright (c) <alt name="copyright" match=".+">2000- (insert then current year) OCLC Online Computer Library Center, Inc. and other
+        <p><optional spacing="none">"</optional>Copyright (c) <alt name="copyright" match=".+">2000- (insert then current year) OCLC Online Computer Library Center, Inc. and other
            contributors</alt>. All rights reserved. The contents of this file, as updated from time to time by the
            OCLC Office of Research, are subject to OCLC Research Public License Version 2.0 (the "License");
            you may not use this file except in compliance with the License. You may obtain a current copy of
@@ -87,7 +87,7 @@
            For more information on OCLC Research, please see http://www.oclc.org/research/. The Original Code
            is <alt name="code" match=".+">______________________________</alt>. The Initial Developer of the Original Code is
            <alt name="initialDeveloper" match=".+">________________________</alt>. Portions created by <alt name="creator" match=".+">______________________</alt> are Copyright (C) <alt name="copyright2" match=".+">____________________________</alt>. All Rights Reserved. Contributor(s):
-           <alt name="contributor" match=".+">______________________________________</alt>.<optional>"</optional></p>
+           <alt name="contributor" match=".+">______________________________________</alt>.<optional spacing="none">"</optional></p>
         </standardLicenseHeader>
          </item>
          <item>

--- a/src/OSL-1.0.xml
+++ b/src/OSL-1.0.xml
@@ -14,7 +14,7 @@
          "Original Work") whose owner (the "Licensor") has placed the following notice
          immediately following the copyright notice for the Original Work:</p>
       <standardLicenseHeader>
-      <p><optional>"</optional>Licensed under the Open Software License version 1.0<optional>"</optional></p>
+      <p><optional spacing="none">"</optional>Licensed under the Open Software License version 1.0<optional spacing="none">"</optional></p>
       </standardLicenseHeader>
       <p>License Terms</p>
       <list>

--- a/src/RPSL-1.0.xml
+++ b/src/RPSL-1.0.xml
@@ -504,7 +504,7 @@
       <optional>
          <p>EXHIBIT A.</p>
         <standardLicenseHeader>
-         <p><optional>"</optional>Copyright (c) 1995-2002 RealNetworks, Inc. and/or its licensors. All Rights Reserved.</p>
+         <p><optional spacing="none">"</optional>Copyright (c) 1995-2002 RealNetworks, Inc. and/or its licensors. All Rights Reserved.</p>
          <p>The contents of this file, and the files included with this file, are subject to the current version of
          the RealNetworks Public Source License Version 1.0 (the "RPSL") available at
          https://www.helixcommunity.org/content/rpsl unless you have licensed the file under the RealNetworks
@@ -522,7 +522,7 @@
          PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.</p>
          <p>Contributor(s): <alt name="contributor" match=".+">____________________________________</alt></p>
          <p>Technology Compatibility Kit Test Suite(s) Location (if licensed under the RCSL):
-         <alt match=".+" name="testLocation">_____</alt><optional>"</optional></p>
+         <alt match=".+" name="testLocation">_____</alt><optional spacing="none">"</optional></p>
          </standardLicenseHeader>
          <p>Object Code Notice: Helix DNA Client technology included. Copyright (c) RealNetworks, Inc., 1995-2002.
          All rights reserved.</p>

--- a/src/RSCPL.xml
+++ b/src/RSCPL.xml
@@ -414,7 +414,7 @@
                  LIMITATION. SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION OR LIMITATION OF INCIDENTAL
                  OR CONSEQUENTIAL DAMAGES, SO THAT EXCLUSION AND LIMITATION MAY NOT APPLY TO YOU. TO
                  THE EXTENT THAT ANY EXCLUSION OF DAMAGES ABOVE IS NOT VALID, YOU AGREE THAT IN NO
-                 EVENT WILL RSV<optional>'</optional>S LIABILITY UNDER OR RELATED TO THIS AGREEMENT EXCEED FIVE THOUSAND
+                 EVENT WILL RSV<optional spacing="none">'</optional>S LIABILITY UNDER OR RELATED TO THIS AGREEMENT EXCEED FIVE THOUSAND
                  DOLLARS ($5,000). THE GOVERNED CODE IS NOT INTENDED FOR USE IN CONNECTION WITH ANY
                  NUCLER, AVIATION, MASS TRANSIT OR MEDICAL APPLICATION OR ANY OTHER INHERENTLY
                  DANGEROUS APPLICATION THAT COULD RESULT IN DEATH, PERSONAL INJURY, CATASTROPHIC DAMAGE
@@ -445,7 +445,7 @@
                  under or related to this Agreement shall be brought in the Federal Courts of the
                  Northern District of California, with venue lying in Santa Clara County, California.
                  The losing party shall be responsible for costs, including without limitation, court
-                 costs and reasonable attorney<optional>'</optional>s fees and expenses. Notwithstanding anything to the
+                 costs and reasonable attorney<optional spacing="none">'</optional>s fees and expenses. Notwithstanding anything to the
                  contrary herein, RSV may seek injunctive relief related to a breach of this Agreement
                  in any court of competent jurisdiction. The application of the United Nations
                  Convention on Contracts for the International Sale of Goods is expressly excluded. Any

--- a/src/SGI-B-1.0.xml
+++ b/src/SGI-B-1.0.xml
@@ -284,20 +284,20 @@
          AND IMPLIED WARRANTIES AND CONDITIONS DISCLAIMED, INCLUDING, WITHOUT LIMITATION, ANY IMPLIED
          WARRANTIES AND CONDITIONS OF MERCHANTABILITY, SATISFACTORY QUALITY, FITNESS FOR A PARTICULAR PURPOSE,
          AND NON-INFRINGEMENT.</p>
-         <p>Original Code. The Original Code is: <optional>[</optional>
+         <p>Original Code. The Original Code is: <optional spacing="before">[</optional>
             <alt match=".+" name="softwareName">name of software</alt>,
       <alt match=".+" name="softwareVersion">version number</alt>, and
       <alt match=".+" name="softwareReleaseDate">release date</alt>
-            <optional>]</optional>, developed by Silicon Graphics, Inc. The Original Code is Copyright (c)
-      <optional>[</optional>
+            <optional spacing="none">]</optional>, developed by Silicon Graphics, Inc. The Original Code is Copyright (c)
+      <optional spacing="before">[</optional>
             <alt match=".+" name="softwareFirstPublicationDate">dates of first publication, as appearing in
         the Notice in the Original Code</alt>
-            <optional>]</optional> Silicon Graphics, Inc. Copyright in any
+            <optional spacing="after">]</optional> Silicon Graphics, Inc. Copyright in any
         portions created by third parties is as indicated elsewhere herein. All Rights Reserved.</p>
-         <p>Additional Notice Provisions: <optional>[</optional>
+         <p>Additional Notice Provisions: <optional spacing="before">[</optional>
             <alt match=".+" name="additionalProvisions">such additional provisions, if any, as appear in
           the Notice in the Original Code under the heading "Additional Notice Provisions"</alt>
-            <optional>]</optional>
+            <optional spacing="none">]</optional>
          </p>
         </standardLicenseHeader>
       </optional>

--- a/src/SGI-B-1.1.xml
+++ b/src/SGI-B-1.1.xml
@@ -297,22 +297,22 @@
          AND IMPLIED WARRANTIES AND CONDITIONS DISCLAIMED, INCLUDING, WITHOUT LIMITATION, ANY IMPLIED
          WARRANTIES AND CONDITIONS OF MERCHANTABILITY, SATISFACTORY QUALITY, FITNESS FOR A PARTICULAR PURPOSE,
          AND NON-INFRINGEMENT.</p>
-         <p>Original Code. The Original Code is: <optional>[</optional>
+         <p>Original Code. The Original Code is: <optional spacing="before">[</optional>
             <alt match=".+" name="softwareName">name of software</alt>,
       <alt match=".+" name="softwareVersion">version number</alt>, and
       <alt match=".+" name="softwareReleaseDate">release date</alt>
-            <optional>]</optional>, developed by Silicon Graphics, Inc. The Original Code is Copyright (c)
-      <optional>[</optional>
+            <optional spacing="after">]</optional>, developed by Silicon Graphics, Inc. The Original Code is Copyright (c)
+      <optional spacing="before">[</optional>
             <alt match=".+" name="softwareFirstPublicationDate">dates of first publication, as appearing in
         the Notice in the Original Code</alt>
-            <optional>]</optional>
+            <optional spacing="after">]</optional>
        Silicon Graphics, Inc. Copyright in any portions created by third
          parties is as indicated elsewhere herein. All Rights Reserved.</p>
          <optional>
-         <p>Additional Notice Provisions: <optional>[</optional>
+         <p>Additional Notice Provisions: <optional spacing="before">[</optional>
             <alt match=".+" name="additionalProvisions">such additional provisions, if any, as appear in the
           Notice in the Original Code under the heading "Additional Notice Provisions"</alt>
-            <optional>]</optional>
+            <optional spacing="after">]</optional>
          </p>
          </optional>
          </standardLicenseHeader>

--- a/src/SISSL-1.2.xml
+++ b/src/SISSL-1.2.xml
@@ -266,22 +266,22 @@
       <optional>
          <p>EXHIBIT A - Sun Industry Standards Source License</p>
       <standardLicenseHeader>
-         <p><optional>"</optional>The contents of this file are subject to the Sun Industry Standards Source License Version 1.2 (the
+         <p><optional spacing="none">"</optional>The contents of this file are subject to the Sun Industry Standards Source License Version 1.2 (the
        License); You
-      <br/>may not use this file except in compliance with the License.<optional>"</optional>
+      <br/>may not use this file except in compliance with the License.<optional spacing="none">"</optional>
     </p>
-         <p><optional>"</optional>You may obtain a copy of the License at gridengine.sunsource.net/license.html<optional>"</optional></p>
-         <p><optional>"</optional>Software distributed under the License is distributed on an AS IS basis, WITHOUT WARRANTY OF ANY KIND,
+         <p><optional spacing="none">"</optional>You may obtain a copy of the License at gridengine.sunsource.net/license.html<optional spacing="none">"</optional></p>
+         <p><optional spacing="none">"</optional>Software distributed under the License is distributed on an AS IS basis, WITHOUT WARRANTY OF ANY KIND,
        either express or
-      <br/>implied. See the License for the specific language governing rights and limitations under the License.<optional>"</optional>
+      <br/>implied. See the License for the specific language governing rights and limitations under the License.<optional spacing="none">"</optional>
     </p>
-         <p><optional>"</optional>The Original Code is Grid Engine.<optional>"</optional></p>
-         <p><optional>"</optional>The Initial Developer of the Original Code is:
-      <br/>Sun Microsystems, Inc.<optional>"</optional>
+         <p><optional spacing="none">"</optional>The Original Code is Grid Engine.<optional spacing="none">"</optional></p>
+         <p><optional spacing="none">"</optional>The Initial Developer of the Original Code is:
+      <br/>Sun Microsystems, Inc.<optional spacing="none">"</optional>
     </p>
-         <p><optional>"</optional>Portions created by: Sun Microsystems, Inc. are Copyright (C) 2001 Sun Microsystems, Inc.<optional>"</optional></p>
-         <p><optional>"</optional>All Rights Reserved.<optional>"</optional></p>
-         <p><optional>"</optional>Contributor(s): <alt name="contributor" match=".+">__________________________________"</alt></p>
+         <p><optional spacing="none">"</optional>Portions created by: Sun Microsystems, Inc. are Copyright (C) 2001 Sun Microsystems, Inc.<optional spacing="none">"</optional></p>
+         <p><optional spacing="none">"</optional>All Rights Reserved.<optional spacing="none">"</optional></p>
+         <p><optional spacing="none">"</optional>Contributor(s): <alt name="contributor" match=".+">__________________________________"</alt></p>
       </standardLicenseHeader>
          <p>EXHIBIT B - Standards</p>
          <list>

--- a/src/SISSL.xml
+++ b/src/SISSL.xml
@@ -318,7 +318,7 @@
       <optional>
          <p>EXHIBIT A - Sun Standards License</p>
          <standardLicenseHeader>
-         <p><optional>"</optional>The contents of this file are subject to the Sun Standards License Version 1.1 (the "License"); You may
+         <p><optional spacing="none">"</optional>The contents of this file are subject to the Sun Standards License Version 1.1 (the "License"); You may
          not use this file except in compliance with the License. You may obtain a copy of the License at
          <alt name="source" match=".+">_______________________________</alt>.</p>
          <p>Software distributed under the License is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,

--- a/src/exceptions/GPL-CC-1.0.xml
+++ b/src/exceptions/GPL-CC-1.0.xml
@@ -47,7 +47,7 @@
 	copyrights.
       </p>
       <p>
-	Definitions<optional>:</optional>
+	Definitions<optional  spacing="none">:</optional>
       </p>
       <p>
 	"Covered License" means the GNU General Public License, version

--- a/src/exceptions/Qt-GPL-exception-1.0.xml
+++ b/src/exceptions/Qt-GPL-exception-1.0.xml
@@ -11,7 +11,7 @@
       </titleText>
       <p>Exception 1:</p>
       <p>
-        As a special exception<optional>,</optional> you may create a larger work which contains the
+        As a special exception<optional spacing="after">,</optional> you may create a larger work which contains the
         output of this application and distribute that work under terms of your
         choice, so long as the work is not otherwise derived from or based on
         this application and so long as the work does not in itself generate


### PR DESCRIPTION
Resolves issue where spaces are being inserted in the non-HTML versions of the license text (e.g. license-text, JSON).

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>