### PR TITLE
Fetch unannotated tag versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ LICENSE_DATA_REPO_NO_SCHEME = github.com/spdx/license-list-data.git
 LICENSE_DATA_REPO = https://$(LICENSE_DATA_REPO_NO_SCHEME)
 LICENSE_DATA_URL = https://$(LICENSE_LIST_GITHUB_TOKEN)@$(LICENSE_DATA_REPO_NO_SCHEME)
 LICENSE_OUTPUT_DIR = .tmp
-GITVERSION = $(shell git describe --always || echo 'UNKNOWN')
+GITVERSION = $(shell git describe --always --tags || echo 'UNKNOWN')
 # Remove leading 'v' or 'V'
 VERSION = $(subst V,,$(subst v,,$(GITVERSION)))
 RELEASE_DATE = $(shell date '+%Y-%m-%d')


### PR DESCRIPTION
Resolves issue when release the license list XML where the version was not getting picked up in the release process