### PR TITLE
Mark Unicode-DFS-2016 as OSI approved

### DIFF
--- a/src/Unicode-DFS-2016.xml
+++ b/src/Unicode-DFS-2016.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-    <license isOsiApproved="false" licenseId="Unicode-DFS-2016" listVersionAdded="2.6"
+    <license isOsiApproved="true" licenseId="Unicode-DFS-2016" listVersionAdded="2.6"
             name="Unicode License Agreement - Data Files and Software (2016)">
         <crossRefs>
             <crossRef>http://www.unicode.org/copyright.html</crossRef>


### PR DESCRIPTION
While working on eemeli/make-plural#19, I noticed that while the Unicode Data and Software License is included in the [list of approved licenses](https://opensource.org/licenses/alphabetical) on opensource.org, it isn't marked as such in SPDX data.

It took a bit of hunting, but apparently this approval was granted [about two years ago](https://lists.opensource.org/pipermail/license-review_lists.opensource.org/2018-September/003504.html). It's not clear to me if this approval was just for `Unicode-DFS-2016`, or also its earlier version `Unicode-DFS-2015`.