### PR TITLE
Add Community-Spec-1.0

### DIFF
--- a/src/Community-Spec-1.0.xml
+++ b/src/Community-Spec-1.0.xml
@@ -1,0 +1,429 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SPDXLicenseCollection xmlns="http://www.spdx.org/license">
+   <license isOsiApproved="false" licenseId="Community-Spec-1.0" name="Community Specification License 1.0">
+      <crossRefs>
+         <crossRef>https://github.com/CommunitySpecification/1.0/blob/master/1._Community_Specification_License-v1.md</crossRef>
+      </crossRefs>
+      <notes>Supporting materials are available at https://github.com/CommunitySpecification/1.0.</notes>
+    <text>
+      <titleText>
+         <p>Community Specification License 1.0</p>
+      </titleText>
+      <p>
+	The Purpose of this License.
+	This License sets forth the terms under which
+	1) Contributor will participate in and contribute to the development of specifications,
+	standards, best practices, guidelines, and other similar materials under this Working Group, and
+	2) how the materials developed under this License may be used.
+	It is not intended for source code.
+	Capitalized terms are defined in the License's last section.
+      </p>
+      <list>
+	<item>
+	  <bullet>1.</bullet>
+          Copyright.
+          <list>
+	    <item>
+	      <bullet>1.1.</bullet>
+	      Copyright License.
+	      Contributor grants everyone a non-sublicensable, perpetual, worldwide, non-exclusive,
+	      no-charge, royalty-free, irrevocable (except as expressly stated in this License)
+	      copyright license, without any obligation for accounting, to reproduce,
+	      prepare derivative works of, publicly display, publicly perform, and distribute
+	      any materials it submits to the full extent of its copyright interest in those materials.
+	      Contributor also acknowledges that the Working Group may exercise copyright rights
+	      in the Specification, including the rights to submit the Specification
+	      to another standards organization.
+	    </item>
+	    <item>
+	      <bullet>1.2.</bullet>
+	      Copyright Attribution.
+	      As a condition, anyone exercising this copyright license must include attribution
+	      to the Working Group in any derivative work based on materials developed by the Working Group.
+	      That attribution must include, at minimum, the material's name, version number,
+	      and source from where the materials were retrieved.
+	      Attribution is not required for implementations of the Specification.
+	    </item>
+	  </list>
+	</item>
+	<item>
+	  <bullet>2.</bullet>
+          Patents.
+          <list>
+	    <item>
+	      <bullet>2.1.</bullet>
+	      Patent License.
+	      <list>
+		<item>
+		  <bullet>2.1.1.</bullet>
+		  As a Result of Contributions.
+		  <list>
+		    <item>
+		      <bullet>2.1.1.1.</bullet>
+		      As a Result of Contributions to Draft Specifications.
+		      Contributor grants Licensee a non-sublicensable, perpetual, worldwide,
+		      non-exclusive, no-charge, royalty-free, irrevocable
+		      (except as expressly stated in this License)
+		      license to its Necessary Claims in
+		      1) Contributor's Contributions and
+		      2) to the Draft Specification that is within Scope as of the date of that Contribution,
+		      in both cases for Licensee's Implementation of the Draft Specification,
+		      except for those patent claims excluded by Contributor under Section 3.
+		    </item>
+		    <item>
+		      <bullet>2.1.1.2.</bullet>
+		      For Approved Specifications.
+		      Contributor grants Licensee a non-sublicensable, perpetual, worldwide,
+		      non-exclusive, no-charge, royalty-free, irrevocable
+		      (except as expressly stated in this License)
+		      license to its Necessary Claims included the Approved Specification
+		      that are within Scope for Licensee's Implementation of the Approved Specification,
+		      except for those patent claims excluded by Contributor under Section 3.
+		    </item>
+		  </list>
+		</item>
+		<item>
+		  <bullet>2.1.2.</bullet>
+		  Patent Grant from Licensee.
+		  Licensee grants each other Licensee a non-sublicensable, perpetual,
+		  worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+		  (except as expressly stated in this License)
+		  license to its Necessary Claims for its Implementation,
+		  except for those patent claims excluded under Section 3.
+		</item>
+		<item>
+		  <bullet>2.1.3.</bullet>
+		  Licensee Acceptance.
+		  The patent grants set forth in Section 2.1 extend only to Licensees
+		  that have indicated their agreement to this License as follows:
+		  <list>
+		    <item>
+		      <bullet>2.1.3.1.</bullet>
+		      Source Code Distributions.
+		      For distribution in source code, by including this License
+		      in the root directory of the source code with the Implementation;
+		    </item>
+		    <item>
+		      <bullet>2.1.3.2.</bullet>
+		      Non-Source Code Distributions.
+		      For distribution in any form other than source code,
+		      by including this License in the documentation,
+		      legal notices, via notice in the software,
+		      and/or other written materials provided with the Implementation; or
+		    </item>
+		    <item>
+		      <bullet>2.1.3.3.</bullet>
+		      Via Notices.md.
+		      By issuing pull request or commit to the Specification's repository's Notices.md file
+		      by the Implementer's authorized representative,
+		      including the Implementer's name, authorized individual and system identifier,
+		      and Specification version.
+		    </item>
+		  </list>
+		</item>
+		<item>
+		  <bullet>2.1.4.</bullet>
+		  Defensive Termination.
+		  If any Licensee files or maintains a claim in a court
+		  asserting that a Necessary Claim is infringed by an Implementation,
+		  any licenses granted under this License to the Licensee are immediately terminated unless
+		  1) that claim is directly in response to a claim
+		  against Licensee regarding an Implementation, or
+		  2) that claim was brought to enforce the terms of this License,
+		  including intervention in a third-party action by a Licensee.
+		</item>
+		<item>
+		  <bullet>2.1.5.</bullet>
+		  Additional Conditions.
+		  This License is not an assurance
+		  (i) that any of Contributor's copyrights or issued patent claims
+		  cover an Implementation of the Specification or are enforceable or
+		  (ii) that an Implementation of the Specification would not infringe
+		  intellectual property rights of any third party.
+		</item>
+	      </list>
+	    </item>
+	    <item>
+	      <bullet>2.2.</bullet>
+	      Patent Licensing Commitment.
+	      In addition to the rights granted in Section 2.1,
+	      Contributor agrees to grant everyone a no charge, royalty-free license
+	      on reasonable and non-discriminatory terms to Contributor's Necessary Claims
+	      that are within Scope for:
+	      1) Implementations of a Draft Specification,
+	      where such license applies only to those Necessary Claims
+	      infringed by implementing Contributor's Contribution(s)
+	      included in that Draft Specification, and
+	      2) Implementations of the Approved Specification.
+	      This patent licensing commitment does not apply to those claims
+	      subject to Contributor's Exclusion Notice under Section 3.
+	    </item>
+	    <item>
+	      <bullet>2.3.</bullet>
+	      Effect of Withdrawal.
+	      Contributor may withdraw from the Working Group by issuing a pull request or commit
+	      providing notice of withdrawal to the Working Group repository's Notices.md file.
+	      All of Contributor's existing commitments and obligations
+	      with respect to the Working Group up to the date of that withdrawal notice
+	      will remain in effect, but no new obligations will be incurred.
+	    </item>
+	    <item>
+	      <bullet>2.4.</bullet>
+	      Binding Encumbrance.
+	      This License is binding on any future owner, assignee, or party
+	      who has been given the right to enforce any Necessary Claims against third parties.
+	    </item>
+	  </list>
+	</item>
+	<item>
+	  <bullet>3.</bullet>
+          Patent Exclusion.
+          <list>
+	    <item>
+	      <bullet>3.1.</bullet>
+	      As a Result of Contributions.
+	      Contributor may exclude Necessary Claims
+	      from its licensing commitments incurred under Section 2.1.1
+	      by issuing an Exclusion Notice within 45 days of the date of that Contribution.
+	      Contributor may not issue an Exclusion Notice for any material
+	      that has been included in a Draft Deliverable
+	      for more than 45 days prior to the date of that Contribution.
+	    </item>
+	    <item>
+	      <bullet>3.2.</bullet>
+	      As a Result of a Draft Specification Becoming an Approved Specification.
+	      Prior to the adoption of a Draft Specification as an Approved Specification,
+	      Contributor may exclude Necessary Claims
+	      from its licensing commitments under this Agreement
+	      by issuing an Exclusion Notice.
+	      Contributor may not issue an Exclusion Notice for patents
+	      that were eligible to have been excluded pursuant to Section 3.1.
+	    </item>
+	  </list>
+	</item>
+	<item>
+	  <bullet>4.</bullet>
+	  Source Code License.
+	  Any source code developed by the Working Group is solely subject
+	  the source code license included in the Working Group's repository for that code.
+	  If no source code license is included, the source code will be subject to the MIT License.
+	</item>
+	<item>
+	  <bullet>5.</bullet>
+	  No Other Rights.
+	  Except as specifically set forth in this License, no other express or implied
+	  patent, trademark, copyright, or other rights are granted under this License,
+	  including by implication, waiver, or estoppel.
+	</item>
+	<item>
+	  <bullet>6.</bullet>
+	  Antitrust Compliance.
+	  Contributor acknowledge that it may compete with other participants in various lines of business
+	  and that it is therefore imperative that they and their respective representatives act
+	  in a manner that does not violate any applicable antitrust laws and regulations.
+	  This License does not restrict any Contributor from engaging
+	  in similar specification development projects.
+	  Each Contributor may design, develop, manufacture, acquire or market
+	  competitive deliverables, products, and services, and conduct its business,
+	  in whatever way it chooses.
+	  No Contributor is obligated to announce or market any products or services.
+	  Without limiting the generality of the foregoing, the Contributors
+	  agree not to have any discussion relating to any product pricing,
+	  methods or channels of product distribution, division of markets,
+	  allocation of customers or any other topic that should not be discussed
+	  among competitors under the auspices of the Working Group.
+	</item>
+	<item>
+	  <bullet>7.</bullet>
+	  Non-Circumvention.
+	  Contributor agrees that it will not intentionally take or willfully assist any third party
+	  to take any action for the purpose of circumventing any obligations under this License.
+	</item>
+	<item>
+	  <bullet>8.</bullet>
+          Representations, Warranties and Disclaimers.
+          <list>
+	    <item>
+	      <bullet>8.1.</bullet>
+	      Representations, Warranties and Disclaimers.
+	      Contributor and Licensee represents and warrants that
+	      1) it is legally entitled to grant the rights set forth in this License and
+	      2) it will not intentionally include any third party materials in any Contribution
+	      unless those materials are available under terms that do not conflict with this License.
+	      IN ALL OTHER RESPECTS ITS CONTRIBUTIONS ARE PROVIDED "AS IS."
+	      The entire risk as to implementing or otherwise using the Contribution
+	      or the Specification is assumed by the implementer and user.
+	      Except as stated herein, CONTRIBUTOR AND LICENSEE EXPRESSLY DISCLAIM ANY WARRANTIES
+	      (EXPRESS, IMPLIED, OR OTHERWISE), INCLUDING IMPLIED WARRANTIES OF MERCHANTABILITY,
+	      NON-INFRINGEMENT, FITNESS FOR A PARTICULAR PURPOSE, CONDITIONS OF QUALITY,
+	      OR TITLE, RELATED TO THE CONTRIBUTION OR THE SPECIFICATION.
+	      IN NO EVENT WILL ANY PARTY BE LIABLE TO ANY OTHER PARTY FOR LOST PROFITS
+	      OR ANY FORM OF INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY CHARACTER
+	      FROM ANY CAUSES OF ACTION OF ANY KIND WITH RESPECT TO THIS AGREEMENT,
+	      WHETHER BASED ON BREACH OF CONTRACT, TORT (INCLUDING NEGLIGENCE), OR OTHERWISE,
+	      AND WHETHER OR NOT THE OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+	      Any obligations regarding the transfer, successors in interest,
+	      or assignment of Necessary Claims will be satisfied
+	      if Contributor or Licensee notifies the transferee or assignee of any patent
+	      that it knows contains Necessary Claims or necessary claims under this License.
+	      Nothing in this License requires Contributor to undertake a patent search.
+	      If Contributor is 1) employed by or acting on behalf of an employer,
+	      2) is making a Contribution under the direction or control of a third party, or
+	      3) is making the Contribution as a consultant, contractor,
+	      or under another similar relationship with a third party,
+	      Contributor represents that they have been authorized by that party
+	      to enter into this License on its behalf.
+	    </item>
+	    <item>
+	      <bullet>8.2.</bullet>
+	      Distribution Disclaimer.
+	      Any distributions of technical information to third parties must include
+	      a notice materially similar to the following:
+	      "THESE MATERIALS ARE PROVIDED "AS IS."
+	      The Contributors and Licensees expressly disclaim any warranties
+	      (express, implied, or otherwise), including implied warranties of merchantability,
+	      non-infringement, fitness for a particular purpose, or title, related to the materials.
+	      The entire risk as to implementing or otherwise using the materials
+	      is assumed by the implementer and user.
+	      IN NO EVENT WILL THE CONTRIBUTORS OR LICENSEES BE LIABLE TO ANY OTHER PARTY
+	      FOR LOST PROFITS OR ANY FORM OF INDIRECT, SPECIAL, INCIDENTAL,
+	      OR CONSEQUENTIAL DAMAGES OF ANY CHARACTER FROM ANY CAUSES OF ACTION OF ANY KIND
+	      WITH RESPECT TO THIS DELIVERABLE OR ITS GOVERNING AGREEMENT,
+	      WHETHER BASED ON BREACH OF CONTRACT, TORT (INCLUDING NEGLIGENCE), OR OTHERWISE,
+	      AND WHETHER OR NOT THE OTHER MEMBER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+	    </item>
+	  </list>
+	</item>
+	<item>
+	  <bullet>9.</bullet>
+          Definitions.
+          <list>
+	    <item>
+	      <bullet>9.1.</bullet>
+	      Affiliate.
+	      "Affiliate" means an entity that directly or indirectly Controls, is Controlled by, or
+	      is under common Control of that party.
+	    </item>
+	    <item>
+	      <bullet>9.2.</bullet>
+	      Approved Specification.
+	      "Approved Specification" means the final version and contents of any Draft Specification
+	      designated as an Approved Specification as set forth in the accompanying Governance.md file.
+	    </item>
+	    <item>
+	      <bullet>9.3.</bullet>
+	      Contribution.
+	      "Contribution" means any original work of authorship,
+	      including any modifications or additions to an existing work,
+	      that Contributor submits for inclusion in a Draft Specification,
+	      which is included in a Draft Specification or Approved Specification.
+	    </item>
+	    <item>
+	      <bullet>9.4.</bullet>
+	      Contributor.
+	      "Contributor" means any person or entity that has indicated its acceptance of the License
+	      1) by making a Contribution to the Specification, or
+	      2) by entering into the Community Specification Contributor License Agreement
+	      for the Specification.
+	      Contributor includes its Affiliates, assigns, agents, and successors in interest.
+	    </item>
+	    <item>
+	      <bullet>9.5.</bullet>
+	      Control.
+	      "Control" means direct or indirect control of more than 50% of the voting power
+	      to elect directors of that corporation, or for any other entity,
+	      the power to direct management of such entity.
+	    </item>
+	    <item>
+	      <bullet>9.6.</bullet>
+	      Draft Specification.
+	      "Draft Specification" means all versions of the material (except an Approved Specification)
+	      developed by this Working Group for the purpose of creating, commenting on,
+	      revising, updating, modifying, or adding to any document
+	      that is to be considered for inclusion in the Approved Specification.
+	    </item>
+	    <item>
+	      <bullet>9.7.</bullet>
+	      Exclusion Notice.
+	      "Exclusion Notice" means a written notice made by making a pull request or commit
+	      to the repository's Notices.md file that identifies patents that Contributor
+	      is excluding from its patent licensing commitments under this License.
+	      The Exclusion Notice for issued patents and published applications must include
+	      the Draft Specification's name, patent number(s) or title and application number(s),
+	      as the case may be, for each of the issued patent(s) or pending patent application(s)
+	      that the Contributor is excluding from the royalty-free licensing commitment
+	      set forth in this License.
+	      If an issued patent or pending patent application that may contain Necessary Claims
+	      is not set forth in the Exclusion Notice, those Necessary Claims shall continue
+	      to be subject to the licensing commitments under this License.
+	      The Exclusion Notice for unpublished patent applications must provide either:
+	      (i) the text of the filed application; or
+	      (ii) identification of the specific part(s) of the Draft Specification
+	      whose implementation makes the excluded claim a Necessary Claim.
+	      If (ii) is chosen, the effect of the exclusion will be limited
+	      to the identified part(s) of the Draft Specification.
+	    </item>
+	    <item>
+	      <bullet>9.8.</bullet>
+	      Implementation.
+	      "Implementation" means making, using, selling, offering for sale,
+	      importing or distributing any implementation of the Specification
+	      1) only to the extent it implements the Specification and
+	      2) so long as all required portions of the Specification are implemented.
+	    </item>
+	    <item>
+	      <bullet>9.9.</bullet>
+	      License.
+	      "License" means this Community Specification License.
+	    </item>
+	    <item>
+	      <bullet>9.10.</bullet>
+	      Licensee.
+	      "Licensee" means any person or entity that has indicated its acceptance of the License
+	      as set forth in Section 2.1.3.
+	      Licensee includes its Affiliates, assigns, agents, and successors in interest.
+	    </item>
+	    <item>
+	      <bullet>9.11.</bullet>
+	      Necessary Claims.
+	      "Necessary Claims" are those patent claims, if any, that a party owns or controls,
+	      including those claims later acquired, that are necessary to implement the required portions
+	      (including the required elements of optional portions) of the Specification
+	      that are described in detail and not merely referenced in the Specification.
+	    </item>
+	    <item>
+	      <bullet>9.12.</bullet>
+	      Specification.
+	      "Specification" means a Draft Specification or Approved Specification
+	      included in the Working Group's repository subject to this License,
+	      and the version of the Specification implemented by the Licensee.
+	    </item>
+	    <item>
+	      <bullet>9.13.</bullet>
+	      Scope.
+	      "Scope" has the meaning as set forth in the accompanying Scope.md file
+	      included in this Specification's repository.
+	      Changes to Scope do not apply retroactively.
+	      If no Scope is provided, each Contributor's Necessary Claims
+	      are limited to that Contributor's Contributions.
+	    </item>
+	    <item>
+	      <bullet>9.14.</bullet>
+	      Working Group.
+	      "Working Group" means this project to develop specifications, standards,
+	      best practices, guidelines, and other similar materials under this License.
+	    </item>
+	  </list>
+	</item>
+      </list>
+      <p>
+	The text of this Community Specification License is Copyright 2020 Joint Development Foundation
+	and is licensed under the Creative Commons Attribution 4.0 International License
+	available at https://creativecommons.org/licenses/by/4.0/.
+      </p>
+      <p>
+	SPDX-License-Identifier: CC-BY-4.0
+      </p>
+    </text>
+  </license>
+</SPDXLicenseCollection>

--- a/src/Community-Spec-1.0.xml
+++ b/src/Community-Spec-1.0.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isOsiApproved="false" licenseId="Community-Spec-1.0" name="Community Specification License 1.0">
+   <license isOsiApproved="false" licenseId="Community-Spec-1.0" listVersionAdded="3.15" name="Community Specification License 1.0">
+
       <crossRefs>
          <crossRef>https://github.com/CommunitySpecification/1.0/blob/master/1._Community_Specification_License-v1.md</crossRef>
       </crossRefs>

--- a/test/simpleTestForGenerator/Community-Spec-1.0.txt
+++ b/test/simpleTestForGenerator/Community-Spec-1.0.txt
@@ -1,0 +1,293 @@
+Community Specification License 1.0
+
+The Purpose of this License. This License sets forth the terms under which
+1) Contributor will participate in and contribute to the development
+of specifications, standards, best practices, guidelines, and other
+similar materials under this Working Group, and 2) how the materials
+developed under this License may be used. It is not intended for source
+code. Capitalized terms are defined in the License’s last section.
+
+1. Copyright.
+
+1.1. Copyright License. Contributor grants everyone a non-sublicensable,
+perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+(except as expressly stated in this License) copyright license, without
+any obligation for accounting, to reproduce, prepare derivative works
+of, publicly display, publicly perform, and distribute any materials
+it submits to the full extent of its copyright interest in those
+materials. Contributor also acknowledges that the Working Group may
+exercise copyright rights in the Specification, including the rights to
+submit the Specification to another standards organization.
+
+1.2. Copyright Attribution. As a condition, anyone exercising this
+copyright license must include attribution to the Working Group in any
+derivative work based on materials developed by the Working Group.
+That attribution must include, at minimum, the material’s name,
+version number, and source from where the materials were retrieved.
+Attribution is not required for implementations of the Specification.
+
+2. Patents.
+
+2.1. Patent License.
+
+2.1.1. As a Result of Contributions.
+
+2.1.1.1. As a Result of Contributions to Draft Specifications.
+Contributor grants Licensee a non-sublicensable, perpetual, worldwide,
+non-exclusive, no-charge, royalty-free, irrevocable (except as
+expressly stated in this License) license to its Necessary Claims in 1)
+Contributor’s Contributions and 2) to the Draft Specification that
+is within Scope as of the date of that Contribution, in both cases for
+Licensee’s Implementation of the Draft Specification, except for those
+patent claims excluded by Contributor under Section 3.
+
+2.1.1.2. For Approved Specifications. Contributor grants Licensee a
+non-sublicensable, perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable (except as expressly stated in this License)
+license to its Necessary Claims included the Approved Specification
+that are within Scope for Licensee’s Implementation of the Approved
+Specification, except for those patent claims excluded by Contributor
+under Section 3.
+
+2.1.2. Patent Grant from Licensee. Licensee grants each other Licensee
+a non-sublicensable, perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable (except as expressly stated in this License)
+license to its Necessary Claims for its Implementation, except for those
+patent claims excluded under Section 3.
+
+2.1.3. Licensee Acceptance. The patent grants set forth in Section 2.1
+extend only to Licensees that have indicated their agreement to this
+License as follows:
+
+2.1.3.1. Source Code Distributions. For distribution in source code,
+by including this License in the root directory of the source code with
+the Implementation;
+
+2.1.3.2. Non-Source Code Distributions. For distribution in any form
+other than source code, by including this License in the documentation,
+legal notices, via notice in the software, and/or other written materials
+provided with the Implementation; or
+
+2.1.3.3. Via Notices.md. By issuing pull request or commit to the
+Specification’s repository’s Notices.md file by the Implementer’s
+authorized representative, including the Implementer’s name, authorized
+individual and system identifier, and Specification version.
+
+2.1.4. Defensive Termination. If any Licensee files or maintains a
+claim in a court asserting that a Necessary Claim is infringed by an
+Implementation, any licenses granted under this License to the Licensee
+are immediately terminated unless 1) that claim is directly in response
+to a claim against Licensee regarding an Implementation, or 2) that claim
+was brought to enforce the terms of this License, including intervention
+in a third-party action by a Licensee.
+
+2.1.5. Additional Conditions. This License is not an assurance (i)
+that any of Contributor’s copyrights or issued patent claims cover
+an Implementation of the Specification or are enforceable or (ii) that
+an Implementation of the Specification would not infringe intellectual
+property rights of any third party.
+
+2.2. Patent Licensing Commitment. In addition to the rights granted
+in Section 2.1, Contributor agrees to grant everyone a no charge,
+royalty-free license on reasonable and non-discriminatory terms
+to Contributor’s Necessary Claims that are within Scope for:
+1) Implementations of a Draft Specification, where such license
+applies only to those Necessary Claims infringed by implementing
+Contributor's Contribution(s) included in that Draft Specification,
+and 2) Implementations of the Approved Specification.
+
+This patent licensing commitment does not apply to those claims subject
+to Contributor’s Exclusion Notice under Section 3.
+
+2.3. Effect of Withdrawal. Contributor may withdraw from the Working Group
+by issuing a pull request or commit providing notice of withdrawal to
+the Working Group repository’s Notices.md file. All of Contributor’s
+existing commitments and obligations with respect to the Working Group
+up to the date of that withdrawal notice will remain in effect, but no
+new obligations will be incurred.
+
+2.4. Binding Encumbrance. This License is binding on any future owner,
+assignee, or party who has been given the right to enforce any Necessary
+Claims against third parties.
+
+3. Patent Exclusion.
+
+3.1. As a Result of Contributions. Contributor may exclude Necessary
+Claims from its licensing commitments incurred under Section 2.1.1
+by issuing an Exclusion Notice within 45 days of the date of that
+Contribution. Contributor may not issue an Exclusion Notice for any
+material that has been included in a Draft Deliverable for more than 45
+days prior to the date of that Contribution.
+
+3.2. As a Result of a Draft Specification Becoming an Approved
+Specification. Prior to the adoption of a Draft Specification as an
+Approved Specification, Contributor may exclude Necessary Claims from
+its licensing commitments under this Agreement by issuing an Exclusion
+Notice. Contributor may not issue an Exclusion Notice for patents that
+were eligible to have been excluded pursuant to Section 3.1.
+
+4. Source Code License. Any source code developed by the Working Group is
+solely subject the source code license included in the Working Group’s
+repository for that code. If no source code license is included, the
+source code will be subject to the MIT License.
+
+5. No Other Rights. Except as specifically set forth in this License, no
+other express or implied patent, trademark, copyright, or other rights are
+granted under this License, including by implication, waiver, or estoppel.
+
+6. Antitrust Compliance. Contributor acknowledge that it may compete
+with other participants in various lines of business and that it is
+therefore imperative that they and their respective representatives
+act in a manner that does not violate any applicable antitrust laws and
+regulations. This License does not restrict any Contributor from engaging
+in similar specification development projects. Each Contributor may
+design, develop, manufacture, acquire or market competitive deliverables,
+products, and services, and conduct its business, in whatever way it
+chooses. No Contributor is obligated to announce or market any products
+or services. Without limiting the generality of the foregoing, the
+Contributors agree not to have any discussion relating to any product
+pricing, methods or channels of product distribution, division of markets,
+allocation of customers or any other topic that should not be discussed
+among competitors under the auspices of the Working Group.
+
+7. Non-Circumvention. Contributor agrees that it will not intentionally
+take or willfully assist any third party to take any action for the
+purpose of circumventing any obligations under this License.
+
+8. Representations, Warranties and Disclaimers.
+
+8.1. Representations, Warranties and Disclaimers. Contributor and Licensee
+represents and warrants that 1) it is legally entitled to grant the
+rights set forth in this License and 2) it will not intentionally include
+any third party materials in any Contribution unless those materials are
+available under terms that do not conflict with this License. IN ALL OTHER
+RESPECTS ITS CONTRIBUTIONS ARE PROVIDED "AS IS." The entire risk as to
+implementing or otherwise using the Contribution or the Specification
+is assumed by the implementer and user. Except as stated herein,
+CONTRIBUTOR AND LICENSEE EXPRESSLY DISCLAIM ANY WARRANTIES (EXPRESS,
+IMPLIED, OR OTHERWISE), INCLUDING IMPLIED WARRANTIES OF MERCHANTABILITY,
+NON-INFRINGEMENT, FITNESS FOR A PARTICULAR PURPOSE, CONDITIONS OF QUALITY,
+OR TITLE, RELATED TO THE CONTRIBUTION OR THE SPECIFICATION. IN NO EVENT
+WILL ANY PARTY BE LIABLE TO ANY OTHER PARTY FOR LOST PROFITS OR ANY
+FORM OF INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF
+ANY CHARACTER FROM ANY CAUSES OF ACTION OF ANY KIND WITH RESPECT TO
+THIS AGREEMENT, WHETHER BASED ON BREACH OF CONTRACT, TORT (INCLUDING
+NEGLIGENCE), OR OTHERWISE, AND WHETHER OR NOT THE OTHER PARTY HAS BEEN
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. Any obligations regarding
+the transfer, successors in interest, or assignment of Necessary Claims
+will be satisfied if Contributor or Licensee notifies the transferee
+or assignee of any patent that it knows contains Necessary Claims or
+necessary claims under this License. Nothing in this License requires
+Contributor to undertake a patent search. If Contributor is 1) employed by
+or acting on behalf of an employer, 2) is making a Contribution under the
+direction or control of a third party, or 3) is making the Contribution
+as a consultant, contractor, or under another similar relationship with
+a third party, Contributor represents that they have been authorized by
+that party to enter into this License on its behalf.
+
+8.2. Distribution Disclaimer. Any distributions of technical
+information to third parties must include a notice materially similar
+to the following: “THESE MATERIALS ARE PROVIDED “AS IS.” The
+Contributors and Licensees expressly disclaim any warranties (express,
+implied, or otherwise), including implied warranties of merchantability,
+non-infringement, fitness for a particular purpose, or title, related to
+the materials. The entire risk as to implementing or otherwise using the
+materials is assumed by the implementer and user. IN NO EVENT WILL THE
+CONTRIBUTORS OR LICENSEES BE LIABLE TO ANY OTHER PARTY FOR LOST PROFITS
+OR ANY FORM OF INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+OF ANY CHARACTER FROM ANY CAUSES OF ACTION OF ANY KIND WITH RESPECT TO
+THIS DELIVERABLE OR ITS GOVERNING AGREEMENT, WHETHER BASED ON BREACH OF
+CONTRACT, TORT (INCLUDING NEGLIGENCE), OR OTHERWISE, AND WHETHER OR NOT
+THE OTHER MEMBER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.”
+
+9. Definitions.
+
+9.1. Affiliate. “Affiliate” means an entity that directly or
+indirectly Controls, is Controlled by, or is under common Control of
+that party.
+
+9.2. Approved Specification. “Approved Specification” means the final
+version and contents of any Draft Specification designated as an Approved
+Specification as set forth in the accompanying Governance.md file.
+
+9.3. Contribution. “Contribution” means any original work of
+authorship, including any modifications or additions to an existing
+work, that Contributor submits for inclusion in a Draft Specification,
+which is included in a Draft Specification or Approved Specification.
+
+9.4. Contributor. “Contributor” means any person or entity that has
+indicated its acceptance of the License 1) by making a Contribution to
+the Specification, or 2) by entering into the Community Specification
+Contributor License Agreement for the Specification. Contributor includes
+its Affiliates, assigns, agents, and successors in interest.
+
+9.5. Control. “Control” means direct or indirect control of more
+than 50% of the voting power to elect directors of that corporation,
+or for any other entity, the power to direct management of such entity.
+
+9.6. Draft Specification. “Draft Specification” means all versions
+of the material (except an Approved Specification) developed by this
+Working Group for the purpose of creating, commenting on, revising,
+updating, modifying, or adding to any document that is to be considered
+for inclusion in the Approved Specification.
+
+9.7. Exclusion Notice. “Exclusion Notice” means a written notice
+made by making a pull request or commit to the repository’s Notices.md
+file that identifies patents that Contributor is excluding from its
+patent licensing commitments under this License. The Exclusion Notice
+for issued patents and published applications must include the Draft
+Specification’s name, patent number(s) or title and application
+number(s), as the case may be, for each of the issued patent(s) or
+pending patent application(s) that the Contributor is excluding from the
+royalty-free licensing commitment set forth in this License. If an issued
+patent or pending patent application that may contain Necessary Claims
+is not set forth in the Exclusion Notice, those Necessary Claims shall
+continue to be subject to the licensing commitments under this License.
+The Exclusion Notice for unpublished patent applications must provide
+either: (i) the text of the filed application; or (ii) identification
+of the specific part(s) of the Draft Specification whose implementation
+makes the excluded claim a Necessary Claim. If (ii) is chosen, the
+effect of the exclusion will be limited to the identified part(s) of
+the Draft Specification.
+
+9.8. Implementation. “Implementation” means making, using, selling,
+offering for sale, importing or distributing any implementation of the
+Specification 1) only to the extent it implements the Specification and 2)
+so long as all required portions of the Specification are implemented.
+
+9.9. License. “License” means this Community Specification License.
+
+9.10. Licensee. “Licensee” means any person or entity that has
+indicated its acceptance of the License as set forth in Section 2.1.3.
+Licensee includes its Affiliates, assigns, agents, and successors in
+interest.
+
+9.11. Necessary Claims. “Necessary Claims” are those patent claims, if
+any, that a party owns or controls, including those claims later acquired,
+that are necessary to implement the required portions (including the
+required elements of optional portions) of the Specification that are
+described in detail and not merely referenced in the Specification.
+
+9.12. Specification. “Specification” means a Draft Specification
+or Approved Specification included in the Working Group’s repository
+subject to this License, and the version of the Specification implemented
+by the Licensee.
+
+9.13. Scope. “Scope” has the meaning as set forth in the accompanying
+Scope.md file included in this Specification’s repository. Changes
+to Scope do not apply retroactively. If no Scope is provided, each
+Contributor’s Necessary Claims are limited to that Contributor’s
+Contributions.
+
+9.14. Working Group. “Working Group” means this project to develop
+specifications, standards, best practices, guidelines, and other similar
+materials under this License.
+
+
+
+The text of this Community Specification License is Copyright 2020
+Joint Development Foundation and is licensed under the Creative
+Commons Attribution 4.0 International License available at
+https://creativecommons.org/licenses/by/4.0/.
+
+SPDX-License-Identifier: CC-BY-4.0


### PR DESCRIPTION
This PR adds Community-Spec-1.0 (and the corresponding test text file).
Closes #1344.

Things to note:

- I've added an entry in the `notes` section, pointing to the supporting material, since they were mentioned in #1344.
- The licence text refers to different `.md` files (which are in the supporting material above). Most references seem to have no effect to the license itself, like references to `Notices.md` which lists patents.  However, *Scope* in the license is essentially defined as "look at the other file, `Scope.md`" and *Approved Specification* is also defined as "look at `Governance.md`." Maybe we should have a note that this license text cannot be used standalone, as it _requires_ extra files?
- When transcribing the text, I found two syntax errors. I've opened a [PR](https://github.com/CommunitySpecification/1.0/pull/5) towards the upstream repo about them. If it's merged, the text here must also be changed.
- Four-level deep nested lists are not fun... :unamused:

I apologize for misconstructions in this PR; I'm using the `gh` CLI for all the workflow and still learning...
