### PR TITLE
Add GPL-3.0-linking-exception and GPL-3.0-linking-source-exception

### DIFF
--- a/src/exceptions/GPL-3.0-linking-exception.xml
+++ b/src/exceptions/GPL-3.0-linking-exception.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SPDXLicenseCollection xmlns="http://www.spdx.org/license">
+  <exception licenseId="GPL-3.0-linking-exception" name="GPL-3.0 Linking Exception" listVersionAdded="3.8">
+    <crossRefs>
+      <crossRef>https://www.gnu.org/licenses/gpl-faq.en.html#GPLIncompatibleLibs</crossRef>
+    </crossRefs>
+    <notes>
+      This exception is based on the suggested template from the Free Software Foundation's FAQ about the GPL. This variant does not include the second optional sentence regarding Corresponding Source. For a variant with that sentence, please see GPL-3.0-linking-source-exception.
+    </notes>
+    <text>
+      <titleText>
+	<optional>
+	<p>
+	  Additional permission under GNU GPL version 3 section 7
+	</p>
+	</optional>
+      </titleText>
+      <p>
+	If you modify this Program, or any covered work, by linking or combining it with <alt match=".+" name="library1">[name of library]</alt> (or a modified version of that library), containing parts covered by the terms of <alt match=".+" name="libraryLicense1">[name of library's license]</alt>, the licensors of this Program grant you additional permission to convey the resulting work.
+      </p>
+    </text>
+  </exception>
+</SPDXLicenseCollection>

--- a/src/exceptions/GPL-3.0-linking-source-exception.xml
+++ b/src/exceptions/GPL-3.0-linking-source-exception.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SPDXLicenseCollection xmlns="http://www.spdx.org/license">
+  <exception licenseId="GPL-3.0-linking-source-exception" name="GPL-3.0 Linking Exception (with Corresponding Source)" listVersionAdded="3.8">
+    <crossRefs>
+      <crossRef>https://www.gnu.org/licenses/gpl-faq.en.html#GPLIncompatibleLibs</crossRef>
+      <crossRef>https://github.com/mirror/wget/blob/master/src/http.c#L20</crossRef>
+    </crossRefs>
+    <notes>
+      This exception is based on the suggested template from the Free Software Foundation's FAQ about the GPL. This variant includes the second optional sentence regarding Corresponding Source. For a variant without that sentence, please see GPL-3.0-linking-exception.
+    </notes>
+    <text>
+      <titleText>
+	<optional>
+	<p>
+	  Additional permission under GNU GPL version 3 section 7
+	</p>
+	</optional>
+      </titleText>
+      <p>
+	If you modify this Program, or any covered work, by linking or combining it with <alt match=".+" name="library1">[name of library]</alt> (or a modified version of that library), containing parts covered by the terms of <alt match=".+" name="libraryLicense1">[name of library's license]</alt>, the licensors of this Program grant you additional permission to convey the resulting work. Corresponding Source for a non-source form of such a combination shall include the source code for the parts of <alt match=".+" name="library2">[name of library]</alt> used as well as that of the covered work.
+      </p>
+    </text>
+  </exception>
+</SPDXLicenseCollection>

--- a/test/simpleTestForGenerator/GPL-3.0-linking-exception.txt
+++ b/test/simpleTestForGenerator/GPL-3.0-linking-exception.txt
@@ -1,0 +1,3 @@
+Additional permission under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or combining it with [name of library] (or a modified version of that library), containing parts covered by the terms of [name of library's license], the licensors of this Program grant you additional permission to convey the resulting work.

--- a/test/simpleTestForGenerator/GPL-3.0-linking-source-exception.txt
+++ b/test/simpleTestForGenerator/GPL-3.0-linking-source-exception.txt
@@ -1,0 +1,3 @@
+Additional permission under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or combining it with [name of library] (or a modified version of that library), containing parts covered by the terms of [name of library's license], the licensors of this Program grant you additional permission to convey the resulting work. Corresponding Source for a non-source form of such a combination shall include the source code for the parts of [name of library] used as well as that of the covered work.


### PR DESCRIPTION
This adds two variants of the recommended template exception from
the FSF's FAQ:
https://www.gnu.org/licenses/gpl-faq.en.html#GPLIncompatibleLibs

The only difference is that the "-source" variant incorporates the
second optional sentence from the FAQ template.

Note that in the identifier, "3.0" is intentionally included after
"GPL" rather than at the end of the identifier. That's because the
exception itself is not versioned, and this is meant to communicate
that the exceptions are intended for use with GPL-3.0.

Fixes #939

Signed-off-by: Steve Winslow <steve@swinslow.net>