### PR TITLE
0BSD: add markup for (optional) title

### DIFF
--- a/src/0BSD.xml
+++ b/src/0BSD.xml
@@ -5,6 +5,9 @@
          <crossRef>http://landley.net/toybox/license.html</crossRef>
       </crossRefs>
     <text>
+      <titleText>
+         <p><alt name="title" match="(BSD Zero[ -]Clause|Zero[ -]Clause BSD)( License)?( \(0BSD\))?">BSD Zero Clause License</alt></p>
+      </titleText>
       <copyrightText>
          <p>Copyright (C) YEAR by AUTHOR EMAIL</p>
       </copyrightText>


### PR DESCRIPTION
Markup for the title added as an optional component, in a similar fashion to what was done for the [ISC license title](https://github.com/spdx/license-list-XML/blob/e0b157f45e17ff1a7b6aa8ad46fbfab05912a014/src/ISC.xml#L9-L11) (see #497 for relevant discussion).

It's also worth noting that, [unlike for ISC](https://opensource.org/licenses/0BSD), opensource.org does include the title in the text for the [0BSD license](https://opensource.org/licenses/0BSD).

The match expression in the `<alt>` element supports the following variations:
- "BSD Zero Clause" or "Zero Clause BSD"
- Both with and without the "License" suffix
- Both with and without the "(0BSD)" suffix
- Both "Zero Clause" (separated with space) and "Zero-Clause" (separated with hyphen)

For reference, this was triggered by the discussion at https://github.com/github/choosealicense.com/issues/837 (/cc @x13a and @mlinksva).