### PR TITLE
Update URLs for bzip2 licenses

### DIFF
--- a/src/bzip2-1.0.5.xml
+++ b/src/bzip2-1.0.5.xml
@@ -4,6 +4,7 @@
             name="bzip2 and libbzip2 License v1.0.5">
       <crossRefs>
          <crossRef>https://sourceware.org/bzip2/1.0.5/bzip2-manual-1.0.5.html</crossRef>
+          <crossRef>http://bzip.org/1.0.5/bzip2-manual-1.0.5.html</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/bzip2-1.0.5.xml
+++ b/src/bzip2-1.0.5.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="false" licenseId="bzip2-1.0.5"
             name="bzip2 and libbzip2 License v1.0.5">
       <crossRefs>
-         <crossRef>http://bzip.org/1.0.5/bzip2-manual-1.0.5.html</crossRef>
+         <crossRef>https://sourceware.org/bzip2/1.0.5/bzip2-manual-1.0.5.html</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/bzip2-1.0.6.xml
+++ b/src/bzip2-1.0.6.xml
@@ -3,9 +3,8 @@
    <license isOsiApproved="false" licenseId="bzip2-1.0.6"
             name="bzip2 and libbzip2 License v1.0.6">
       <crossRefs>
-         <crossRef>https://github.com/asimonov-im/bzip2/blob/master/LICENSE</crossRef>
+         <crossRef>https://sourceware.org/git/?p=bzip2.git;a=blob;f=LICENSE;hb=bzip2-1.0.6</crossRef>
       </crossRefs>
-      <notes>The bzip2.org website only shows version 1.0.5 of the license.</notes>
     <text>
       <copyrightText>
          <p>This program, "bzip2", the associated library "libbzip2", and all documentation, are

--- a/src/bzip2-1.0.6.xml
+++ b/src/bzip2-1.0.6.xml
@@ -4,6 +4,7 @@
             name="bzip2 and libbzip2 License v1.0.6">
       <crossRefs>
          <crossRef>https://sourceware.org/git/?p=bzip2.git;a=blob;f=LICENSE;hb=bzip2-1.0.6</crossRef>
+          <crossRef>http://bzip.org/1.0.5/bzip2-manual-1.0.5.html</crossRef>
       </crossRefs>
     <text>
       <copyrightText>


### PR DESCRIPTION
While I was looking for SPDX License Identifier for `bzip2`, I didn't find it for 2 versions (1.0.7 and 1.0.8), which was released recently after [9 years](https://sourceware.org/git/?p=bzip2.git;a=blob;f=CHANGES;h=30afead2586b6d64f50988a41d394a0131b38949;hb=HEAD).

Currently, there is an SPDX License Identifier for version [1.0.5](https://spdx.org/licenses/bzip2-1.0.5.html) and [1.0.6](https://spdx.org/licenses/bzip2-1.0.6.html). The first one is using incorrect URL as the previous owner of bzip.org let it go. More details about it can be found [here](https://lwn.net/Articles/762264/).
As official website they are using their former project home https://sourceware.org/bzip2/ For the other one, the Github repository doesn't seem to be correct, because since version 0.1 till 1.0.6 there was just one developer - [Julian Seward](https://sourceware.org/git/?p=bzip2.git;a=shortlog). Also, in the Github repository there are just two commits and it seems to be abandoned nor official repository for bzip2.