### PR TITLE
BSD-3-Clause - remove "all rights reserved"

### DIFF
--- a/src/BSD-2-Clause.xml
+++ b/src/BSD-2-Clause.xml
@@ -7,7 +7,7 @@
       </crossRefs>
     <text>
       <copyrightText>
-         <p>Copyright (c) &lt;year&gt; &lt;owner&gt;. All rights reserved.
+         <p>Copyright (c) &lt;year&gt; &lt;owner&gt;. 
       </p>
       </copyrightText>
 

--- a/src/BSD-3-Clause.xml
+++ b/src/BSD-3-Clause.xml
@@ -7,7 +7,7 @@
       </crossRefs>
     <text>
       <copyrightText>
-        <p>Copyright (c) &lt;year&gt; &lt;owner&gt;. All rights reserved.</p>
+        <p>Copyright (c) &lt;year&gt; &lt;owner&gt;. </p>
       </copyrightText>
 
         <p>Redistribution and use in source and binary forms, with or without modification, are permitted provided

--- a/test/simpleTestForGenerator/BSD-2-Clause.txt
+++ b/test/simpleTestForGenerator/BSD-2-Clause.txt
@@ -1,4 +1,4 @@
-Copyright (c) <year> <owner> All rights reserved.
+Copyright (c) <year> <owner> 
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 

--- a/test/simpleTestForGenerator/BSD-3-Clause.txt
+++ b/test/simpleTestForGenerator/BSD-3-Clause.txt
@@ -1,4 +1,4 @@
-Copyright (c) <year> <owner>. All rights reserved.
+Copyright (c) <year> <owner>. 
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 


### PR DESCRIPTION
While this language doesn't have real significance, someone asked me about it and I noticed that it is now not showing on the OSI page for BSD-3-Clause - so might as well remove it here to.