### PR TITLE
Deprecate BSD-2-Clause-FreeBSD and add generic version

### DIFF
--- a/src/BSD-2-Clause-FreeBSD.xml
+++ b/src/BSD-2-Clause-FreeBSD.xml
@@ -1,10 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="false" licenseId="BSD-2-Clause-FreeBSD"
-            name="BSD 2-Clause FreeBSD License">
+            name="BSD 2-Clause FreeBSD License"
+            isDeprecated="true" deprecatedVersion="3.10">
       <crossRefs>
          <crossRef>http://www.freebsd.org/copyright/freebsd-license.html</crossRef>
       </crossRefs>
+      <notes>
+         This license was deprecated because BSD-2-Clause-Views has been added, as a more generalized version; and
+         because FreeBSD project community members have indicated that the final sentence is not part of that
+         project's code license.
+      </notes>
     <text>
       <titleText>
          <p>The FreeBSD Copyright</p>

--- a/src/BSD-2-Clause-Views.xml
+++ b/src/BSD-2-Clause-Views.xml
@@ -42,8 +42,8 @@
         TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
         ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</p>
       <p>The views and conclusions contained in the software and documentation are those of the authors and should
-         not be interpreted as representing official policies, either expressed or implied, of the copyright holders
-         or contributors.</p>
+         not be interpreted as representing official policies, either expressed or implied, of <alt match=".+"
+         name="copyrightHolderViews">the copyright holders or contributors.</alt></p>
     </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/BSD-2-Clause-Views.xml
+++ b/src/BSD-2-Clause-Views.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SPDXLicenseCollection xmlns="http://www.spdx.org/license">
+   <license isOsiApproved="false" licenseId="BSD-2-Clause-Views"
+            name="BSD 2-Clause with views sentence" listVersionAdded="3.10">
+      <crossRefs>
+         <crossRef>http://www.freebsd.org/copyright/freebsd-license.html</crossRef>
+         <crossRef>https://people.freebsd.org/~ivoras/wine/patch-wine-nvidia.sh</crossRef>
+         <crossRef>https://github.com/protegeproject/protege/blob/master/license.txt</crossRef>
+      </crossRefs>
+      <notes>
+         This is a more generalized version of BSD-2-Clause-FreeBSD, which is now deprecated. It is identical to
+         BSD-2-Clause with the addition of the "views and conclusions" sentence at the end.
+      </notes>
+    <text>
+      <copyrightText>
+         <p>Copyright (c) &lt;year&gt; &lt;owner&gt; All rights reserved.</p>
+      </copyrightText>
+
+      <p>Redistribution and use in source and binary forms, with or without modification, are permitted provided
+         that the following conditions are met:</p>
+      <list>
+        <item>
+            <bullet>1.</bullet>
+          Redistributions of source code must retain the above copyright notice, this list of conditions
+             and the following disclaimer.
+        </item>
+        <item>
+            <bullet>2.</bullet>
+          Redistributions in binary form must reproduce the above copyright notice, this list of conditions
+             and the following disclaimer in the documentation and/or other materials provided with the
+             distribution.
+        </item>
+      </list>
+      <p>THIS SOFTWARE IS PROVIDED BY
+        <alt match=".+" name="copyrightHolderAsIs">THE COPYRIGHT HOLDERS AND CONTRIBUTORS</alt> "AS IS" AND ANY
+        <alt match="EXPRESS(ED)?" name="express">EXPRESS</alt> OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+        AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+        <alt match=".+" name="copyrightHolderLiability">THE COPYRIGHT HOLDER OR CONTRIBUTORS</alt> BE LIABLE FOR
+        ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+        LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+        INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+        TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+        ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</p>
+      <p>The views and conclusions contained in the software and documentation are those of the authors and should
+         not be interpreted as representing official policies, either expressed or implied, of the copyright holders
+         or contributors.</p>
+    </text>
+  </license>
+</SPDXLicenseCollection>

--- a/test/simpleTestForGenerator/BSD-2-Clause-Views.txt
+++ b/test/simpleTestForGenerator/BSD-2-Clause-Views.txt
@@ -1,0 +1,11 @@
+Copyright (c) <year> <owner> All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+The views and conclusions contained in the software and documentation are those of the authors and should not be interpreted as representing official policies, either expressed or implied, of the copyright holders or contributors.


### PR DESCRIPTION
This commit adds BSD-2-Clause-Views, a generic version of
BSD-2-Clause-FreeBSD that templatizes the FreeBSD-specific
language. -Views is identical to standard BSD-2-Clause with the
addition of the "views and conclusions" final sentence.

It also deprecates BSD-2-Clause-FreeBSD, to avoid further
confusion, as developers from the FreeBSD community have indicated
that it was not intended to be part of that project's license for
source code.

Fixes #976

Signed-off-by: Steve Winslow <steve@swinslow.net>