### PR TITLE
Update LicenseListPublisher to version 2.2.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: CC0-1.0
 
-TOOL_VERSION = 2.2.4
+TOOL_VERSION = 2.2.5
 TEST_DATA = test/simpleTestForGenerator
 GIT_AUTHOR = License Publisher (maintained by Gary O'Neall) <gary@sourceauditor.com>
 GIT_AUTHOR_EMAIL = gary@sourceauditor.com


### PR DESCRIPTION
Very minor update to the LicenseListPublisher.  Primary change is
to update the log4j version to 2.17.0.  Previous version of log4j
has know security vulnerabilities.

Note - Although some security vulnerability checkers will report
a vulnerability for the LicenseListPublisher, it is very unlikely this vulnerability 
could be exploited based on the usage in license-list-XML CI process.

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>