### PR TITLE
fix: Commas in MulanPSL-2.0

### DIFF
--- a/src/MulanPSL-2.0.xml
+++ b/src/MulanPSL-2.0.xml
@@ -6,9 +6,9 @@
       </crossRefs>
       <notes>Both the Chinese and English translations of this license have been included in the markup, because current examples of use appear to include both translations in license documents.</notes>
     <text>
-        <titleText><p>木兰宽松许可证, 第2版</p></titleText>
+        <titleText><p>木兰宽松许可证，第2版</p></titleText>
 
-        <titleText><p>木兰宽松许可证， 第2版</p>
+        <titleText><p>木兰宽松许可证，第2版</p>
 
         <p>2020年1月 http://license.coscl.org.cn/MulanPSL2</p></titleText>
 
@@ -81,9 +81,9 @@
             <p>See the Mulan PSL v2 for more details.</p>
         </standardLicenseHeader>
 
-        <titleText><p>Mulan Permissive Software License，Version 2</p></titleText>
+        <titleText><p>Mulan Permissive Software License, Version 2</p></titleText>
 
-        <titleText><p>Mulan Permissive Software License，Version 2 (Mulan PSL v2)</p>
+        <titleText><p>Mulan Permissive Software License, Version 2 (Mulan PSL v2)</p>
 
         <p>January 2020 http://license.coscl.org.cn/MulanPSL2</p></titleText>
 
@@ -143,7 +143,7 @@
 
         <p>END OF THE TERMS AND CONDITIONS</p>
 
-        <p>How to Apply the Mulan Permissive Software License，Version 2 (Mulan PSL v2) to Your Software</p>
+        <p>How to Apply the Mulan Permissive Software License, Version 2 (Mulan PSL v2) to Your Software</p>
 
         <p>To apply the Mulan PSL v2 to your work, for easy identification by recipients, you are suggested to complete following three steps:</p>
 


### PR DESCRIPTION
Consistent full width comma in Chinese sections, and plain comma in English sections