### PR TITLE
Use generic copyright in Linux-man-pages-copyleft

### DIFF
--- a/test/simpleTestForGenerator/Linux-man-pages-copyleft.txt
+++ b/test/simpleTestForGenerator/Linux-man-pages-copyleft.txt
@@ -1,4 +1,4 @@
-Copyright (c) 0000, Obelix the Gaul <obelix@galia.org>.
+Copyright (c) <year> <owner> All rights reserved.
 
 Permission is granted to make and distribute verbatim copies of this
 manual provided the copyright notice and this permission notice are


### PR DESCRIPTION
This pull request is a follow-up to #1319. I remember that we discussed this at the last SPDX Legal Team meeting - much as we found the notice amusing, it might be confusing to those who use the text files in their applications' license files :)

@swinslow, any chance you could merge this for 3.15? Thank you!