### PR TITLE
Add missing item for 3.11 release notes

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -11,7 +11,7 @@ New licenses/exceptions added: 6
 1. HTMLTIDY
 1. MIT-open-group
 
-Update several licenses to note where they have become OSI-approved.
+Update several licenses to note that they have become OSI-approved.
 
 Updates and cleanup of markup for various licenses and other minor changes.
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -2,8 +2,9 @@
 
 ## version 3.11 - 2020-11-25
 
-New licenses/exceptions added: 5
+New licenses/exceptions added: 6
 
+1. ANTLR-PD-fallback
 1. BUSL-1.1
 1. CC-BY-3.0-US
 1. CC-BY-SA-2.0-UK


### PR DESCRIPTION
The ANTLR-PD-fallback license was inadvertently omitted
from the list of added licenses in the release notes for 3.11.
This commit reinserts it.

Signed-off-by: Steve Winslow <steve@swinslow.net>