### PR TITLE
Adding cross reference for WTFPL

### DIFF
--- a/src/WTFPL.xml
+++ b/src/WTFPL.xml
@@ -3,6 +3,7 @@
    <license isOsiApproved="false" licenseId="WTFPL"
             name="Do What The F*ck You Want To Public License">
       <crossRefs>
+         <crossRef>http://www.wtfpl.net/about/</crossRef>
          <crossRef>http://sam.zoy.org/wtfpl/COPYING</crossRef>
       </crossRefs>
     <text>


### PR DESCRIPTION
As discussed in https://github.com/spdx/license-list-XML/issues/1049#issuecomment-645369852, this will add a cross reference to the currently functioning site for the WTFPL license. The previous link no longer works (404) but is maintained for older files that referenced it.