### PR TITLE
Add a version number to NLOD-1.0

### DIFF
--- a/src/NLOD-1.0.xml
+++ b/src/NLOD-1.0.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="false" licenseId="NLOD-1.0"
-            name="Norwegian Licence for Open Government Data">
+            name="Norwegian Licence for Open Government Data (NLOD) 1.0">
       <crossRefs>
          <crossRef>http://data.norge.no/nlod/en/1.0</crossRef>
       </crossRefs>
@@ -9,7 +9,7 @@
          http://data.norge.no/nlod/no/1.0</notes>
     <text>
       <titleText>
-         <p>Norwegian Licence for Open Government Data (NLOD)</p>
+         <p>Norwegian Licence for Open Government Data (NLOD) 1.0</p>
       </titleText>
           <p>Preface of licence</p>
       <p>This licence grants you the right to copy, use and distribute

--- a/test/simpleTestForGenerator/NLOD-1.0.txt
+++ b/test/simpleTestForGenerator/NLOD-1.0.txt
@@ -1,4 +1,4 @@
-Norwegian Licence for Open Government Data (NLOD)
+Norwegian Licence for Open Government Data (NLOD) 1.0
 
 Preface of licence
 


### PR DESCRIPTION
Version 2.0 of the Norwegian Licence for Open Data (NLOD) has now been
released; version 1.0 should be differentiated in the list.

This is a follow-up to the issue raised during the review of #1262 