### PR TITLE
add backstory on license inclusion guidelines

### DIFF
--- a/DOCS/license-inclusion-principles.md
+++ b/DOCS/license-inclusion-principles.md
@@ -17,6 +17,21 @@ Determining whether a candidate license should be included on the SPDX License L
 
 Comments on license inclusion will be noted in the Github issue for the license (or reference to meeting minutes, as necessary). Some license requests may be decided solely via comments in the Github issue and some may involve discussion on the bi-weekly legal call. Thus it is recommended that requestors join the mailing list and calls to fully participate.
 
+
+## Backstory
+The first beta version of the SPDX License List was published in August 2010 and had approximately one hundred licenses on it. The initial set of licenses was included based on informal discussion and consensus on the SPDX working group calls and email list. Although various "guidelines" were identified in regards to which licenses to include or not during this time, formal guidelines were not recorded beyond the meeting minutes. We had to start somewhere, and the obvious was the easy beginning point. Decisions or guidelines that evolved out of discussion or by implication included the following:
+* Include commonly found open source licenses. Although discussion was not explicit in regards to how to define an "open source license," this was always an implicit guiding principle
+* Include all OSI approved licenses, both current and those approved but now deprecated. The rationale being that once OSI-approved, always OSI-approved and deprecated licenses still appear "in the wild"
+
+At some point in these early days, there was consensus to include all of the Creative Commons licenses, even though the NC and ND do not fit the OSD. Other older licenses that were accepted on the list by consensus before we had formal inclusion guidelines may also fall under this "grand-licensed-in" reality.
+
+Before long we recognized the need for a more formal process for requesting new licenses to be added to the SPDX License List. Such a process was discussed in terms of an ideal goal and pragmatic approach for the current reality (people sent an email to the mailing list). A process that bridged the former, with more weight on the latter was implemented in April 2012. 
+
+In the waning days of 2012, we realized the need to make it clear and transparent to the world what criteria was being used to determine when to "accept" or "reject" a request to add a license to the SPDX License List. The result of those discussions was the publication of the license inclusion guidelines on the SPDX website in early 2013.
+
+These guidelines served us well. But as time marches on and things evolve, we set out to consider a revision in 2019...
+
+OLD COPY:
 ## Background Principles
 The Software Package Data Exchange® (SPDX®) specification is a standard format for communicating, among other things, the components, licenses, and copyrights associated with open source software packages. Use of this standard streamlines license identification across the supply chain while reducing redundant work.
 


### PR DESCRIPTION
add the history of the how licenses got on the SPDX License List and development of the license inclusion guidelines