### PR TITLE
Update the LicenseListPublisher to version 2.2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: CC0-1.0
 
-TOOL_VERSION = 2.1.23
+TOOL_VERSION = 2.2.0
 TEST_DATA = test/simpleTestForGenerator
 GIT_AUTHOR = License Publisher (maintained by Gary O'Neall) <gary@sourceauditor.com>
 GIT_AUTHOR_EMAIL = gary@sourceauditor.com

--- a/Makefile
+++ b/Makefile
@@ -43,11 +43,11 @@ release-license-data: deploy-license-data
 
 .PRECIOUS: licenseListPublisher-%.jar
 licenseListPublisher-%.jar:
-	curl -L https://dl.bintray.com/spdx/spdx-tools/org/spdx/licenseListPublisher/$*/licenseListPublisher-$*-jar-with-dependencies.jar >$@
+	curl -L https://repo1.maven.org/maven2/org/spdx/licenseListPublisher/$*/licenseListPublisher-$*-jar-with-dependencies.jar >$@
 
 .PRECIOUS: licenseListPublisher-%.jar.asc
 licenseListPublisher-%.jar.asc:
-	curl -L https://dl.bintray.com/spdx/spdx-tools/org/spdx/licenseListPublisher/$*/licenseListPublisher-$*-jar-with-dependencies.jar.asc >$@
+	curl -L https://repo1.maven.org/maven2/org/spdx/licenseListPublisher/$*/licenseListPublisher-$*-jar-with-dependencies.jar.asc >$@
 
 .PHONY: licenseListPublisher-%.jar-valid
 licenseListPublisher-%.jar-valid: licenseListPublisher-%.jar.asc licenseListPublisher-%.jar goneall.gpg


### PR DESCRIPTION
The new version addresses several issue:

- Duplicate checking when submitting a single file
- Updated website description
- More accurate link status in CrossRefs
- License text in the data formats are now copied from the test data making the formatting similar to the origin

Note that this new version has some significant changes, so we should manually inspect some of the published files prior to release.