### PR TITLE
Match erroneous punctuation in Verbatim-man-pages

### DIFF
--- a/src/Verbatim-man-pages.xml
+++ b/src/Verbatim-man-pages.xml
@@ -1,41 +1,22 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-    <license isOsiApproved="false"
-             licenseId="Verbatim-man-pages"
-             listVersionAdded="3.15"
-             name="The &#34;Verbatim&#34; License (man-pages)">
-        <crossRefs>
-            <crossRef>https://www.kernel.org/doc/man-pages/licenses.html</crossRef>
-        </crossRefs>
-        <text>
-            <copyrightText>
-                <p>Copyright (c) &lt;year&gt;, &lt;owner&gt;.</p>
-            </copyrightText>
-    
-            <p>
-                Permission is granted to make and distribute verbatim copies of this
-                manual provided the copyright notice and this permission notice are
-                preserved on all copies.
-            </p>
-            <p>
-                Permission is granted to copy and distribute modified versions of
-                this manual under the conditions for verbatim copying, provided that
-                the entire resulting derived work is distributed under the terms of
-                a permission notice identical to this one.
-            </p>
-            <p>
-                Since the Linux kernel and libraries are constantly changing, this
-                manual page may be incorrect or out-of-date.  The author(s) assume
-                no responsibility for errors or omissions, or for damages resulting
-                from the use of the information contained herein.  The author(s) may
-                not have taken the same level of care in the production of this
-                manual, which is licensed free of charge, as they might when working
-                professionally.
-            </p>
-            <p>
-                Formatted or processed versions of this manual, if unaccompanied by
-                the source, must acknowledge the copyright and authors of this work.
-            </p>
-        </text>
-    </license>
+   <license isOsiApproved="false" licenseId="Verbatim-man-pages" listVersionAdded="3.15" name="The &quot;Verbatim&quot; License (man-pages)">
+      <crossRefs>
+         <crossRef>https://www.kernel.org/doc/man-pages/licenses.html</crossRef>
+      </crossRefs>
+      <text>
+         <copyrightText>
+            <p>Copyright (c) &lt;year&gt;, &lt;owner&gt;.</p>
+         </copyrightText>
+         <p>Permission is granted to make and distribute verbatim copies of this manual provided the copyright notice and this permission notice are preserved on all copies.</p>
+         <p>Permission is granted to copy and distribute modified versions of this manual under the conditions for verbatim copying, provided that the entire resulting derived work is distributed under the terms of a permission notice identical to this one.</p>
+         <p>Since the Linux kernel and libraries are constantly changing, this manual page may be incorrect or out-of-date. The author(s)
+         <alt name="trailing-.-1" spacing="both" match="assume\.?">assume</alt>no responsibility for errors or omissions, or for damages
+         <alt name="trailing-.-2" spacing="both" match="resulting\.?">resulting</alt>from the use of the information contained herein. The author(s)
+         <alt name="trailing-.-3" spacing="both" match="may\.?">may</alt>not have taken the same level of care in the production of
+         <alt name="trailing-.-4" spacing="both" match="this\.?">this</alt>manual, which is licensed free of charge, as they might when
+         <alt name="trailing-.-5" spacing="both" match="working\.?">working</alt>professionally.</p>
+         <p>Formatted or processed versions of this manual, if unaccompanied by the source, must acknowledge the copyright and authors of this work.</p>
+      </text>
+   </license>
 </SPDXLicenseCollection>


### PR DESCRIPTION
The trailing characters in the license text are likely to be removed upstream. However, as users of SPDX may wish to run automated license matchers on older files, this commit adds `alt` elements to match license texts containing the erroneous punctuation.

Related to issue #1310 and pull request #1319.