### PR TITLE
Don't delete github actions in license-list-data repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ deploy-license-data: licenseListPublisher-$(TOOL_VERSION).jar-valid $(TEST_DATA)
 	rm -rf '$(LICENSE_OUTPUT_DIR)'
 	git clone --quiet --depth 1 $(LICENSE_DATA_URL) '$(LICENSE_OUTPUT_DIR)'
 	# Clean out the old data directories
-	find '$(LICENSE_OUTPUT_DIR)' -mindepth 1 -maxdepth 1 -name .git -prune -o -type d -exec rm -rf {} \+
+	find '$(LICENSE_OUTPUT_DIR)' -mindepth 1 -maxdepth 1 -name .git -prune -o -name .github -prune -o -type d -exec rm -rf {} \+
 	rm -f $(LICENSE_OUTPUT_DIR)/licenses.md
 	java -jar -DLocalFsfFreeJson=false -DlistedLicenseSchema="schema/ListedLicense.xsd" licenseListPublisher-$(TOOL_VERSION).jar LicenseRDFAGenerator src '$(LICENSE_OUTPUT_DIR)' $(VERSION) $(RELEASE_DATE) $(TEST_DATA) expected-warnings
 	git -C '$(LICENSE_OUTPUT_DIR)' add -A .


### PR DESCRIPTION
Resolves an issue where the license-list-data repo Github actions disappear when there is a merge to master of the license-list-XML repo

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>