### PR TITLE
Change markup for Xerox to recognize Tiny CLOS variant

### DIFF
--- a/src/Xerox.xml
+++ b/src/Xerox.xml
@@ -9,7 +9,7 @@
          <p>Copyright (c) 1995, 1996 Xerox Corporation. All Rights Reserved.</p>
       </copyrightText>
 
-      <p>Use and copying of this software and preparation of derivative works based upon this software are
+      <p><alt match="(Use and copying of this software|Use, reproduction,)" name="useAndCopying">Use and copying of this software</alt> and preparation of derivative works <optional>based upon this software</optional> are
          permitted. Any copy of this software or of any derivative work must include the above copyright notice
          of Xerox Corporation, this paragraph and the one after it. Any distribution of this software or
          derivative works must comply with all applicable United States export control laws.</p>


### PR DESCRIPTION
A variant of the `Xerox` license was used for Tiny CLOS, a Scheme version of the Common Lisp Object System. In addition to Tiny CLOS itself, the license applies to derived software, like Racket's Swindle and Guile's GOOPS.

This pull request attempts to add markup to the `Xerox` license to support matching the Tiny CLOS variant: I've written it in the form of a pull request to be concrete, but I'm not very familiar with the markup schema—corrections and improvements are very welcome!

The text from the header of `tiny-clos.scm` in  https://www.cs.cmu.edu/afs/cs/project/ai-repository/ai/lang/scheme/oop/tinyclos/tinyclos.tgz is:
```scheme
; **********************************************************************
; Copyright (c) 1992 Xerox Corporation.  
; All Rights Reserved.  
;
; Use, reproduction, and preparation of derivative works are permitted.
; Any copy of this software or of any derivative work must include the
; above copyright notice of Xerox Corporation, this paragraph and the
; one after it.  Any distribution of this software or derivative works
; must comply with all applicable United States export control laws.
;
; This software is made available AS IS, and XEROX CORPORATION DISCLAIMS
; ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION THE
; IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
; PURPOSE, AND NOTWITHSTANDING ANY OTHER PROVISION CONTAINED HEREIN, ANY
; LIABILITY FOR DAMAGES RESULTING FROM THE SOFTWARE OR ITS USE IS
; EXPRESSLY DISCLAIMED, WHETHER ARISING IN CONTRACT, TORT (INCLUDING
; NEGLIGENCE) OR STRICT LIABILITY, EVEN IF XEROX CORPORATION IS ADVISED
; OF THE POSSIBILITY OF SUCH DAMAGES.
; **********************************************************************
```
(Alternatively, the copy from Swindle is [on GitHub](https://github.com/racket/swindle/blob/122e38efb9842394ef6462053991efb4bd0edf3b/tiny-clos.rkt#L14-L31).)

The only differences from the current text of the `Xerox` license are the year in the copyright text—which IIUC is ignored for matching anyway—and the simplified first sentence. The author of Tiny CLOS, @GregorKiczales, shared some historical recollections about the license in <https://github.com/racket/swindle/pull/1#issuecomment-949858263>.