### PR TITLE
Add spacing attribute to alt text

### DIFF
--- a/schema/ListedLicense.xsd
+++ b/schema/ListedLicense.xsd
@@ -265,6 +265,15 @@
 				</documentation>
 			</annotation>
 		</attribute>
+		<attribute name="spacing" type="string" default="before">
+			<annotation>
+				<documentation xml:lang="en">
+					<xhtml:p>
+						<xhtml:code>spacing</xhtml:code> defines how spacing is handled around the alt text.  Since XML does not preserve white space, to render the text from the license XML we need to provide hints to the tools that translate the XML to text (or other formats).  Valid values are <xhtml:code>none</xhtml:code> for no spaces before or after the alt text; <xhtml:code>before</xhtml:code> (default) for a space before, but not after the alt text; <xhtml:code>after</xhtml:code> for a space after, but not before the alt text; <xhtml:code>both</xhtml:code>a space before and after the alt text.
+					</xhtml:p>
+				</documentation>
+			</annotation>
+		</attribute>
 	</complexType>
 	<complexType name="optionalType" mixed="true">
 		<annotation>


### PR DESCRIPTION
Adding the spacing attribute to alt text will allow for spacing hints to be provided to the LicenseListPublisher and other tools that interpret the XML.

This will enable modifications to the tools and XML files to resolve issue #1146 

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>