### PR TITLE
Update 0BSD.xml

### DIFF
--- a/src/0BSD.xml
+++ b/src/0BSD.xml
@@ -6,7 +6,7 @@
       </crossRefs>
     <text>
       <copyrightText>
-         <p>Copyright (C) 2006 by Rob Landley &lt;rob@landley.net&gt;</p>
+         <p>Copyright (C) &lt;year&gt; &lt;copyright holder&gt;</p>
       </copyrightText>
 
       <p>Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is


### PR DESCRIPTION
Replace year and copyright holder specific example with placeholder. This method is consistent with BSD-2 and MIT files.

The root issue is that some software may (incorrectly?) consume the license file and generate a license citing Rob Landley, causing confusion. This has come up before, #737 for example. It was addressed by #738, but regressed by c6ac6f10087e66b5858fb8f072bba2cb326f5928.