### PR TITLE
Deprecate BSD-2-Clause-NetBSD

### DIFF
--- a/src/BSD-2-Clause-NetBSD.xml
+++ b/src/BSD-2-Clause-NetBSD.xml
@@ -21,7 +21,7 @@
       </copyrightText>
 
       <p>This code is derived from software contributed to The NetBSD Foundation by
-        <alt match=".*" name="contributors">[contributor name]</alt>.
+        <alt match=".*" name="contributors"/>
       </p>
       <p>Redistribution and use in source and binary forms, with or without modification, are permitted provided
          that the following conditions are met:</p>

--- a/src/BSD-2-Clause-NetBSD.xml
+++ b/src/BSD-2-Clause-NetBSD.xml
@@ -11,9 +11,9 @@
       </crossRefs>
       <notes>
         NetBSD adopted this 2-clause license in 2008 for code contributed to NetBSD Foundation.
-        It is being deprecated as a separate license because the only difference from BSD-2-Clause
-        is the line describing that the code is derived from software contributed to NetBSD,
-        which is not viewed as being a substantive part of the license text.
+        It is being deprecated as a separate license because it is a match to BSD-2-Clause.
+        The line describing that the code is derived from software contributed to NetBSD
+        is not viewed as being a substantive part of the license text.
       </notes>
     <text>
       <copyrightText>

--- a/src/BSD-2-Clause-NetBSD.xml
+++ b/src/BSD-2-Clause-NetBSD.xml
@@ -1,18 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="false" licenseId="BSD-2-Clause-NetBSD"
-            name="BSD 2-Clause NetBSD License">
+            name="BSD 2-Clause NetBSD License"
+            isDeprecated="true" deprecatedVersion="3.9">
+      <obsoletedBys>
+        <obsoletedBy>BSD-2-Clause</obsoletedBy>
+      </obsoletedBys>
       <crossRefs>
          <crossRef>http://www.netbsd.org/about/redistribution.html#default</crossRef>
       </crossRefs>
-      <notes>NetBSD adopted this 2-clause license in 2008 for code contributed to NetBSD Foundation.</notes>
+      <notes>
+        NetBSD adopted this 2-clause license in 2008 for code contributed to NetBSD Foundation.
+        It is being deprecated as a separate license because the only difference from BSD-2-Clause
+        is the line describing that the code is derived from software contributed to NetBSD,
+        which is not viewed as being a substantive part of the license text.
+      </notes>
     <text>
       <copyrightText>
          <p>Copyright (c) 2008 The NetBSD Foundation, Inc. All rights reserved.</p>
       </copyrightText>
 
       <p>This code is derived from software contributed to The NetBSD Foundation by
-        <alt match=".*" name="contributors"/>
+        <alt match=".*" name="contributors">[contributor name]</alt>.
       </p>
       <p>Redistribution and use in source and binary forms, with or without modification, are permitted provided
          that the following conditions are met:</p>

--- a/test/simpleTestForGenerator/BSD-2-Clause-NetBSD.txt
+++ b/test/simpleTestForGenerator/BSD-2-Clause-NetBSD.txt
@@ -1,6 +1,6 @@
 Copyright (c) 2008 The NetBSD Foundation, Inc. All rights reserved.
 
-This code is derived from software contributed to The NetBSD Foundation by [contributor name].
+This code is derived from software contributed to The NetBSD Foundation by
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 

--- a/test/simpleTestForGenerator/BSD-2-Clause-NetBSD.txt
+++ b/test/simpleTestForGenerator/BSD-2-Clause-NetBSD.txt
@@ -1,6 +1,6 @@
 Copyright (c) 2008 The NetBSD Foundation, Inc. All rights reserved.
 
-This code is derived from software contributed to The NetBSD Foundation by
+This code is derived from software contributed to The NetBSD Foundation by [contributor name].
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 


### PR DESCRIPTION
This patch deprecates BSD-2-Clause-NetBSD in favor of the standard
BSD-2-Clause license, as discussed in #980.

For those who do choose to continue using it, this also fixes the
markup for the "This code is derived from..." line so that it does
not render on the license list as an incomplete sentence.

Fixes #980

Signed-off-by: Steve Winslow <steve@swinslow.net>