### PR TITLE
Make the "/or" optional in "and/or" (0BSD)

### DIFF
--- a/src/0BSD.xml
+++ b/src/0BSD.xml
@@ -9,7 +9,7 @@
          <p>Copyright (C) 2006 by Rob Landley &lt;rob@landley.net&gt;</p>
       </copyrightText>
 
-      <p>Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is
+       <p>Permission to use, copy, modify, and<optional>/or</optional> distribute this software for any purpose with or without fee is
          hereby granted.</p>
       <p>THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE
          INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE

--- a/src/0BSD.xml
+++ b/src/0BSD.xml
@@ -9,7 +9,7 @@
          <p>Copyright (C) 2006 by Rob Landley &lt;rob@landley.net&gt;</p>
       </copyrightText>
 
-       <p>Permission to use, copy, modify, and<optional>/or</optional> distribute this software for any purpose with or without fee is
+      <p>Permission to use, copy, modify, and<optional>/or</optional> distribute this software for any purpose with or without fee is
          hereby granted.</p>
       <p>THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE
          INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE


### PR DESCRIPTION
0BSD is just a conditionless ISC, so there can be a chance that some people don't use "/or".