### PR TITLE
remove isOsiApproved for MIT-0

### DIFF
--- a/src/MIT-0.xml
+++ b/src/MIT-0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-  <license isOsiApproved="true" licenseId="MIT-0" name="MIT No Attribution">
+  <license isOsiApproved="false" licenseId="MIT-0" name="MIT No Attribution">
     <crossRefs>
       <crossRef>https://github.com/aws/mit-0</crossRef>
       <crossRef>https://romanrm.net/mit-zero</crossRef>


### PR DESCRIPTION
MIT-0 is not OSI approved, however it is displayed as such on SPDX
because it was inadvertently marked to be approved in the template
file. The relevant comments on license-review: [1](https://lists.opensource.org/pipermail/license-review_lists.opensource.org/2019-December/004576.html), [2](https://lists.opensource.org/pipermail/license-review_lists.opensource.org/2019-December/004577.html).

Fixes #957.