### PR TITLE
Update contributing recommendations for the test license text

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ The SPDX Legal Team appreciates proposals for new free and open source licenses 
 1. The SPDX Legal Team will discuss any submissions for new licenses or exceptions via comments in the Github issue. Please follow the comments and respond accordingly if there are questions or additional information requested.
 2. New licenses may be approved if 3 SPDX-legal team members (2 lawyers, 1 non-lawyer) sign-off that the license is acceptable AND there is no objection raised from the greater SPDX-legal community within the Github issue comments. If there are objections, then the issue will be labelled "discuss on legal call" and will be discussed on an upcoming bi-weekly call.
 3. Issues will be labelled either "new license/exception: Accepted" or "new license/exception: Not Accepted" as appropriate with an explanation and the Issue closed for the latter case.
-4. If accepted, the new license or exception will be need to be prepared in the proper XML format and plain text test file via a Pull Request and reviewed as appropriate.This is ideally done by the license submitter, with help from experienced members of the SPDX legal team, as needed.
+4. If accepted, the new license or exception will be need to be prepared in the proper XML format and plain text test file via a Pull Request and reviewed as appropriate. The plain text test file should be UTF-8 encoded and match the text and formatting of the original license. The Pull Request is ideally done by the license submitter, with help from experienced members of the SPDX legal team, as needed.
 5. The new license/exception will be officially added for the next release of the SPDX License List.
 
 ## Release Timing


### PR DESCRIPTION
Add recommendation that plain text test files should match the text and formatting of the original license.

The test license text is used for test and is also used as the original formatting of the license text.  This helps resolve several issues where users of the license list would like to have a reference to the license text which include the original line breaks and formatting.

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>