### PR TITLE
Adding replaceable text to GCC 2.0 exception

### DIFF
--- a/src/exceptions/GCC-exception-2.0.xml
+++ b/src/exceptions/GCC-exception-2.0.xml
@@ -9,16 +9,12 @@
   </notes>
     <text>
       <p>In addition to the permissions in the GNU
-        <optional>Library</optional> General Public License, the Free
-        Software Foundation gives you unlimited permission to link the
-        compiled version of this file<optional> into
-        combinations</optional> with other programs, and to distribute
-        those
-        <alt name="programs" match="combinations|programs">programs</alt>
-        without any restriction coming from the use of this file.  (The
-        <alt name="general" match="General|Library">General</alt>
-        Public License restrictions do apply in other respects; for
-        example, they cover modification of the file, and distribution
+        <optional>Library</optional> General Public License, the <alt match=".+" name="authors">authors</alt>
+        <alt match="give(s)?" name="gives">give</alt> you unlimited permission to link the compiled version of this
+        <alt name="file" match="file|library">file</alt><optional> into combinations</optional> with other programs,
+        and to distribute those <alt name="programs" match="combinations|programs">programs</alt> without any restriction
+        coming from the use of this file.  (The <alt name="general" match="General|Library">General</alt> Public License
+        restrictions do apply in other respects; for example, they cover modification of the file, and distribution
         when not linked into
         <alt name="anotherProgram" match="a combined? executable|another program">another program</alt>.)</p>
     </text>


### PR DESCRIPTION
- Replaced "Free Software Foundation" with "authors"
- Can use either "give" or "gives"
- Can use either "file" or "library"