### PR TITLE
Update Internet Systems Consortium (ISC) license

### DIFF
--- a/src/ISC.xml
+++ b/src/ISC.xml
@@ -5,6 +5,11 @@
          <crossRef>https://www.isc.org/downloads/software-support-policy/isc-license/</crossRef>
          <crossRef>https://opensource.org/licenses/ISC</crossRef>
       </crossRefs>
+      <notes>
+         The ISC License text changed 'and' to 'and/or' in July 2007. ISC has released their license
+         text under the following public-domain-equivalent license: "Permission to use, copy, modify,
+         and/or distribute this License text for any purpose with or without fee is hereby granted. (like SPDX: 0BSD)"
+      </notes>
     <text>
       <titleText>
          <p><alt name="title" match="(The )?ISC License( \(ISC[L]?\))?:?">ISC License</alt></p>

--- a/src/ISC.xml
+++ b/src/ISC.xml
@@ -6,9 +6,7 @@
          <crossRef>https://opensource.org/licenses/ISC</crossRef>
       </crossRefs>
       <notes>
-         The ISC License text changed 'and' to 'and/or' in July 2007. ISC has released their license
-         text under the following public-domain-equivalent license: "Permission to use, copy, modify,
-         and/or distribute this License text for any purpose with or without fee is hereby granted. (like SPDX: 0BSD)"
+         The ISC License text changed 'and' to 'and/or' in July 2007. 
       </notes>
     <text>
       <titleText>


### PR DESCRIPTION
These changes were requested by a user on our IRC channel; the user asked to remain anonymous, but wrote the modifications to the XML for these commits.

**Add new crossRef element:** the main URL for the license has changed from <https://www.isc.org/downloads/software-support-policy/isc-license/> to <https://www.isc.org/licenses/> - note that the old URL now redirects to the new one. **Edit:** this has been moved to pull request #1303.

**Add notes:** this includes a reference to the newly-added 'license to the license' on the ISC website, as well as a note to the historical wording change from 'and' to 'and/or'.