### PR TITLE
Update crossRef for Apache-2.0 to use https

### DIFF
--- a/src/Apache-2.0.xml
+++ b/src/Apache-2.0.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="Apache-2.0" name="Apache License 2.0">
       <crossRefs>
-         <crossRef>http://www.apache.org/licenses/LICENSE-2.0</crossRef>
+         <crossRef>https://www.apache.org/licenses/LICENSE-2.0</crossRef>
          <crossRef>https://opensource.org/licenses/Apache-2.0</crossRef>
       </crossRefs>
       <notes>This license was released January 2004</notes>


### PR DESCRIPTION
The http:// address redirects to an https:// address, so this avoids a redirect.