### PR TITLE
Update MPL-2.0 crossRef to use https

### DIFF
--- a/src/MPL-2.0.xml
+++ b/src/MPL-2.0.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="MPL-2.0" name="Mozilla Public License 2.0">
       <crossRefs>
-         <crossRef>http://www.mozilla.org/MPL/2.0/</crossRef>
+         <crossRef>https://www.mozilla.org/MPL/2.0/</crossRef>
          <crossRef>https://opensource.org/licenses/MPL-2.0</crossRef>
       </crossRefs>
       <notes>This license was released in January 2012. This license list entry is for use when the standard MPL 2.0 is


### PR DESCRIPTION
The http:// address redirects to an https:// address, so this avoids a redirect.