### PR TITLE
Fix NCGL-UK-2.0 metadata typos

### DIFF
--- a/src/NCGL-UK-2.0.xml
+++ b/src/NCGL-UK-2.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-    <license licenseId="NCGL-UK-2.0" name="Non-Commercial Government Licence" listVersionAdded="2.0">
+    <license licenseId="NCGL-UK-2.0" name="Non-Commercial Government Licence" listVersionAdded="3.9">
         <crossRefs>
             <crossRef>http://www.nationalarchives.gov.uk/doc/non-commercial-government-licence/version/2/</crossRef>
         </crossRefs>

--- a/src/NCGL-UK-2.0.xml
+++ b/src/NCGL-UK-2.0.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-    <license licenseId="NCGL-UK-2.0" name="Non-Commercial Government Licence" listVersionAdded="3.9">
+    <license licenseId="NCGL-UK-2.0" name="Non-Commercial Government Licence" listVersionAdded="2.0">
         <crossRefs>
-            <crossRef>https://github.com/spdx/license-list-XML/blob/master/src/Apache-2.0.xml</crossRef>
+            <crossRef>http://www.nationalarchives.gov.uk/doc/non-commercial-government-licence/version/2/</crossRef>
         </crossRefs>
         <text>
             <titleText>Non-Commercial Government Licence


### PR DESCRIPTION
Fixing some typos in the XML metadata:

- Correcting <crossRef> link
- Correcting version `listVersionAdded`