### PR TITLE
Correct spelling error in CC-BY-NC-ND-2.0

### DIFF
--- a/src/CC-BY-NC-ND-2.0.xml
+++ b/src/CC-BY-NC-ND-2.0.xml
@@ -153,7 +153,7 @@
           <list>
                      <item>
                         <bullet>i.</bullet>
-              Performancf Royalties Under Blanket Licenses. Licensor reserves the exclusive right to
+              Performance Royalties Under Blanket Licenses. Licensor reserves the exclusive right to
                  collect, whether individually or via a performance rights society (e.g. ASCAP, BMI,
                  SESAC), royalties for the public performance or public digital performance (e.g.
                  webcast) of the Work if that performance is primarily intended for or directed toward

--- a/test/simpleTestForGenerator/CC-BY-NC-ND-2.0.txt
+++ b/test/simpleTestForGenerator/CC-BY-NC-ND-2.0.txt
@@ -42,7 +42,7 @@ The above rights may be exercised in all media and formats whether now known or 
 
      d. For the avoidance of doubt, where the Work is a musical composition:
 
-          i. Performancf Royalties Under Blanket Licenses. Licensor reserves the exclusive right to collect, whether individually or via a performance rights society (e.g. ASCAP, BMI, SESAC), royalties for the public performance or public digital performance (e.g. webcast) of the Work if that performance is primarily intended for or directed toward commercial advantage or private monetary compensation.
+          i. Performance Royalties Under Blanket Licenses. Licensor reserves the exclusive right to collect, whether individually or via a performance rights society (e.g. ASCAP, BMI, SESAC), royalties for the public performance or public digital performance (e.g. webcast) of the Work if that performance is primarily intended for or directed toward commercial advantage or private monetary compensation.
 
           ii. Mechanical Rights and Statutory Royalties. Licensor reserves the exclusive right to collect, whether individually or via a music rights agency or designated agent (e.g. Harry Fox Agency), royalties for any phonorecord You create from the Work ("cover version") and distribute, subject to the compulsory license created by 17 USC Section 115 of the US Copyright Act (or the equivalent in other jurisdictions), if Your distribution of such cover version is primarily intended for or directed toward commercial advantage or private monetary compensation.
 


### PR DESCRIPTION
This commit fixes a spelling error in the XML and text files for the CC-BY-NC-ND-2.0 license, [as reported](https://github.com/spdx/license-list-data/pull/75) by @seydel1847 in the license-list-data repository.