### PR TITLE
Change alt pattern for GPL-3.0-or-later

### DIFF
--- a/src/GPL-3.0-or-later.xml
+++ b/src/GPL-3.0-or-later.xml
@@ -835,7 +835,7 @@
         linking proprietary applications with the library. If this
         is what you want to do, use the GNU Lesser General Public
 	License instead of this License. But first, please read
-	&lt;http<optional spacing="none">s</optional>://www.gnu.org/<alt match="philosophy|licenses" name="philicenses">licenses</alt>/why-not-lgpl.html&gt;.
+	&lt;http<optional spacing="none">s</optional>:<alt match="//www.gnu.org/philosophy/why-not-lgpl\.html&gt;\.|//www.gnu.org/licenses/why-not-lgpl\.html&gt;\." name="philicenses">//www.gnu.org/licenses/why-not-lgpl.html&gt;.</alt>
       </p>
     </optional>
     </text>


### PR DESCRIPTION
This change works around the formatting issues described in issue #1146 

Note - there are very likely other licenses that the same issue.

The approach to resolving the formatting is to make sure the `<alt`... element is on a word boundary where it would be natural to have a space.

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>