### PR TITLE
Add osiApproved=true to wxWindow

### DIFF
--- a/src/wxWindows.xml
+++ b/src/wxWindows.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license licenseId="wxWindows" name="wxWindows Library License"  isDeprecated="true" deprecatedVersion="2.0rc2">
+   <license licenseId="wxWindows" isOsiApproved="true" name="wxWindows Library License"  isDeprecated="true" deprecatedVersion="2.0rc2">
       <obsoletedBys>
          <obsoletedBy>GPL-2.0-or-later WITH WxWindows-exception-3.1</obsoletedBy>
       </obsoletedBys>


### PR DESCRIPTION
The OSI website lists this license as OSI approved (see https://opensource.org/licenses/alphabetical).

Even though this license is deprecated, adding this flag removes a warning while running the license generation tool.