### PR TITLE
Add CC-BY-2.5-AU license

### DIFF
--- a/src/CC-BY-2.5-AU.xml
+++ b/src/CC-BY-2.5-AU.xml
@@ -381,21 +381,23 @@
           </list>
         </item>
       </list>
-      <p>Creative Commons is not a party to this Licence, and, to the full extent permitted by
-        applicable law, makes no representation or warranty whatsoever in connection with the Work.
-        To the full extent permitted by applicable law, Creative Commons will not be liable to You or
-        any party on any legal theory (including, without limitation, negligence) for any damages
-        whatsoever, including without limitation any general, special, incidental or consequential
-        damages arising in connection to this licence. Notwithstanding the foregoing two (2)
-        sentences, if Creative Commons has expressly identified itself as the Licensor hereunder, it
-        shall have all rights and obligations of Licensor.</p>
-      <p>Except for the limited purpose of indicating to the public that the Work is licensed under the
-        CCPL, neither party will use the trademark "Creative Commons" or any related trademark or
-        logo of Creative Commons without the prior written consent of Creative Commons. Any
-        permitted use will be in compliance with Creative Commons' then-current trademark usage
-        guidelines, as may be published on its website or otherwise made available upon request from
-        time to time.</p>
-      <p>Creative Commons may be contacted at https://creativecommons.org/.</p>
+      <optional>
+        <p>Creative Commons is not a party to this Licence, and, to the full extent permitted by
+          applicable law, makes no representation or warranty whatsoever in connection with the Work.
+          To the full extent permitted by applicable law, Creative Commons will not be liable to You or
+          any party on any legal theory (including, without limitation, negligence) for any damages
+          whatsoever, including without limitation any general, special, incidental or consequential
+          damages arising in connection to this licence. Notwithstanding the foregoing two (2)
+          sentences, if Creative Commons has expressly identified itself as the Licensor hereunder, it
+          shall have all rights and obligations of Licensor.</p>
+        <p>Except for the limited purpose of indicating to the public that the Work is licensed under the
+          CCPL, neither party will use the trademark "Creative Commons" or any related trademark or
+          logo of Creative Commons without the prior written consent of Creative Commons. Any
+          permitted use will be in compliance with Creative Commons' then-current trademark usage
+          guidelines, as may be published on its website or otherwise made available upon request from
+          time to time.</p>
+        <p>Creative Commons may be contacted at https://creativecommons.org/.</p>
+      </optional>
     </text>
    </license>
 </SPDXLicenseCollection>

--- a/src/CC-BY-2.5-AU.xml
+++ b/src/CC-BY-2.5-AU.xml
@@ -1,0 +1,401 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SPDXLicenseCollection xmlns="http://www.spdx.org/license">
+   <license isOsiApproved="false" licenseId="CC-BY-2.5-AU"
+            name="Creative Commons Attribution 2.5 Australia">
+      <crossRefs>
+         <crossRef>https://creativecommons.org/licenses/by/2.5/au/legalcode</crossRef>
+      </crossRefs>
+    <text>
+      <titleText>
+        <p><optional>Creative Commons </optional>Attribution 2.5 Australia</p>
+      </titleText>
+      <optional>
+        <p>CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE LEGAL
+          SERVICES. DISTRIBUTION OF THIS LICENCE DOES NOT CREATE AN ATTORNEY-CLIENT
+          RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS INFORMATION ON AN "AS-IS" BASIS.
+          CREATIVE COMMONS MAKES NO WARRANTIES REGARDING THE INFORMATION PROVIDED,
+          AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM ITS USE.</p>
+        <p>Licence</p>
+      </optional>
+
+      <p>THE WORK (AS DEFINED BELOW) IS PROVIDED UNDER THE TERMS OF THIS CREATIVE
+        COMMONS PUBLIC LICENCE ("CCPL" OR "LICENCE"). THE WORK IS PROTECTED BY COPYRIGHT
+        AND/OR OTHER APPLICABLE LAW. ANY USE OF THE WORK OTHER THAN AS AUTHORISED UNDER
+        THIS LICENCE AND/OR APPLICABLE LAW IS PROHIBITED.</p>
+      <p>BY EXERCISING ANY RIGHTS TO THE WORK PROVIDED HERE, YOU ACCEPT AND AGREE TO BE
+        BOUND BY THE TERMS OF THIS LICENCE. THE LICENSOR GRANTS YOU THE RIGHTS CONTAINED
+        HERE IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND CONDITIONS.</p>
+      <list>
+        <item>
+          <bullet>1.</bullet>
+          Definitions
+        </item>
+        <list>
+          <item>
+            <bullet>a.</bullet>
+            "Collective Work" means a work, such as a periodical issue, anthology or
+            encyclopaedia, in which the Work in its entirety in unmodified form, along with a
+            number of other contributions, constituting separate and independent works in
+            themselves, are assembled into a collective whole. A work that constitutes a
+            Collective Work will not be considered a Derivative Work (as defined below) for the
+            purposes of this Licence.
+          </item>
+          <item>
+            <bullet>b.</bullet>
+            "Derivative Work" means a work that reproduces a substantial part of the Work,
+            or of the Work and other pre-existing works protected by copyright, or that is an
+            adaptation of a Work that is a literary, dramatic, musical or artistic work.
+            Derivative Works include a translation, musical arrangement, dramatisation,
+            motion picture version, sound recording, art reproduction, abridgment, condensation,
+            or any other form in which a work may be adapted, except that a
+            work that constitutes a Collective Work will not be considered a Derivative Work for
+            the purpose of this Licence. For the avoidance of doubt, where the Work is a
+            musical composition or sound recording, the synchronization of the Work in timed-relation
+            with a moving image ("synching") will be considered a Derivative Work for
+            the purpose of this Licence.
+          </item>
+          <item>
+            <bullet>c.</bullet>
+            "Licensor" means the individual or entity that offers the Work under the terms of
+            this Licence.
+          </item>
+          <item>
+            <bullet>d.</bullet>
+            "Moral rights law" means laws under which an individual who creates a work
+            protected by copyright has rights of integrity of authorship of the work, rights of
+            attribution of authorship of the work, rights not to have authorship of the work
+            falsely attributed, or rights of a similar or analogous nature in the work anywhere
+            in the world.
+          </item>
+          <item>
+            <bullet>e.</bullet>
+            "Original Author" means the individual or entity who created the Work.
+          </item>
+          <item>
+            <bullet>f.</bullet>
+            "Work" means the work or other subject-matter protected by copyright that is
+            offered under the terms of this Licence, which may include (without limitation) a
+            literary, dramatic, musical or artistic work, a sound recording or cinematograph
+            film, a published edition of a literary, dramatic, musical or artistic work or a
+            television or sound broadcast.
+          </item>
+          <item>
+            <bullet>g.</bullet>
+            "You" means an individual or entity exercising rights under this Licence who has
+            not previously violated the terms of this Licence with respect to the Work, or who
+            has received express permission from the Licensor to exercise rights under this
+            Licence despite a previous violation.
+          </item>
+          <item>
+            <bullet>h.</bullet>
+            "Licence Elements" means the following high-level licence attributes as selected
+            by Licensor and indicated in the title of this Licence: Attribution, NonCommercial,
+            NoDerivatives, ShareAlike.
+          </item>
+        </list>
+        <item>
+          <bullet>2.</bullet>
+          Fair Dealing and Other Rights. Nothing in this Licence excludes or modifies, or is intended
+          to exclude or modify, (including by reducing, limiting, or restricting) the rights of You or others to
+          use the Work arising from fair dealings or other limitations on the rights of the copyright owner
+          or the Original Author under copyright law, moral rights law or other applicable laws.
+        </item>
+        <item>
+          <bullet>3.</bullet>
+          Licence Grant. Subject to the terms and conditions of this Licence, Licensor hereby grants
+          You a worldwide, royalty-free, non-exclusive, perpetual (for the duration of the applicable
+          copyright) licence to exercise the rights in the Work as stated below:
+        <list>
+          <item>
+            <bullet>a.</bullet>
+            to reproduce the Work, to incorporate the Work into one or more Collective Works,
+            and to reproduce the Work as incorporated in the Collective Works;
+          </item>
+          <item>
+            <bullet>b.</bullet>
+            to create and reproduce Derivative Works;
+          </item>
+          <item>
+            <bullet>c.</bullet>
+            to publish, communicate to the public, distribute copies or records of, exhibit or
+            display publicly, perform publicly and perform publicly by means of a digital audio
+            transmission the Work including as incorporated in Collective Works;
+          </item>
+          <item>
+            <bullet>d.</bullet>
+            to publish, communicate to the public, distribute copies or records of, exhibit or
+            display publicly, perform publicly, and perform publicly by means of a digital audio
+            transmission Derivative Works;
+          </item>
+          <item>
+            <bullet>e.</bullet>
+            For the avoidance of doubt, where the Work is a musical composition:
+          </item>
+          <list>
+            <item>
+              <bullet>i.</bullet>
+              Performance Royalties Under Blanket Licences. Licensor will
+              not collect, whether individually or via a performance rights society,
+              royalties for Your communication to the public, broadcast, public
+              performance or public digital performance (e.g. webcast) of the Work.
+            </item>
+            <item>
+              <bullet>ii.</bullet>
+              Mechanical Rights and Statutory Royalties. Licensor will not
+              collect, whether individually or via a music rights agency, designated
+              agent or a music publisher, royalties for any record You create from
+              the Work ("cover version") and distribute, subject to the compulsory
+              licence created by 17 USC Section 115 of the US Copyright Act (or
+              an equivalent statutory licence under the Australian Copyright Act or
+              in other jurisdictions).
+            </item>
+          </list>
+          <item>
+            <bullet>f.</bullet>
+            Webcasting Rights and Statutory Royalties. For the avoidance of doubt, where
+            the Work is a sound recording, Licensor will not collect, whether individually or via
+            a performance-rights society, royalties for Your public digital performance (e.g.
+            webcast) of the Work, subject to the compulsory licence created by 17 USC Section
+            114 of the US Copyright Act (or the equivalent in other jurisdictions).
+          </item>
+        </list>
+        <p>The above rights may be exercised in all media and formats whether now known or hereafter
+          devised. The above rights include the right to make such modifications as are technically
+          necessary to exercise the rights in other media and formats. All rights not expressly granted by
+          Licensor under this Licence are hereby reserved.
+        </p>
+        </item>
+        <item>
+          <bullet>4.</bullet>
+          Restrictions. The licence granted in Section 3 above is expressly made subject to and limited
+          by the following restrictions:
+          <list>
+            <item>
+              <bullet>a.</bullet>
+              You may publish, communicate to the public, distribute, publicly exhibit or display,
+              publicly perform, or publicly digitally perform the Work only under the terms of this
+              Licence, and You must include a copy of, or the Uniform Resource Identifier for, this
+              Licence with every copy or record of the Work You publish, communicate to the
+              public, distribute, publicly exhibit or display, publicly perform or publicly digitally
+              perform. You may not offer or impose any terms on the Work that exclude, alter or
+              restrict the terms of this Licence or the recipients' exercise of the rights granted
+              hereunder. You may not sublicense the Work. You must keep intact all notices that
+              refer to this Licence and to the disclaimer of representations and warranties. You
+              may not publish, communicate to the public, distribute, publicly exhibit or display,
+              publicly perform, or publicly digitally perform the Work with any technological
+              measures that control access or use of the Work in a manner inconsistent with the
+              terms of this Licence. The above applies to the Work as incorporated in a Collective
+              Work, but this does not require the Collective Work apart from the Work itself to be
+              made subject to the terms of this Licence. If You create a Collective Work, upon
+              notice from any Licensor You must, to the extent practicable, remove from the
+              Collective Work any credit as required by Section 4(b), as requested. If You create
+              a Derivative Work, upon notice from any Licensor You must, to the extent
+              practicable, remove from the Derivative Work any credit as required by Section
+              4(b), as requested.
+            </item>
+            <item>
+              <bullet>b.</bullet>
+              If you publish, communicate to the public, distribute, publicly exhibit or display,
+              publicly perform, or publicly digitally perform the Work or any Derivative Works or
+              Collective Works, You must keep intact all copyright notices for the Work. You must
+              also give clear and reasonably prominent credit to (i) the Original Author (by name
+              or pseudonym if applicable), if the name or pseudonym is supplied; and (ii) if
+              another party or parties (eg a sponsor institute, publishing entity or journal) is
+              designated for attribution in the copyright notice, terms of service or other
+              reasonable means associated with the Work, such party or parties. If applicable,
+              that credit must be given in the particular way made known by the Original Author
+              and otherwise as reasonable to the medium or means You are utilizing, by
+              conveying the identity of the Original Author and the other designated party or
+              parties (if applicable); the title of the Work if supplied; to the extent reasonably
+              practicable, the Uniform Resource Identifier, if any, that Licensor specifies to be
+              associated with the Work, unless such URI does not refer to the copyright notice or
+              licensing information for the Work; and in the case of a Derivative Work, a credit
+              identifying the use of the Work in the Derivative Work (e.g., "French translation of
+              the Work by Original Author," or "Screenplay based on original Work by Original
+              Author"). Such credit may be implemented in any reasonable manner; provided,
+              however, that in the case of a Derivative Work or Collective Work, at a minimum
+              such credit will appear where any other comparable authorship credit appears and
+              in a manner at least as prominent as such other comparable authorship credit.
+            </item>
+            <item>
+              <bullet>c.</bullet>
+              False attribution prohibited. Except as otherwise agreed in writing by the
+              Licensor, if You publish, communicate to the public, distribute, publicly exhibit or
+              display, publicly perform, or publicly digitally perform the Work or any Derivative
+              Works or Collective Works in accordance with this Licence, You must not falsely
+              attribute the Work to someone other than the Original Author.
+            </item>
+            <item>
+              <bullet>d.</bullet>
+              Prejudice to honour or reputation prohibited. Except as otherwise agreed in
+              writing by the Licensor, if you publish, communicate to the public, distribute,
+              publicly exhibit or display, publicly perform, or publicly digitally perform the Work
+              or any Derivative Works or Collective Works, You must not do anything that results
+              in a material distortion of, the mutilation of, or a material alteration to, the Work
+              that is prejudicial to the Original Author's honour or reputation, and You must not
+              do anything else in relation to the Work that is prejudicial to the Original Author's
+              honour or reputation.
+            </item>
+          </list>
+        </item>
+        <item>
+          <bullet>5.</bullet>
+          Disclaimer.
+          <p>EXCEPT AS EXPRESSLY STATED IN THIS LICENCE OR OTHERWISE MUTUALLY AGREED TO BY THE
+            PARTIES IN WRITING, AND TO THE FULL EXTENT PERMITTED BY APPLICABLE LAW, LICENSOR
+            OFFERS THE WORK "AS-IS" AND MAKES NO REPRESENTATIONS, WARRANTIES OR CONDITIONS
+            OF ANY KIND CONCERNING THE WORK, EXPRESS, IMPLIED, STATUTORY OR OTHERWISE,
+            INCLUDING, WITHOUT LIMITATION, ANY REPRESENTATIONS, WARRANTIES OR CONDITIONS
+            REGARDING THE CONTENTS OR ACCURACY OF THE WORK, OR OF TITLE, MERCHANTABILITY,
+            FITNESS FOR A PARTICULAR PURPOSE, NONINFRINGEMENT, THE ABSENCE OF LATENT OR
+            OTHER DEFECTS, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+            DISCOVERABLE.</p>
+        </item>
+        <item>
+          <bullet>6.</bullet>
+          Limitation on Liability.
+          <p>TO THE FULL EXTENT PERMITTED BY APPLICABLE LAW, AND EXCEPT FOR ANY LIABILITY
+            ARISING FROM CONTRARY MUTUAL AGREEMENT AS REFERRED TO IN SECTION 5, IN NO EVENT
+            WILL LICENSOR BE LIABLE TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+            NEGLIGENCE) FOR ANY LOSS OR DAMAGE WHATSOEVER, INCLUDING (WITHOUT LIMITATION)
+            LOSS OF PRODUCTION OR OPERATION TIME, LOSS, DAMAGE OR CORRUPTION OF DATA OR
+            RECORDS; OR LOSS OF ANTICIPATED SAVINGS, OPPORTUNITY, REVENUE, PROFIT OR
+            GOODWILL, OR OTHER ECONOMIC LOSS; OR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL,
+            PUNITIVE OR EXEMPLARY DAMAGES ARISING OUT OF OR IN CONNECTION WITH THIS LICENCE
+            OR THE USE OF THE WORK, EVEN IF LICENSOR HAS BEEN ADVISED OF THE POSSIBILITY OF
+            SUCH DAMAGES.</p>
+          <p>If applicable legislation implies warranties or conditions, or imposes obligations or liability on the
+            Licensor in respect of this Licence that cannot be wholly or partly excluded, restricted or
+            modified, the Licensor's liability is limited, to the full extent permitted by the applicable
+            legislation, at its option, to:</p>
+          <list>
+            <item>
+              <bullet>a.</bullet>
+              in the case of goods, any one or more of the following:
+            </item>
+            <list>
+              <item>
+                <bullet>i.</bullet>
+                the replacement of the goods or the supply of equivalent goods;
+              </item>
+              <item>
+                <bullet>ii.</bullet>
+                the repair of the goods;
+              </item>
+              <item>
+                <bullet>iii.</bullet>
+                the payment of the cost of replacing the goods or of acquiring equivalent goods;
+              </item>
+              <item>
+                <bullet>iv.</bullet>
+                the payment of the cost of having the goods repaired; or
+              </item>
+            </list>
+            <item>
+              <bullet>b.</bullet>
+              in the case of services:
+            </item>
+            <list>
+              <item>
+                <bullet>i.</bullet>
+                the supplying of the services again; or
+              </item>
+              <item>
+                <bullet>ii.</bullet>
+                the payment of the cost of having the services supplied again.
+              </item>
+            </list>
+          </list>
+        </item>
+        <item>
+          <bullet>7.</bullet>
+          Termination.
+          <list>
+            <item>
+              <bullet>a.</bullet>
+              This Licence and the rights granted hereunder will terminate automatically upon
+              any breach by You of the terms of this Licence. Individuals or entities who have
+              received Derivative Works or Collective Works from You under this Licence,
+              however, will not have their licences terminated provided such individuals or
+              entities remain in full compliance with those licences. Sections 1, 2, 5, 6, 7, and 8
+              will survive any termination of this Licence.
+            </item>
+            <item>
+              <bullet>b.</bullet>
+              Subject to the above terms and conditions, the licence granted here is perpetual
+              (for the duration of the applicable copyright in the Work). Notwithstanding the
+              above, Licensor reserves the right to release the Work under different licence
+              terms or to stop distributing the Work at any time; provided, however that any
+              such election will not serve to withdraw this Licence (or any other licence that has
+              been, or is required to be, granted under the terms of this Licence), and this
+              Licence will continue in full force and effect unless terminated as stated above.
+            </item>
+          </list>
+        </item>
+        <item>
+          <bullet>8.</bullet>
+          Miscellaneous.
+          <list>
+            <item>
+              <bullet>a.</bullet>
+              Each time You publish, communicate to the public, distribute or publicly digitally
+              perform the Work or a Collective Work, the Licensor offers to the recipient a licence
+              to the Work on the same terms and conditions as the licence granted to You under
+              this Licence.
+            </item>
+            <item>
+              <bullet>b.</bullet>
+              Each time You publish, communicate to the public, distribute or publicly digitally
+              perform a Derivative Work, Licensor offers to the recipient a licence to the original
+              Work on the same terms and conditions as the licence granted to You under this
+              Licence.
+            </item>
+            <item>
+              <bullet>c.</bullet>
+              If any provision of this Licence is invalid or unenforceable under applicable law, it
+              shall not affect the validity or enforceability of the remainder of the terms of this
+              Licence, and without further action by the parties to this agreement, such provision
+              shall be reformed to the minimum extent necessary to make such provision valid
+              and enforceable.
+            </item>
+            <item>
+              <bullet>d.</bullet>
+              No term or provision of this Licence shall be deemed waived and no breach
+              consented to unless such waiver or consent shall be in writing and signed by the
+              party to be charged with such waiver or consent.
+            </item>
+            <item>
+              <bullet>e.</bullet>
+              This Licence constitutes the entire agreement between the parties with respect to
+              the Work licensed here. To the full extent permitted by applicable law, there are no
+              understandings, agreements or representations with respect to the Work not
+              specified here. Licensor shall not be bound by any additional provisions that may
+              appear in any communication from You. This Licence may not be modified without
+              the mutual written agreement of the Licensor and You.
+            </item>
+            <item>
+              <bullet>f.</bullet>
+              The construction, validity and performance of this Licence shall be governed by the
+              laws in force in New South Wales, Australia.
+            </item>
+          </list>
+        </item>
+      </list>
+      <p>Creative Commons is not a party to this Licence, and, to the full extent permitted by
+        applicable law, makes no representation or warranty whatsoever in connection with the Work.
+        To the full extent permitted by applicable law, Creative Commons will not be liable to You or
+        any party on any legal theory (including, without limitation, negligence) for any damages
+        whatsoever, including without limitation any general, special, incidental or consequential
+        damages arising in connection to this licence. Notwithstanding the foregoing two (2)
+        sentences, if Creative Commons has expressly identified itself as the Licensor hereunder, it
+        shall have all rights and obligations of Licensor.</p>
+      <p>Except for the limited purpose of indicating to the public that the Work is licensed under the
+        CCPL, neither party will use the trademark "Creative Commons" or any related trademark or
+        logo of Creative Commons without the prior written consent of Creative Commons. Any
+        permitted use will be in compliance with Creative Commons' then-current trademark usage
+        guidelines, as may be published on its website or otherwise made available upon request from
+        time to time.</p>
+      <p>Creative Commons may be contacted at https://creativecommons.org/.</p>
+    </text>
+   </license>
+</SPDXLicenseCollection>

--- a/test/simpleTestForGenerator/CC-BY-2.5-AU.txt
+++ b/test/simpleTestForGenerator/CC-BY-2.5-AU.txt
@@ -1,0 +1,112 @@
+Creative Commons Attribution 2.5 Australia
+
+CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE LEGAL SERVICES. DISTRIBUTION OF THIS LICENCE DOES NOT CREATE AN ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES REGARDING THE INFORMATION PROVIDED, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM ITS USE.
+
+Licence
+
+THE WORK (AS DEFINED BELOW) IS PROVIDED UNDER THE TERMS OF THIS CREATIVE COMMONS PUBLIC LICENCE ("CCPL" OR "LICENCE"). THE WORK IS PROTECTED BY COPYRIGHT AND/OR OTHER APPLICABLE LAW. ANY USE OF THE WORK OTHER THAN AS AUTHORISED UNDER THIS LICENCE AND/OR APPLICABLE LAW IS PROHIBITED.
+
+BY EXERCISING ANY RIGHTS TO THE WORK PROVIDED HERE, YOU ACCEPT AND AGREE TO BE BOUND BY THE TERMS OF THIS LICENCE. THE LICENSOR GRANTS YOU THE RIGHTS CONTAINED HERE IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND CONDITIONS.
+
+   1. Definitions
+
+      a. "Collective Work" means a work, such as a periodical issue, anthology or encyclopaedia, in which the Work in its entirety in unmodified form, along with a number of other contributions, constituting separate and independent works in themselves, are assembled into a collective whole. A work that constitutes a Collective Work will not be considered a Derivative Work (as defined below) for the purposes of this Licence.
+
+      b. "Derivative Work" means a work that reproduces a substantial part of the Work, or of the Work and other pre-existing works protected by copyright, or that is an adaptation of a Work that is a literary, dramatic, musical or artistic work. Derivative Works include a translation, musical arrangement, dramatisation, motion picture version, sound recording, art reproduction, abridgment, condensation, or any other form in which a work may be adapted, except that a work that constitutes a Collective Work will not be considered a Derivative Work for the purpose of this Licence. For the avoidance of doubt, where the Work is a musical composition or sound recording, the synchronization of the Work in timed-relation with a moving image ("synching") will be considered a Derivative Work for the purpose of this Licence.
+
+     c. "Licensor" means the individual or entity that offers the Work under the terms of this Licence.
+
+     d. "Moral rights law" means laws under which an individual who creates a work protected by copyright has rights of integrity of authorship of the work, rights of attribution of authorship of the work, rights not to have authorship of the work falsely attributed, or rights of a similar or analogous nature in the work anywhere in the world.
+
+     e. "Original Author" means the individual or entity who created the Work.
+
+     f. "Work" means the work or other subject-matter protected by copyright that is offered under the terms of this Licence, which may include (without limitation) a literary, dramatic, musical or artistic work, a sound recording or cinematograph film, a published edition of a literary, dramatic, musical or artistic work or a television or sound broadcast.
+
+     g. "You" means an individual or entity exercising rights under this Licence who has not previously violated the terms of this Licence with respect to the Work, or who has received express permission from the Licensor to exercise rights under this Licence despite a previous violation.
+
+     h. "Licence Elements" means the following high-level licence attributes as selected by Licensor and indicated in the title of this Licence: Attribution, NonCommercial, NoDerivatives, ShareAlike.
+
+2. Fair Dealing and Other Rights. Nothing in this Licence excludes or modifies, or is intended to exclude or modify, (including by reducing, limiting, or restricting) the rights of You or others to use the Work arising from fair dealings or other limitations on the rights of the copyright owner or the Original Author under copyright law, moral rights law or other applicable laws.
+
+3. Licence Grant. Subject to the terms and conditions of this Licence, Licensor hereby grants You a worldwide, royalty-free, non-exclusive, perpetual (for the duration of the applicable copyright) licence to exercise the rights in the Work as stated below:
+
+     a. to reproduce the Work, to incorporate the Work into one or more Collective Works, and to reproduce the Work as incorporated in the Collective Works;
+
+     b. to create and reproduce Derivative Works;
+
+     c. to publish, communicate to the public, distribute copies or records of, exhibit or display publicly, perform publicly and perform publicly by means of a digital audio transmission the Work including as incorporated in Collective Works;
+
+     d. to publish, communicate to the public, distribute copies or records of, exhibit or display publicly, perform publicly, and perform publicly by means of a digital audio transmission Derivative Works;
+
+     e. For the avoidance of doubt, where the Work is a musical composition:
+
+          i. Performance Royalties Under Blanket Licences. Licensor will not collect, whether individually or via a performance rights society, royalties for Your communication to the public, broadcast, public performance or public digital performance (e.g. webcast) of the Work.
+
+          ii. Mechanical Rights and Statutory Royalties. Licensor will not collect, whether individually or via a music rights agency, designated agent or a music publisher, royalties for any record You create from the Work ("cover version") and distribute, subject to the compulsory licence created by 17 USC Section 115 of the US Copyright Act (or an equivalent statutory licence under the Australian Copyright Act or in other jurisdictions).
+
+
+     f. Webcasting Rights and Statutory Royalties. For the avoidance of doubt, where the Work is a sound recording, Licensor will not collect, whether individually or via a performance-rights society, royalties for Your public digital performance (e.g. webcast) of the Work, subject to the compulsory licence created by 17 USC Section 114 of the US Copyright Act (or the equivalent in other jurisdictions).
+
+The above rights may be exercised in all media and formats whether now known or hereafter devised. The above rights include the right to make such modifications as are technically necessary to exercise the rights in other media and formats. All rights not expressly granted by Licensor under this Licence are hereby reserved.
+
+4. Restrictions. The licence granted in Section 3 above is expressly made subject to and limited by the following restrictions:
+
+     a. You may publish, communicate to the public, distribute, publicly exhibit or display, publicly perform, or publicly digitally perform the Work only under the terms of this Licence, and You must include a copy of, or the Uniform Resource Identifier for, this Licence with every copy or record of the Work You publish, communicate to the public, distribute, publicly exhibit or display, publicly perform or publicly digitally perform. You may not offer or impose any terms on the Work that exclude, alter or restrict the terms of this Licence or the recipients' exercise of the rights granted hereunder. You may not sublicense the Work. You must keep intact all notices that refer to this Licence and to the disclaimer of representations and warranties. You may not publish, communicate to the public, distribute, publicly exhibit or display, publicly perform, or publicly digitally perform the Work with any technological measures that control access or use of the Work in a manner inconsistent with the terms of this Licence. The above applies to the Work as incorporated in a Collective Work, but this does not require the Collective Work apart from the Work itself to be made subject to the terms of this Licence. If You create a Collective Work, upon notice from any Licensor You must, to the extent practicable, remove from the Collective Work any credit as required by Section 4(b), as requested. If You create a Derivative Work, upon notice from any Licensor You must, to the extent practicable, remove from the Derivative Work any credit as required by Section 4(b), as requested.
+
+     b. If you publish, communicate to the public, distribute, publicly exhibit or display, publicly perform, or publicly digitally perform the Work or any Derivative Works or Collective Works, You must keep intact all copyright notices for the Work. You must also give clear and reasonably prominent credit to (i) the Original Author (by name or pseudonym if applicable), if the name or pseudonym is supplied; and (ii) if another party or parties (eg a sponsor institute, publishing entity or journal) is designated for attribution in the copyright notice, terms of service or other reasonable means associated with the Work, such party or parties. If applicable, that credit must be given in the particular way made known by the Original Author and otherwise as reasonable to the medium or means You are utilizing, by conveying the identity of the Original Author and the other designated party or parties (if applicable); the title of the Work if supplied; to the extent reasonably practicable, the Uniform Resource Identifier, if any, that Licensor specifies to be associated with the Work, unless such URI does not refer to the copyright notice or licensing information for the Work; and in the case of a Derivative Work, a credit identifying the use of the Work in the Derivative Work (e.g., "French translation of the Work by Original Author," or "Screenplay based on original Work by Original Author"). Such credit may be implemented in any reasonable manner; provided, however, that in the case of a Derivative Work or Collective Work, at a minimum such credit will appear where any other comparable authorship credit appears and in a manner at least as prominent as such other comparable authorship credit.
+
+     c. False attribution prohibited. Except as otherwise agreed in writing by the Licensor, if You publish, communicate to the public, distribute, publicly exhibit or display, publicly perform, or publicly digitally perform the Work or any Derivative Works or Collective Works in accordance with this Licence, You must not falsely attribute the Work to someone other than the Original Author.
+
+     d. Prejudice to honour or reputation prohibited. Except as otherwise agreed in writing by the Licensor, if you publish, communicate to the public, distribute, publicly exhibit or display, publicly perform, or publicly digitally perform the Work or any Derivative Works or Collective Works, You must not do anything that results in a material distortion of, the mutilation of, or a material alteration to, the Work that is prejudicial to the Original Author's honour or reputation, and You must not do anything else in relation to the Work that is prejudicial to the Original Author's honour or reputation.
+
+5. Disclaimer.
+
+EXCEPT AS EXPRESSLY STATED IN THIS LICENCE OR OTHERWISE MUTUALLY AGREED TO BY THE PARTIES IN WRITING, AND TO THE FULL EXTENT PERMITTED BY APPLICABLE LAW, LICENSOR OFFERS THE WORK "AS-IS" AND MAKES NO REPRESENTATIONS, WARRANTIES OR CONDITIONS OF ANY KIND CONCERNING THE WORK, EXPRESS, IMPLIED, STATUTORY OR OTHERWISE, INCLUDING, WITHOUT LIMITATION, ANY REPRESENTATIONS, WARRANTIES OR CONDITIONS REGARDING THE CONTENTS OR ACCURACY OF THE WORK, OR OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NONINFRINGEMENT, THE ABSENCE OF LATENT OR OTHER DEFECTS, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT DISCOVERABLE.
+
+6. Limitation on Liability.
+
+TO THE FULL EXTENT PERMITTED BY APPLICABLE LAW, AND EXCEPT FOR ANY LIABILITY ARISING FROM CONTRARY MUTUAL AGREEMENT AS REFERRED TO IN SECTION 5, IN NO EVENT WILL LICENSOR BE LIABLE TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION, NEGLIGENCE) FOR ANY LOSS OR DAMAGE WHATSOEVER, INCLUDING (WITHOUT LIMITATION) LOSS OF PRODUCTION OR OPERATION TIME, LOSS, DAMAGE OR CORRUPTION OF DATA OR RECORDS; OR LOSS OF ANTICIPATED SAVINGS, OPPORTUNITY, REVENUE, PROFIT OR GOODWILL, OR OTHER ECONOMIC LOSS; OR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY DAMAGES ARISING OUT OF OR IN CONNECTION WITH THIS LICENCE OR THE USE OF THE WORK, EVEN IF LICENSOR HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+If applicable legislation implies warranties or conditions, or imposes obligations or liability on the Licensor in respect of this Licence that cannot be wholly or partly excluded, restricted or modified, the Licensor's liability is limited, to the full extent permitted by the applicable legislation, at its option, to:
+
+     a. in the case of goods, any one or more of the following:
+
+           i. the replacement of the goods or the supply of equivalent goods;
+
+           ii. the repair of the goods;
+
+           iii. the payment of the cost of replacing the goods or of acquiring equivalent goods;
+
+           iv. the payment of the cost of having the goods repaired; or
+
+     b. in the case of services:
+
+           i. the supplying of the services again; or
+
+           ii. the payment of the cost of having the services supplied again.
+
+7. Termination.
+
+     a. This Licence and the rights granted hereunder will terminate automatically upon any breach by You of the terms of this Licence. Individuals or entities who have received Derivative Works or Collective Works from You under this Licence, however, will not have their licences terminated provided such individuals or entities remain in full compliance with those licences. Sections 1, 2, 5, 6, 7, and 8 will survive any termination of this Licence.
+
+     b. Subject to the above terms and conditions, the licence granted here is perpetual (for the duration of the applicable copyright in the Work). Notwithstanding the above, Licensor reserves the right to release the Work under different licence terms or to stop distributing the Work at any time; provided, however that any such election will not serve to withdraw this Licence (or any other licence that has been, or is required to be, granted under the terms of this Licence), and this Licence will continue in full force and effect unless terminated as stated above.
+
+8. Miscellaneous.
+
+     a. Each time You publish, communicate to the public, distribute or publicly digitally perform the Work or a Collective Work, the Licensor offers to the recipient a licence to the Work on the same terms and conditions as the licence granted to You under this Licence.
+
+     b. Each time You publish, communicate to the public, distribute or publicly digitally perform a Derivative Work, Licensor offers to the recipient a licence to the original Work on the same terms and conditions as the licence granted to You under this Licence.
+
+     c. If any provision of this Licence is invalid or unenforceable under applicable law, it shall not affect the validity or enforceability of the remainder of the terms of this Licence, and without further action by the parties to this agreement, such provision shall be reformed to the minimum extent necessary to make such provision valid and enforceable.
+
+     d. No term or provision of this Licence shall be deemed waived and no breach consented to unless such waiver or consent shall be in writing and signed by the party to be charged with such waiver or consent.
+
+     e. This Licence constitutes the entire agreement between the parties with respect to the Work licensed here. To the full extent permitted by applicable law, there are no understandings, agreements or representations with respect to the Work not specified here. Licensor shall not be bound by any additional provisions that may appear in any communication from You. This Licence may not be modified without the mutual written agreement of the Licensor and You.
+
+     f. The construction, validity and performance of this Licence shall be governed by the laws in force in New South Wales, Australia.
+
+Creative Commons is not a party to this Licence, and, to the full extent permitted by applicable law, makes no representation or warranty whatsoever in connection with the Work. To the full extent permitted by applicable law, Creative Commons will not be liable to You or any party on any legal theory (including, without limitation, negligence) for any damages whatsoever, including without limitation any general, special, incidental or consequential damages arising in connection to this licence. Notwithstanding the foregoing two (2) sentences, if Creative Commons has expressly identified itself as the Licensor hereunder, it shall have all rights and obligations of Licensor.
+
+Except for the limited purpose of indicating to the public that the Work is licensed under the CCPL, neither party will use the trademark "Creative Commons" or any related trademark or logo of Creative Commons without the prior written consent of Creative Commons. Any permitted use will be in compliance with Creative Commons' then-current trademark usage guidelines, as may be published on its website or otherwise made available upon request from time to time.
+
+Creative Commons may be contacted at https://creativecommons.org/.


### PR DESCRIPTION
Adds the Creative Commmons Attribution 2.5 Australia (CC BY 2.5 AU) license.

Closes #1171

Signed-off-by: Nico Rikken <nico.rikken@alliander.com>