### PR TITLE
Update LicenseListPublisher to the latest version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: CC0-1.0
 
-TOOL_VERSION = 2.2.1
+TOOL_VERSION = 2.2.2
 TEST_DATA = test/simpleTestForGenerator
 GIT_AUTHOR = License Publisher (maintained by Gary O'Neall) <gary@sourceauditor.com>
 GIT_AUTHOR_EMAIL = gary@sourceauditor.com


### PR DESCRIPTION
Update the spdx-java-rdf-store to version [1.0.1](https://github.com/spdx/spdx-java-rdf-store/releases/tag/v1.0.1) and SPDX Java Library version to version [1.0.5](https://github.com/spdx/Spdx-Java-Library/releases/tag/v1.0.5).

Resolves issues with license compares with different comma characters and adds isFsfLibre to the JSON table of contents.

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>