### PR TITLE
Add softwareName replacement of Vim license

### DIFF
--- a/src/Vim.xml
+++ b/src/Vim.xml
@@ -12,15 +12,15 @@
       <list>
         <item>
             <bullet>I)</bullet>
-          There are no restrictions on distributing unmodified copies of Vim except that they must include
-             this license text. You can also distribute unmodified parts of Vim, likewise unrestricted
+          There are no restrictions on distributing unmodified copies of <alt match=".+" name="softwareName">Vim</alt> except that they must include
+             this license text. You can also distribute unmodified parts of <alt match=".+" name="softwareName">Vim</alt>, likewise unrestricted
              except that they must include this license text. You are also allowed to include executables
-             that you made from the unmodified Vim sources, plus your own usage examples and Vim
+             that you made from the unmodified <alt match=".+" name="softwareName">Vim</alt> sources, plus your own usage examples and Vim
              scripts.
         </item>
         <item>
             <bullet>II)</bullet>
-          It is allowed to distribute a modified (or extended) version of Vim, including executables and/or
+          It is allowed to distribute a modified (or extended) version of <alt match=".+" name="softwareName">Vim</alt>, including executables and/or
              source code, when the following four conditions are met:
           <list>
                <item>
@@ -29,14 +29,14 @@
             </item>
                <item>
                   <bullet>2)</bullet>
-              The modified Vim must be distributed in one of the following five ways:
+              The modified <alt match=".+" name="softwareName">Vim</alt> must be distributed in one of the following five ways:
               <list>
                      <item>
                         <bullet>a)</bullet>
-                  If you make changes to Vim yourself, you must clearly describe in the distribution how to contact
-                    you. When the maintainer asks you (in any way) for a copy of the modified Vim you distributed,
+                  If you make changes to <alt match=".+" name="softwareName">Vim</alt> yourself, you must clearly describe in the distribution how to contact
+                    you. When the maintainer asks you (in any way) for a copy of the modified <alt match=".+" name="softwareName">Vim</alt> you distributed,
                     you must make your changes, including source code, available to the maintainer without fee.
-                    The maintainer reserves the right to include your changes in the official version of Vim. What
+                    The maintainer reserves the right to include your changes in the official version of <alt match=".+" name="softwareName">Vim</alt>. What
                     the maintainer will do with your changes and under what license they will be distributed is
                     negotiable. If there has been no negotiation then this license, or a later version, also
                     applies to your changes. The current maintainer is Bram Moolenaar &lt;Bram@vim.org&gt;. If
@@ -47,38 +47,38 @@
                 </item>
                      <item>
                         <bullet>b)</bullet>
-                  If you have received a modified Vim that was distributed as mentioned under a) you are allowed to
+                  If you have received a modified <alt match=".+" name="softwareName">Vim</alt> that was distributed as mentioned under a) you are allowed to
                     further distribute it unmodified, as mentioned at I). If you make additional changes the text
                     under a) applies to those changes.
                 </item>
                      <item>
                         <bullet>c)</bullet>
-                  Provide all the changes, including source code, with every copy of the modified Vim you
+                  Provide all the changes, including source code, with every copy of the modified <alt match=".+" name="softwareName">Vim</alt> you
                     distribute. This may be done in the form of a context diff. You can choose what license to use
                     for new code you add. The changes and their license must not restrict others from making their
-                    own changes to the official version of Vim.
+                    own changes to the official version of <alt match=".+" name="softwareName">Vim</alt>.
                 </item>
                      <item>
                         <bullet>d)</bullet>
-                  When you have a modified Vim which includes changes as mentioned under c), you can distribute it
+                  When you have a modified <alt match=".+" name="softwareName">Vim</alt> which includes changes as mentioned under c), you can distribute it
                     without the source code for the changes if the following three conditions are met:
                   <list>
                            <item>
                               <bullet>-</bullet>
                       The license that applies to the changes permits you to distribute the changes to the Vim
                         maintainer without fee or restriction, and permits the Vim maintainer to include the changes
-                        in the official version of Vim without fee or restriction.
+                        in the official version of <alt match=".+" name="softwareName">Vim</alt> without fee or restriction.
                     </item>
                            <item>
                               <bullet>-</bullet>
                       You keep the changes for at least three years after last distributing the corresponding modified
-                        Vim. When the maintainer or someone who you distributed the modified Vim to asks you (in any
+                        <alt match=".+" name="softwareName">Vim</alt>. When the maintainer or someone who you distributed the modified <alt match=".+" name="softwareName">Vim</alt> to asks you (in any
                         way) for the changes within this period, you must make them available to him.
                     </item>
                            <item>
                               <bullet>-</bullet>
                       You clearly describe in the distribution how to contact you. This contact information must remain
-                        valid for at least three years after last distributing the corresponding modified Vim, or as
+                        valid for at least three years after last distributing the corresponding modified <alt match=".+" name="softwareName">Vim</alt>, or as
                         long as possible.
                     </item>
                         </list>
@@ -86,14 +86,14 @@
                      <item>
                         <bullet>e)</bullet>
                   When the GNU General Public License (GPL) applies to the changes, you can distribute the modified
-                    Vim under the GNU GPL version 2 or any later version.
+                    <alt match=".+" name="softwareName">Vim</alt> under the GNU GPL version 2 or any later version.
                 </item>
                   </list>
                </item>
                <item>
                   <bullet>3)</bullet>
               A message must be added, at least in the output of the ":version" command and in the intro
-                screen, such that the user of the modified Vim is able to see that it was modified. When
+                screen, such that the user of the modified <alt match=".+" name="softwareName">Vim</alt> is able to see that it was modified. When
                 distributing as mentioned under 2)e) adding the message is only required for as far as this
                 does not conflict with the license used for the changes.
             </item>
@@ -106,7 +106,7 @@
         </item>
         <item>
             <bullet>III)</bullet>
-          If you distribute a modified version of Vim, you are encouraged to use the Vim license for your
+          If you distribute a modified version of <alt match=".+" name="softwareName">Vim</alt>, you are encouraged to use the Vim license for your
              changes and make them available to the maintainer, including the source code. The preferred
              way to do this is by e-mail or by uploading the files to a server and e-mailing the URL. If
              the number of changes is small (e.g., a modified Makefile) e-mailing a context diff will do.
@@ -114,8 +114,8 @@
         </item>
         <item>
             <bullet>IV)</bullet>
-          It is not allowed to remove this license from the distribution of the Vim sources, parts of it or
-             from a modified version. You may use this license for previous Vim releases instead of the
+          It is not allowed to remove this license from the distribution of the <alt match=".+" name="softwareName">Vim</alt> sources, parts of it or
+             from a modified version. You may use this license for previous <alt match=".+" name="softwareName">Vim</alt> releases instead of the
              license that they came with, at your option.
         </item>
       </list>


### PR DESCRIPTION
Hi All

I am working on let GitHub to detect **Vim License**. Had some discussion with Bram(Vim author)[1] and GitHub staff[2]. We found the Vim License text have some variable text placeholders. If any other project(most are Vim scripts/plugins) uses Vim License. These parts should be replaced to corresponding value to make it right to use. And it will be great if SPDX license list have definitions of these placeholders.

This PR adds these placeholders. Only one variable: `softwareName`. The name of the variable is from existing one in [SGI-B][3]. Not sure is it fits for our case(Can script/plugin also called software?). I used to use `projectName`. So if `softwareName` is not fit our case. I can change to `projectName`.

[1]:https://groups.google.com/forum/#!searchin/vim_dev/license%7Csort:date/vim_dev/DlTVMew1ZSo/s3KkBdJ5BgAJ
[2]:https://github.com/licensee/licensee/issues/385#issuecomment-506386613
[3]:https://github.com/spdx/license-list-XML/blob/ccfec34109bec311c5da8f236274eedaab6fb4c1/src/SGI-B-1.0.xml#L288

Refs:

* [Post at mailing list][4]

[4]:https://lists.spdx.org/g/Spdx-legal/topic/32343388#2635
