### PR TITLE
updates to MPL-2.0-nocopyleft-exception-

### DIFF
--- a/src/MPL-2.0-no-copyleft-exception.xml
+++ b/src/MPL-2.0-no-copyleft-exception.xml
@@ -404,15 +404,19 @@
       </list>
       <optional>
         <p>Exhibit A - Source Code Form License Notice</p>
+         <standardLicenseHeader>
         <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL
          was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.</p>
+         </standardLicenseHeader>
         <p>If it is not possible or desirable to put the notice in a particular file, then You may include the
          notice in a location (such as a LICENSE file in a relevant directory) where a recipient would be
          likely to look for such a notice.</p>
         <p>You may add additional accurate notices of copyright ownership.</p>
         <p>Exhibit B - "Incompatible With Secondary Licenses" Notice</p>
+         <standardLicenseHeader>
         <p>This Source Code Form is "Incompatible With Secondary Licenses", as defined by the Mozilla
          Public License, v. 2.0.</p>
+          </standardLicenseHeader>
       </optional>
     </text>
   </license>

--- a/src/MPL-2.0-no-copyleft-exception.xml
+++ b/src/MPL-2.0-no-copyleft-exception.xml
@@ -6,8 +6,8 @@
          <crossRef>http://www.mozilla.org/MPL/2.0/</crossRef>
          <crossRef>https://opensource.org/licenses/MPL-2.0</crossRef>
       </crossRefs>
-      <notes>This license was released in January 2012. This license list entry is for use when the MPL's Exhibit B,
-         which removes the Sec 3.3 copyleft exception.</notes>
+      <notes>This license was released in January 2012. This license list entry is for use when the MPL's Exhibit B is used,
+         which effectively negates the copyleft compatibility clause in section 3.3.</notes>
     <text>
       <titleText>
          <p>Mozilla Public License Version 2.0</p>


### PR DESCRIPTION
update Notes re: Exhibit B to make more sense

add standardLicenseHeader tag to Exhibit A and B (it was missing entirely)