### PR TITLE
Update to version 2.2.3 of the LicenseListPublisher

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: CC0-1.0
 
-TOOL_VERSION = 2.2.2
+TOOL_VERSION = 2.2.3
 TEST_DATA = test/simpleTestForGenerator
 GIT_AUTHOR = License Publisher (maintained by Gary O'Neall) <gary@sourceauditor.com>
 GIT_AUTHOR_EMAIL = gary@sourceauditor.com

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: CC0-1.0
 
-TOOL_VERSION = 2.2.3
+TOOL_VERSION = 2.2.4
 TEST_DATA = test/simpleTestForGenerator
 GIT_AUTHOR = License Publisher (maintained by Gary O'Neall) <gary@sourceauditor.com>
 GIT_AUTHOR_EMAIL = gary@sourceauditor.com


### PR DESCRIPTION
See [LicenseListPublisher release](https://github.com/spdx/LicenseListPublisher/releases/tag/v2.2.3) for a full description of the changes.

Resolves issue #1323 

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>