### PR TITLE
Spencer-94 - add markup

### DIFF
--- a/src/Spencer-94.xml
+++ b/src/Spencer-94.xml
@@ -12,7 +12,7 @@
       <p>This software is not subject to any license of the American Telephone and Telegraph Company or of the
          Regents of the University of California.
       <br/>Permission is granted to anyone to use this software for any purpose on any computer system, and to alter it
-         and redistribute it, subject to the following restrictions:</p>
+         and redistribute it <optional>freely</optional>, subject to the following restrictions:</p>
       <list>
         <item>
             <bullet>1.</bullet>


### PR DESCRIPTION
in https://metacpan.org/dist/File-MMagic - this license appears but adds one word. 

I used the <optional> tag, but it'd be nice to be more exact perhaps, if that's possible with the replaceable tag?