### PR TITLE
Unlicense "For more information..." line is optional

### DIFF
--- a/src/Unlicense.xml
+++ b/src/Unlicense.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="false" licenseId="Unlicense" name="The Unlicense">
       <crossRefs>
-         <crossRef>http://unlicense.org/</crossRef>
+         <crossRef>https://unlicense.org/</crossRef>
       </crossRefs>
       <notes>This is a public domain dedication</notes>
     <text>
@@ -21,7 +21,7 @@
          NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
          OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
          OTHER DEALINGS IN THE SOFTWARE.</p>
-      <optional><p>For more information, please refer to &lt;http://unlicense.org/&gt;</p></optional>
+      <optional><p>For more information, please refer to &lt;https://unlicense.org/&gt;</p></optional>
     </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/Unlicense.xml
+++ b/src/Unlicense.xml
@@ -21,7 +21,7 @@
          NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
          OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
          OTHER DEALINGS IN THE SOFTWARE.</p>
-      <p>For more information, please refer to &lt;http://unlicense.org/&gt;</p>
+      <optional><p>For more information, please refer to &lt;http://unlicense.org/&gt;</p></optional>
     </text>
   </license>
 </SPDXLicenseCollection>


### PR DESCRIPTION
See https://unlicense.org which says:

> You should feel free, though, to leave out the last line containing the link to this site, if that's your preference.

As pointed out by @Hexstream at https://github.com/unlicense/unlicense.org/pull/55#issuecomment-420831489 (and more recently).