### PR TITLE
mark entire "Creative Commons notice at bottom" as optional

### DIFF
--- a/src/CC-BY-4.0.xml
+++ b/src/CC-BY-4.0.xml
@@ -428,17 +428,19 @@
                the legal processes of any jurisdiction or authority.
           </item>
         </list>
-      <p>Creative Commons is not a party to its public licenses. Notwithstanding, Creative Commons may elect to
-         apply one of its public licenses to material it publishes and in those instances will be considered
-         the “Licensor.” <optional>The text of the Creative Commons public licenses is dedicated to the public
-         domain under the CC0 Public Domain Dedication.</optional> Except for the limited purpose of indicating that material is shared under a Creative
-         Commons public license or as otherwise permitted by the Creative Commons policies published at
-         creativecommons.org/policies, Creative Commons does not authorize the use of the trademark “Creative
-         Commons” or any other trademark or logo of Creative Commons without its prior written consent
-         including, without limitation, in connection with any unauthorized modifications to any of its public
-         licenses or any other arrangements, understandings, or agreements concerning use of licensed material.
-         For the avoidance of doubt, this paragraph does not form part of the public licenses.</p>
-      <p>Creative Commons may be contacted at creativecommons.org.</p>
+      <optional>
+        <p>Creative Commons is not a party to its public licenses. Notwithstanding, Creative Commons may elect to
+           apply one of its public licenses to material it publishes and in those instances will be considered
+           the “Licensor.” The text of the Creative Commons public licenses is dedicated to the public
+           domain under the CC0 Public Domain Dedication. Except for the limited purpose of indicating that material is shared under a Creative
+           Commons public license or as otherwise permitted by the Creative Commons policies published at
+           creativecommons.org/policies, Creative Commons does not authorize the use of the trademark “Creative
+           Commons” or any other trademark or logo of Creative Commons without its prior written consent
+           including, without limitation, in connection with any unauthorized modifications to any of its public
+           licenses or any other arrangements, understandings, or agreements concerning use of licensed material.
+           For the avoidance of doubt, this paragraph does not form part of the public licenses.</p>
+        <p>Creative Commons may be contacted at creativecommons.org.</p>
+      </optional>
     </text>
     </license>
 </SPDXLicenseCollection>

--- a/src/CC-BY-4.0.xml
+++ b/src/CC-BY-4.0.xml
@@ -431,8 +431,8 @@
       <optional>
         <p>Creative Commons is not a party to its public licenses. Notwithstanding, Creative Commons may elect to
            apply one of its public licenses to material it publishes and in those instances will be considered
-           the “Licensor.” The text of the Creative Commons public licenses is dedicated to the public
-           domain under the CC0 Public Domain Dedication. Except for the limited purpose of indicating that material is shared under a Creative
+           the “Licensor.” <optional>The text of the Creative Commons public licenses is dedicated to the public
+           domain under the CC0 Public Domain Dedication.</optional> Except for the limited purpose of indicating that material is shared under a Creative
            Commons public license or as otherwise permitted by the Creative Commons policies published at
            creativecommons.org/policies, Creative Commons does not authorize the use of the trademark “Creative
            Commons” or any other trademark or logo of Creative Commons without its prior written consent

--- a/src/CC-BY-NC-4.0.xml
+++ b/src/CC-BY-NC-4.0.xml
@@ -462,8 +462,8 @@
       <optional>
         <p>Creative Commons is not a party to its public licenses. Notwithstanding, Creative Commons may elect to
            apply one of its public licenses to material it publishes and in those instances will be considered
-           the “Licensor.” The text of the Creative Commons public licenses is dedicated to the public
-           domain under the CC0 Public Domain Dedication. Except for the limited purpose of indicating that material is shared under a Creative
+           the “Licensor.” <optional>The text of the Creative Commons public licenses is dedicated to the public
+           domain under the CC0 Public Domain Dedication.</optional> Except for the limited purpose of indicating that material is shared under a Creative
            Commons public license or as otherwise permitted by the Creative Commons policies published at
            creativecommons.org/policies, Creative Commons does not authorize the use of the trademark “Creative
            Commons” or any other trademark or logo of Creative Commons without its prior written consent

--- a/src/CC-BY-NC-4.0.xml
+++ b/src/CC-BY-NC-4.0.xml
@@ -459,17 +459,19 @@
                 </list>
             </item>
         </list>
+      <optional>
         <p>Creative Commons is not a party to its public licenses. Notwithstanding, Creative Commons may elect to
-            apply one of its public licenses to material it publishes and in those instances will be considered
-            the “Licensor.” <optional>The text of the Creative Commons public licenses is dedicated to the public
-            domain under the CC0 Public Domain Dedication.</optional> Except for the limited purpose of indicating that material is shared under a Creative
-            Commons public license or as otherwise permitted by the Creative Commons policies published at
-            creativecommons.org/policies, Creative Commons does not authorize the use of the trademark “Creative
-            Commons” or any other trademark or logo of Creative Commons without its prior written consent
-            including, without limitation, in connection with any unauthorized modifications to any of its public
-            licenses or any other arrangements, understandings, or agreements concerning use of licensed material.
-            For the avoidance of doubt, this paragraph does not form part of the public licenses.</p>
+           apply one of its public licenses to material it publishes and in those instances will be considered
+           the “Licensor.” The text of the Creative Commons public licenses is dedicated to the public
+           domain under the CC0 Public Domain Dedication. Except for the limited purpose of indicating that material is shared under a Creative
+           Commons public license or as otherwise permitted by the Creative Commons policies published at
+           creativecommons.org/policies, Creative Commons does not authorize the use of the trademark “Creative
+           Commons” or any other trademark or logo of Creative Commons without its prior written consent
+           including, without limitation, in connection with any unauthorized modifications to any of its public
+           licenses or any other arrangements, understandings, or agreements concerning use of licensed material.
+           For the avoidance of doubt, this paragraph does not form part of the public licenses.</p>
         <p>Creative Commons may be contacted at creativecommons.org.</p>
+      </optional>
     </text>
     </license>
 </SPDXLicenseCollection>

--- a/src/CC-BY-NC-ND-4.0.xml
+++ b/src/CC-BY-NC-ND-4.0.xml
@@ -441,17 +441,19 @@
             </list>
         </item>
       </list>
-      <p>Creative Commons is not a party to its public licenses. Notwithstanding, Creative Commons may elect to
-         apply one of its public licenses to material it publishes and in those instances will be considered
-         the “Licensor.” <optional>The text of the Creative Commons public licenses is dedicated to the public
-         domain under the CC0 Public Domain Dedication.</optional> Except for the limited purpose of indicating that material is shared under a Creative
-         Commons public license or as otherwise permitted by the Creative Commons policies published at
-         creativecommons.org/policies, Creative Commons does not authorize the use of the trademark “Creative
-         Commons” or any other trademark or logo of Creative Commons without its prior written consent
-         including, without limitation, in connection with any unauthorized modifications to any of its public
-         licenses or any other arrangements, understandings, or agreements concerning use of licensed material.
-         For the avoidance of doubt, this paragraph does not form part of the public licenses.</p>
-      <p>Creative Commons may be contacted at creativecommons.org.</p>
+      <optional>
+        <p>Creative Commons is not a party to its public licenses. Notwithstanding, Creative Commons may elect to
+           apply one of its public licenses to material it publishes and in those instances will be considered
+           the “Licensor.” The text of the Creative Commons public licenses is dedicated to the public
+           domain under the CC0 Public Domain Dedication. Except for the limited purpose of indicating that material is shared under a Creative
+           Commons public license or as otherwise permitted by the Creative Commons policies published at
+           creativecommons.org/policies, Creative Commons does not authorize the use of the trademark “Creative
+           Commons” or any other trademark or logo of Creative Commons without its prior written consent
+           including, without limitation, in connection with any unauthorized modifications to any of its public
+           licenses or any other arrangements, understandings, or agreements concerning use of licensed material.
+           For the avoidance of doubt, this paragraph does not form part of the public licenses.</p>
+        <p>Creative Commons may be contacted at creativecommons.org.</p>
+      </optional>
     </text>
     </license>
 </SPDXLicenseCollection>

--- a/src/CC-BY-NC-ND-4.0.xml
+++ b/src/CC-BY-NC-ND-4.0.xml
@@ -444,8 +444,8 @@
       <optional>
         <p>Creative Commons is not a party to its public licenses. Notwithstanding, Creative Commons may elect to
            apply one of its public licenses to material it publishes and in those instances will be considered
-           the “Licensor.” The text of the Creative Commons public licenses is dedicated to the public
-           domain under the CC0 Public Domain Dedication. Except for the limited purpose of indicating that material is shared under a Creative
+           the “Licensor.” <optional>The text of the Creative Commons public licenses is dedicated to the public
+           domain under the CC0 Public Domain Dedication.</optional> Except for the limited purpose of indicating that material is shared under a Creative
            Commons public license or as otherwise permitted by the Creative Commons policies published at
            creativecommons.org/policies, Creative Commons does not authorize the use of the trademark “Creative
            Commons” or any other trademark or logo of Creative Commons without its prior written consent

--- a/src/CC-BY-NC-SA-4.0.xml
+++ b/src/CC-BY-NC-SA-4.0.xml
@@ -470,17 +470,19 @@
                        the legal processes of any jurisdiction or authority.
                 </item>
             </list>
-      <p>Creative Commons is not a party to its public licenses. Notwithstanding, Creative Commons may elect to
-        apply one of its public licenses to material it publishes and in those instances will be considered
-         the “Licensor.” <optional>The text of the Creative Commons public licenses is dedicated to the public
-         domain under the CC0 Public Domain Dedication.</optional> Except for the limited purpose of indicating that material is shared under a Creative
-         Commons public license or as otherwise permitted by the Creative Commons policies published at
-         creativecommons.org/policies, Creative Commons does not authorize the use of the trademark “Creative
-         Commons” or any other trademark or logo of Creative Commons without its prior written consent
-         including, without limitation, in connection with any unauthorized modifications to any of its public
-         licenses or any other arrangements, understandings, or agreements concerning use of licensed material.
-         For the avoidance of doubt, this paragraph does not form part of the public licenses.</p>
-      <p>Creative Commons may be contacted at creativecommons.org.</p>
+      <optional>
+        <p>Creative Commons is not a party to its public licenses. Notwithstanding, Creative Commons may elect to
+           apply one of its public licenses to material it publishes and in those instances will be considered
+           the “Licensor.” The text of the Creative Commons public licenses is dedicated to the public
+           domain under the CC0 Public Domain Dedication. Except for the limited purpose of indicating that material is shared under a Creative
+           Commons public license or as otherwise permitted by the Creative Commons policies published at
+           creativecommons.org/policies, Creative Commons does not authorize the use of the trademark “Creative
+           Commons” or any other trademark or logo of Creative Commons without its prior written consent
+           including, without limitation, in connection with any unauthorized modifications to any of its public
+           licenses or any other arrangements, understandings, or agreements concerning use of licensed material.
+           For the avoidance of doubt, this paragraph does not form part of the public licenses.</p>
+        <p>Creative Commons may be contacted at creativecommons.org.</p>
+      </optional>
     </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/CC-BY-NC-SA-4.0.xml
+++ b/src/CC-BY-NC-SA-4.0.xml
@@ -473,8 +473,8 @@
       <optional>
         <p>Creative Commons is not a party to its public licenses. Notwithstanding, Creative Commons may elect to
            apply one of its public licenses to material it publishes and in those instances will be considered
-           the “Licensor.” The text of the Creative Commons public licenses is dedicated to the public
-           domain under the CC0 Public Domain Dedication. Except for the limited purpose of indicating that material is shared under a Creative
+           the “Licensor.” <optional>The text of the Creative Commons public licenses is dedicated to the public
+           domain under the CC0 Public Domain Dedication.</optional> Except for the limited purpose of indicating that material is shared under a Creative
            Commons public license or as otherwise permitted by the Creative Commons policies published at
            creativecommons.org/policies, Creative Commons does not authorize the use of the trademark “Creative
            Commons” or any other trademark or logo of Creative Commons without its prior written consent

--- a/src/CC-BY-ND-4.0.xml
+++ b/src/CC-BY-ND-4.0.xml
@@ -422,8 +422,8 @@
       <optional>
         <p>Creative Commons is not a party to its public licenses. Notwithstanding, Creative Commons may elect to
            apply one of its public licenses to material it publishes and in those instances will be considered
-           the “Licensor.” The text of the Creative Commons public licenses is dedicated to the public
-           domain under the CC0 Public Domain Dedication. Except for the limited purpose of indicating that material is shared under a Creative
+           the “Licensor.” <optional>The text of the Creative Commons public licenses is dedicated to the public
+           domain under the CC0 Public Domain Dedication.</optional> Except for the limited purpose of indicating that material is shared under a Creative
            Commons public license or as otherwise permitted by the Creative Commons policies published at
            creativecommons.org/policies, Creative Commons does not authorize the use of the trademark “Creative
            Commons” or any other trademark or logo of Creative Commons without its prior written consent

--- a/src/CC-BY-ND-4.0.xml
+++ b/src/CC-BY-ND-4.0.xml
@@ -419,18 +419,19 @@
                the legal processes of any jurisdiction or authority.
           </item>
         </list>
-      <p>Creative Commons is not a party to its public licenses. Notwithstanding, Creative Commons may elect to
-         apply one of its public licenses to material it publishes and in those instances will be considered
-         the “Licensor.” <optional>The text of the Creative Commons public licenses is dedicated to the public
-         domain under the CC0 Public Domain Dedication.</optional> Except for the limited purpose of indicating
-         that material is shared under a Creative Commons public license or as otherwise permitted by the
-         Creative Commons policies published at creativecommons.org/policies, Creative Commons does not
-         authorize the use of the trademark “Creative Commons” or any other trademark or logo of Creative
-         Commons without its prior written consent including, without limitation, in connection with any
-         unauthorized modifications to any of its public licenses or any other arrangements, understandings, or
-         agreements concerning use of licensed material. For the avoidance of doubt, this paragraph does not
-         form part of the public licenses.</p>
+      <optional>
+        <p>Creative Commons is not a party to its public licenses. Notwithstanding, Creative Commons may elect to
+           apply one of its public licenses to material it publishes and in those instances will be considered
+           the “Licensor.” The text of the Creative Commons public licenses is dedicated to the public
+           domain under the CC0 Public Domain Dedication. Except for the limited purpose of indicating that material is shared under a Creative
+           Commons public license or as otherwise permitted by the Creative Commons policies published at
+           creativecommons.org/policies, Creative Commons does not authorize the use of the trademark “Creative
+           Commons” or any other trademark or logo of Creative Commons without its prior written consent
+           including, without limitation, in connection with any unauthorized modifications to any of its public
+           licenses or any other arrangements, understandings, or agreements concerning use of licensed material.
+           For the avoidance of doubt, this paragraph does not form part of the public licenses.</p>
         <p>Creative Commons may be contacted at creativecommons.org.</p>
+      </optional>
     </text>
     </license>
 </SPDXLicenseCollection>

--- a/src/CC-BY-SA-4.0.xml
+++ b/src/CC-BY-SA-4.0.xml
@@ -462,8 +462,8 @@
       <optional>
         <p>Creative Commons is not a party to its public licenses. Notwithstanding, Creative Commons may elect to
            apply one of its public licenses to material it publishes and in those instances will be considered
-           the “Licensor.” The text of the Creative Commons public licenses is dedicated to the public
-           domain under the CC0 Public Domain Dedication. Except for the limited purpose of indicating that material is shared under a Creative
+           the “Licensor.” <optional>The text of the Creative Commons public licenses is dedicated to the public
+           domain under the CC0 Public Domain Dedication.</optional> Except for the limited purpose of indicating that material is shared under a Creative
            Commons public license or as otherwise permitted by the Creative Commons policies published at
            creativecommons.org/policies, Creative Commons does not authorize the use of the trademark “Creative
            Commons” or any other trademark or logo of Creative Commons without its prior written consent

--- a/src/CC-BY-SA-4.0.xml
+++ b/src/CC-BY-SA-4.0.xml
@@ -459,17 +459,19 @@
                the legal processes of any jurisdiction or authority.
           </item>
         </list>
-      <p>Creative Commons is not a party to its public licenses. Notwithstanding, Creative Commons may elect to
-         apply one of its public licenses to material it publishes and in those instances will be considered
-         the “Licensor.” <optional>The text of the Creative Commons public licenses is dedicated to the public
-         domain under the CC0 Public Domain Dedication.</optional> Except for the limited purpose of indicating that material is shared under a Creative
-         Commons public license or as otherwise permitted by the Creative Commons policies published at
-         creativecommons.org/policies, Creative Commons does not authorize the use of the trademark “Creative
-         Commons” or any other trademark or logo of Creative Commons without its prior written consent
-         including, without limitation, in connection with any unauthorized modifications to any of its public
-         licenses or any other arrangements, understandings, or agreements concerning use of licensed material.
-         For the avoidance of doubt, this paragraph does not form part of the public licenses.</p>
-      <p>Creative Commons may be contacted at creativecommons.org.</p>
+      <optional>
+        <p>Creative Commons is not a party to its public licenses. Notwithstanding, Creative Commons may elect to
+           apply one of its public licenses to material it publishes and in those instances will be considered
+           the “Licensor.” The text of the Creative Commons public licenses is dedicated to the public
+           domain under the CC0 Public Domain Dedication. Except for the limited purpose of indicating that material is shared under a Creative
+           Commons public license or as otherwise permitted by the Creative Commons policies published at
+           creativecommons.org/policies, Creative Commons does not authorize the use of the trademark “Creative
+           Commons” or any other trademark or logo of Creative Commons without its prior written consent
+           including, without limitation, in connection with any unauthorized modifications to any of its public
+           licenses or any other arrangements, understandings, or agreements concerning use of licensed material.
+           For the avoidance of doubt, this paragraph does not form part of the public licenses.</p>
+        <p>Creative Commons may be contacted at creativecommons.org.</p>
+      </optional>
     </text>
     </license>
 </SPDXLicenseCollection>


### PR DESCRIPTION
Per [Legal Code Defined - Creative Commons](https://creativecommons.org/legal-code-defined/), the *Creative Commons notice at bottom* is one of the *Elements of the license page that are not part of the legal code*.

This not only improves the accuracy of the data here, but helps with [Does not detect "trimmed down" CC-BY-4.0 · Issue #464 · licensee/licensee](https://github.com/licensee/licensee/issues/464)--ex. helps end users with a trimmed down CC Licenses in their repository.
