### PR TITLE
Add crossRef to EUPL-1.2.xml

### DIFF
--- a/src/EUPL-1.2.xml
+++ b/src/EUPL-1.2.xml
@@ -5,6 +5,7 @@
     <crossRefs>
       <crossRef>https://joinup.ec.europa.eu/page/eupl-text-11-12</crossRef>
       <crossRef>https://joinup.ec.europa.eu/sites/default/files/custom-page/attachment/eupl_v1.2_en.pdf</crossRef>
+      <crossRef>https://joinup.ec.europa.eu/sites/default/files/custom-page/attachment/2020-03/EUPL-1.2%20EN.txt</crossRef>
       <crossRef>https://joinup.ec.europa.eu/sites/default/files/inline-files/EUPL%20v1_2%20EN(1).txt</crossRef>
       <crossRef>http://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32017D0863</crossRef>
       <crossRef>https://opensource.org/licenses/EUPL-1.2</crossRef>


### PR DESCRIPTION
Add crossRef to the official UTF-8 version from that is linked on
https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12.

See also: https://github.com/github/choosealicense.com/pull/797