### PR TITLE
Add Prosperity-3.0.0

### DIFF
--- a/src/Prosperity-3.0.0.xml
+++ b/src/Prosperity-3.0.0.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SPDXLicenseCollection xmlns="http://www.spdx.org/license">
+  <license isOsiApproved="false" licenseId="Prosperity-3.0.0" name="The Prosperity Public License 3.0.0" listVersionAdded="3.6">
+    <crossRefs>
+      <crossRef>https://prosperitylicense.com/versions/3.0.0.html</crossRef>
+    </crossRefs>
+    <notes>This license was released on December 15, 2019.</notes>
+    <text>
+      <titleText>
+        <p><optional># </optional>The Prosperity Public License 3.0.0</p>
+      </titleText>
+      <p>Contributor: <alt match=".+" name="copyright">name</alt></p>
+      <p>Source Code: <alt match=".+" name="address">address</alt></p>
+      <p><optional>## </optional>Purpose</p>
+      <p>This license allows you to use and share this software for noncommercial purposes for free and to try this software for commercial purposes for thirty days.</p>
+      <p><optional>## </optional>Agreement</p>
+      <p>In order to receive this license, you have to agree to its rules.  Those rules are both obligations under that agreement and conditions to your license.  Don't do anything with this software that triggers a rule you can't or won't follow.</p>
+      <p><optional>## </optional>Notices</p>
+      <p>Make sure everyone who gets a copy of any part of this software from you, with or without changes, also gets the text of this license and the contributor and source code lines above.</p>
+      <p><optional>## </optional>Commercial Trial</p>
+      <p>Limit your use of this software for commercial purposes to a thirty-day trial period.  If you use this software for work, your company gets one trial period for all personnel, not one trial per person.</p>
+      <p><optional>## </optional>Contributions Back</p>
+      <p>Developing feedback, changes, or additions that you contribute back to the contributor on the terms of a standardized public software license such as <alt name="licenseList" match="\[the Blue Oak Model License 1\.0\.0\]\(https://blueoakcouncil\.org/license/1\.0\.0\), \[the Apache License 2\.0\]\(https://www\.apache\.org/licenses/LICENSE-2\.0\.html\), \[the MIT license\]\(https://spdx\.org/licenses/MIT\.html\), or \[the two-clause BSD license\]\(https://spdx\.org/licenses/BSD-2-Clause\.html\)">the Blue Oak Model License 1.0.0, the Apache License 2.0, the MIT license, or the two-clause BSD license</alt> doesn't count as use for a commercial purpose.</p>
+      <p><optional>## </optional>Personal Uses</p>
+      <p>Personal use for research, experiment, and testing for the benefit of public knowledge, personal study, private entertainment, hobby projects, amateur pursuits, or religious observance, without any anticipated commercial application, doesn't count as use for a commercial purpose.</p>
+      <p><optional>## </optional>Noncommercial Organizations</p>
+      <p>Use by any charitable organization, educational institution, public research organization, public safety or health organization, environmental protection organization, or government institution doesn't count as use for a commercial purpose regardless of the source of funding or obligations resulting from the funding.</p>
+      <p><optional>## </optional>Defense</p>
+      <p>Don't make any legal claim against anyone accusing this software, with or without changes, alone or with other technology, of infringing any patent.</p>
+      <p><optional>## </optional>Copyright</p>
+      <p>The contributor licenses you to do everything with this software that would otherwise infringe their copyright in it.</p>
+      <p><optional>## </optional>Patent</p>
+      <p>The contributor licenses you to do everything with this software that would otherwise infringe any patents they can license or become able to license.</p>
+      <p><optional>## </optional>Reliability</p>
+      <p>The contributor can't revoke this license.</p>
+      <p><optional>## </optional>Excuse</p>
+      <p>You're excused for unknowingly breaking <alt name="noticesRef" match="\[Notices\]\(#notices\)|Notices">[Notices](#notices)</alt> if you take all practical steps to comply within thirty days of learning you broke the rule.</p>
+      <p><optional>## </optional>No Liability</p>
+      <p>***As far as the law allows, this software comes as is, without any warranty or condition, and the contributor won't be liable to anyone for any damages related to this software or this license, under any kind of legal claim.***</p>
+    </text>
+  </license>
+</SPDXLicenseCollection>

--- a/test/simpleTestForGenerator/Prosperity-3.0.0.txt
+++ b/test/simpleTestForGenerator/Prosperity-3.0.0.txt
@@ -1,0 +1,57 @@
+# The Prosperity Public License 3.0.0
+
+Contributor: Example, Inc.
+
+Source Code: http://example.com
+
+## Purpose
+
+This license allows you to use and share this software for noncommercial purposes for free and to try this software for commercial purposes for thirty days.
+
+## Agreement
+
+In order to receive this license, you have to agree to its rules.  Those rules are both obligations under that agreement and conditions to your license.  Don't do anything with this software that triggers a rule you can't or won't follow.
+
+## Notices
+
+Make sure everyone who gets a copy of any part of this software from you, with or without changes, also gets the text of this license and the contributor and source code lines above.
+
+## Commercial Trial
+
+Limit your use of this software for commercial purposes to a thirty-day trial period.  If you use this software for work, your company gets one trial period for all personnel, not one trial per person.
+
+## Contributions Back
+
+Developing feedback, changes, or additions that you contribute back to the contributor on the terms of a standardized public software license such as [the Blue Oak Model License 1.0.0](https://blueoakcouncil.org/license/1.0.0), [the Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0.html), [the MIT license](https://spdx.org/licenses/MIT.html), or [the two-clause BSD license](https://spdx.org/licenses/BSD-2-Clause.html) doesn't count as use for a commercial purpose.
+
+## Personal Uses
+
+Personal use for research, experiment, and testing for the benefit of public knowledge, personal study, private entertainment, hobby projects, amateur pursuits, or religious observance, without any anticipated commercial application, doesn't count as use for a commercial purpose.
+
+## Noncommercial Organizations
+
+Use by any charitable organization, educational institution, public research organization, public safety or health organization, environmental protection organization, or government institution doesn't count as use for a commercial purpose regardless of the source of funding or obligations resulting from the funding.
+
+## Defense
+
+Don't make any legal claim against anyone accusing this software, with or without changes, alone or with other technology, of infringing any patent.
+
+## Copyright
+
+The contributor licenses you to do everything with this software that would otherwise infringe their copyright in it.
+
+## Patent
+
+The contributor licenses you to do everything with this software that would otherwise infringe any patents they can license or become able to license.
+
+## Reliability
+
+The contributor can't revoke this license.
+
+## Excuse
+
+You're excused for unknowingly breaking [Notices](#notices) if you take all practical steps to comply within thirty days of learning you broke the rule.
+
+## No Liability
+
+***As far as the law allows, this software comes as is, without any warranty or condition, and the contributor won't be liable to anyone for any damages related to this software or this license, under any kind of legal claim.***


### PR DESCRIPTION
I'd like to add Prosperity-3.0.0 to the SPDX license list. Here's a PR!

Previously, there was discussion about adding Prosperity-2.0.0 in https://github.com/spdx/license-list-XML/issues/805. Since that time, Prosperity-3.0.0 was released. The announcement post is here: https://blog.licensezero.com/2019/12/15/prosperity-3.html