### PR TITLE
Update LicenseListPublisher to version 2.2.1. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: CC0-1.0
 
-TOOL_VERSION = 2.2.0
+TOOL_VERSION = 2.2.1
 TEST_DATA = test/simpleTestForGenerator
 GIT_AUTHOR = License Publisher (maintained by Gary O'Neall) <gary@sourceauditor.com>
 GIT_AUTHOR_EMAIL = gary@sourceauditor.com


### PR DESCRIPTION
 Increases the maximum size of copyrights from 1000 characters to 5000 characters.

Resolves the issue found in PR #1209 

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>