### PR TITLE
Add NTP No Attribution

### DIFF
--- a/src/NTP-0.xml
+++ b/src/NTP-0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isOsiApproved="false" licenseId="NTP-0" name="NTP No Copyright" listVersionAdded="3.8">
+   <license isOsiApproved="false" licenseId="NTP-0" name="NTP No Attribution" listVersionAdded="3.8">
       <crossRefs>
          <crossRef>https://github.com/tytso/e2fsprogs/blob/master/lib/et/et_name.c</crossRef>
       </crossRefs>

--- a/src/NTP-0.xml
+++ b/src/NTP-0.xml
@@ -1,12 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isOsiApproved="false" licenseId="NTP-0" name="NTP No Copyright">
+   <license isOsiApproved="false" licenseId="NTP-0" name="NTP No Copyright" listVersionAdded="3.8">
       <crossRefs>
-         <crossRef></crossRef>
+         <crossRef>https://github.com/tytso/e2fsprogs/blob/master/lib/et/et_name.c</crossRef>
       </crossRefs>
+      <notes>
+         This license is similar to NTP, but it omits the language regarding reproduction of copyright and permission notices. It also omits the phrase "with or without fee".
+      </notes>
     <text>
       <titleText>
-         <p>NTP No Copyright (NTP-0)</p>
+         <p>NTP No Attribution (NTP-0)</p>
       </titleText>
       <copyrightText>
          <p>Copyright (4-digit-year) by (CopyrightHoldersName)
@@ -14,10 +17,10 @@
       </copyrightText>
 
       <p>Permission to use, copy, modify, and distribute this software and its documentation for any purpose
-         is hereby granted, provided that the name(s) of
+         is hereby granted, provided that the name<optional spacing="none">s</optional> of
         <alt match=".+" name="TMname">(TrademarkedName)</alt> not be used in advertising or publicity pertaining
         to distribution of the software without specific, written prior permission.
-        <alt match=".+" name="TMname">(TrademarkedName)</alt> make(s) no representations about the suitability
+        <alt match=".+" name="TMname">(TrademarkedName)</alt> make<optional spacing="none">s</optional> no representations about the suitability
         of this software for any purpose. It is provided "as is" without express or implied warranty.
       </p>
     </text>

--- a/src/NTP-0.xml
+++ b/src/NTP-0.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SPDXLicenseCollection xmlns="http://www.spdx.org/license">
+   <license isOsiApproved="false" licenseId="NTP-0" name="NTP No Copyright">
+      <crossRefs>
+         <crossRef></crossRef>
+      </crossRefs>
+    <text>
+      <titleText>
+         <p>NTP No Copyright (NTP-0)</p>
+      </titleText>
+      <copyrightText>
+         <p>Copyright (4-digit-year) by (CopyrightHoldersName)
+         </p>
+      </copyrightText>
+
+      <p>Permission to use, copy, modify, and distribute this software and its documentation for any purpose
+         is hereby granted, provided that the name(s) of
+        <alt match=".+" name="TMname">(TrademarkedName)</alt> not be used in advertising or publicity pertaining
+        to distribution of the software without specific, written prior permission.
+        <alt match=".+" name="TMname">(TrademarkedName)</alt> make(s) no representations about the suitability
+        of this software for any purpose. It is provided "as is" without express or implied warranty.
+      </p>
+    </text>
+  </license>
+</SPDXLicenseCollection>

--- a/test/simpleTestForGenerator/NTP-0.txt
+++ b/test/simpleTestForGenerator/NTP-0.txt
@@ -1,0 +1,5 @@
+NTP No Copyright (NTP-0)
+
+Copyright (4-digit-year) by (CopyrightHoldersName)
+
+Permission to use, copy, modify, and distribute this software and its documentation for any purpose is hereby granted, provided that the name(s) of  (TrademarkedName) not be used in advertising or publicity pertaining to distribution of the software without specific, written prior permission. (TrademarkedName) make(s) no representations about the suitability this software for any purpose. It is provided "as is" without express or implied warranty.

--- a/test/simpleTestForGenerator/NTP-0.txt
+++ b/test/simpleTestForGenerator/NTP-0.txt
@@ -1,5 +1,5 @@
-NTP No Copyright (NTP-0)
+NTP No Attribution (NTP-0)
 
 Copyright (4-digit-year) by (CopyrightHoldersName)
 
-Permission to use, copy, modify, and distribute this software and its documentation for any purpose is hereby granted, provided that the name(s) of (TrademarkedName) not be used in advertising or publicity pertaining to distribution of the software without specific, written prior permission. (TrademarkedName) make(s) no representations about the suitability of this software for any purpose. It is provided "as is" without express or implied warranty.
+Permission to use, copy, modify, and distribute this software and its documentation for any purpose is hereby granted, provided that the name of (TrademarkedName) not be used in advertising or publicity pertaining to distribution of the software without specific, written prior permission. (TrademarkedName) make no representations about the suitability of this software for any purpose. It is provided "as is" without express or implied warranty.

--- a/test/simpleTestForGenerator/NTP-0.txt
+++ b/test/simpleTestForGenerator/NTP-0.txt
@@ -2,4 +2,4 @@ NTP No Copyright (NTP-0)
 
 Copyright (4-digit-year) by (CopyrightHoldersName)
 
-Permission to use, copy, modify, and distribute this software and its documentation for any purpose is hereby granted, provided that the name(s) of  (TrademarkedName) not be used in advertising or publicity pertaining to distribution of the software without specific, written prior permission. (TrademarkedName) make(s) no representations about the suitability of this software for any purpose. It is provided "as is" without express or implied warranty.
+Permission to use, copy, modify, and distribute this software and its documentation for any purpose is hereby granted, provided that the name(s) of (TrademarkedName) not be used in advertising or publicity pertaining to distribution of the software without specific, written prior permission. (TrademarkedName) make(s) no representations about the suitability of this software for any purpose. It is provided "as is" without express or implied warranty.

--- a/test/simpleTestForGenerator/NTP-0.txt
+++ b/test/simpleTestForGenerator/NTP-0.txt
@@ -2,4 +2,4 @@ NTP No Copyright (NTP-0)
 
 Copyright (4-digit-year) by (CopyrightHoldersName)
 
-Permission to use, copy, modify, and distribute this software and its documentation for any purpose is hereby granted, provided that the name(s) of  (TrademarkedName) not be used in advertising or publicity pertaining to distribution of the software without specific, written prior permission. (TrademarkedName) make(s) no representations about the suitability this software for any purpose. It is provided "as is" without express or implied warranty.
+Permission to use, copy, modify, and distribute this software and its documentation for any purpose is hereby granted, provided that the name(s) of  (TrademarkedName) not be used in advertising or publicity pertaining to distribution of the software without specific, written prior permission. (TrademarkedName) make(s) no representations about the suitability of this software for any purpose. It is provided "as is" without express or implied warranty.


### PR DESCRIPTION
This is an update to #954 from @johnmhoran, to tweak a few items so that it matches the original upstream license, and also to clarify the name and add notes.

Fixes #947 

Signed-off-by: Steve Winslow <steve@swinslow.net>