### PR TITLE
BSD-3-Clause-LBNL: Add markup for template

### DIFF
--- a/src/BSD-3-Clause-LBNL.xml
+++ b/src/BSD-3-Clause-LBNL.xml
@@ -8,9 +8,13 @@
       <notes>This license is the same as BSD-3-Clause, but with an additional default contribution licensing clause</notes>
 
     <text>
-      <p>Copyright (c) 2003, The Regents of the University of California, through Lawrence Berkeley National
+      <copyrightText>
+         <p>Copyright (c) 2003, The Regents of the University of California, through Lawrence Berkeley National
          Laboratory (subject to receipt of any required approvals from the U.S. Dept. of Energy). All rights
-         reserved. Redistribution and use in source and binary forms, with or without modification, are
+         reserved.</p>
+      </copyrightText>
+      
+      <p>Redistribution and use in source and binary forms, with or without modification, are
          permitted provided that the following conditions are met:</p>
       <list>
         <item>
@@ -26,24 +30,27 @@
         </item>
         <item>
             <bullet>(3)</bullet>
-          Neither the name of the University of California, Lawrence Berkeley National Laboratory, U.S.
-             Dept. of Energy nor the names of its contributors may be used to endorse or promote products
+            <alt match="(The name of.+may not)|(Neither the name of.+nor the names of its contributors may)" name="organizationClause3">
+            Neither the name of the University of California, Lawrence Berkeley National Laboratory, U.S.
+             Dept. of Energy nor the names of its contributors may</alt> be used to endorse or promote products
              derived from this software without specific prior written permission.
         </item>
       </list>
       <p>THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
          WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-         PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+         PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER<optional>, THE UNITED STATES GOVERNMENT,</optional> OR CONTRIBUTORS BE LIABLE FOR
          ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
          LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
          INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-        <br/>LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-             SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+         LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+         SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       </p>
       <p>You are under no obligation whatsoever to provide any bug fixes, patches, or upgrades to the features,
          functionality or performance of the source code ("Enhancements") to anyone; however, if you choose to
-         make your Enhancements available either publicly, or directly to Lawrence Berkeley National
-         Laboratory, without imposing a separate written license agreement for such Enhancements, then you
+         make your Enhancements available either publicly, or directly to 
+         <alt match=".+" name="copyrightHolderEnhancements">Lawrence Berkeley National
+         Laboratory</alt>,
+         without imposing a separate written license agreement for such Enhancements, then you
          hereby grant the following license: a non-exclusive, royalty-free perpetual license to install, use,
          modify, prepare derivative works, incorporate into other computer software, distribute, and sublicense
          such Enhancements or derivative works thereof, in binary and source code form.</p>


### PR DESCRIPTION
This modifies the markup for BSD-3-Clause-LBNL to permit other
copyright holders besides LBNL, as issue #994 documents that
Stanford SLAC is also using this license.

The copyright notice is also now moved into `copyrightText` tags
to make matching easier.

Fixes #994

Signed-off-by: Steve Winslow <steve@swinslow.net>