### PR TITLE
MIT: Expand markup for Software definition

### DIFF
--- a/src/MIT.xml
+++ b/src/MIT.xml
@@ -13,8 +13,8 @@
          </p>
       </copyrightText>
 
-      <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
-         associated documentation files (the "Software"), to deal in the Software without restriction,
+      <p>Permission is hereby granted, free of charge, to any person obtaining a copy of <alt match=".+" name="software">this software and
+         associated documentation files</alt> (the "Software"), to deal in the Software without restriction,
          including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
          and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
          subject to the following conditions:</p>

--- a/src/MIT.xml
+++ b/src/MIT.xml
@@ -13,7 +13,7 @@
          </p>
       </copyrightText>
 
-      <p>Permission is hereby granted, free of charge, to any person obtaining a copy of <alt match=".+" name="software">this software and
+      <p>Permission is hereby granted, free of charge, to any person obtaining a copy of <alt match="this software and associated documentation files|this source file" name="software">this software and
          associated documentation files</alt> (the "Software"), to deal in the Software without restriction,
          including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
          and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,


### PR DESCRIPTION
This adds markup to the specific language used to define "Software",
enabling MIT to match when used in cases where e.g. "this source file"
is used instead of "this software and associated documentation files".

Fixes #866 

Signed-off-by: Steve Winslow <steve@swinslow.net>