### PR TITLE
Fixes #1349, adding Elastic-2.0 license

### DIFF
--- a/src/Elastic-2.0.xml
+++ b/src/Elastic-2.0.xml
@@ -8,7 +8,7 @@
       <notes>This license was released on February 3, 2021</notes>
     <text>
       <titleText>
-        <p>Elastic License</p>
+        <p>Elastic License 2.0</p>
       </titleText>
       <p>URL: https://www.elastic.co/licensing/elastic-license</p>
       <p>## Acceptance</p>

--- a/src/Elastic-2.0.xml
+++ b/src/Elastic-2.0.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SPDXLicenseCollection xmlns="http://www.spdx.org/license">
+   <license isOsiApproved="false" licenseId="Elastic-2.0" name="Elastic License 2.0">
+      <crossRefs>
+         <crossRef>https://www.elastic.co/licensing/elastic-license</crossRef>
+         <crossRef>https://github.com/elastic/elasticsearch/blob/master/licenses/ELASTIC-LICENSE-2.0.txt</crossRef>
+      </crossRefs>
+      <notes>This license was released on February 3, 2021</notes>
+    <text>
+      <titleText>
+        <p>Elastic License</p>
+      </titleText>
+      <p>URL: https://www.elastic.co/licensing/elastic-license</p>
+      <p>## Acceptance</p>
+      <p>By using the software, you agree to all of the terms and conditions below.</p>
+      <p>## Copyright License</p>
+      <p>
+        The licensor grants you a non-exclusive, royalty-free, worldwide,
+        non-sublicensable, non-transferable license to use, copy, distribute, make
+        available, and prepare derivative works of the software, in each case subject to
+        the limitations and conditions below.
+      </p>
+      <p>## Limitations</p>
+      <p>
+        You may not provide the software to third parties as a hosted or managed
+        service, where the service provides users with access to any substantial set of
+        the features or functionality of the software.
+      </p>
+      <p>
+        You may not move, change, disable, or circumvent the license key functionality
+        in the software, and you may not remove or obscure any functionality in the
+        software that is protected by the license key.
+      </p>
+      <p>
+        You may not alter, remove, or obscure any licensing, copyright, or other notices
+        of the licensor in the software. Any use of the licensor’s trademarks is subject
+        to applicable law.
+      </p>
+      <p>## Patents</p>
+      <p>
+        The licensor grants you a license, under any patent claims the licensor can
+        license, or becomes able to license, to make, have made, use, sell, offer for
+        sale, import and have imported the software, in each case subject to the
+        limitations and conditions in this license. This license does not cover any
+        patent claims that you cause to be infringed by modifications or additions to
+        the software. If you or your company make any written claim that the software
+        infringes or contributes to infringement of any patent, your patent license for
+        the software granted under these terms ends immediately. If your company makes
+        such a claim, your patent license ends immediately for work on behalf of your
+        company.
+      </p>
+      <p>## Notices</p>
+      <p>
+        You must ensure that anyone who gets a copy of any part of the software from you
+        also gets a copy of these terms.
+      </p>
+      <p>
+        If you modify the software, you must include in any modified copies of the
+        software prominent notices stating that you have modified the software.
+      </p>
+      <p>## No Other Rights</p>
+      <p>
+        These terms do not imply any licenses other than those expressly granted in
+        these terms.
+      </p>
+      <p>## Termination</p>
+      <p>
+        If you use the software in violation of these terms, such use is not licensed,
+        and your licenses will automatically terminate. If the licensor provides you
+        with a notice of your violation, and you cease all violation of this license no
+        later than 30 days after you receive that notice, your licenses will be
+        reinstated retroactively. However, if you violate these terms after such
+        reinstatement, any additional violation of these terms will cause your licenses
+        to terminate automatically and permanently.
+      </p>
+      <p>## No Liability</p>
+      <p>
+        *As far as the law allows, the software comes as is, without any warranty or
+        condition, and the licensor will not be liable to you for any damages arising
+        out of these terms or the use or nature of the software, under any kind of
+        legal claim.*
+      </p>
+      <p>## Definitions</p>
+      <p>
+        The **licensor** is the entity offering these terms, and the **software** is the
+        software the licensor makes available under these terms, including any portion
+        of it.
+      </p>
+      <p>**you** refers to the individual or entity agreeing to these terms.</p>
+      <p>
+        **your company** is any legal entity, sole proprietorship, or other kind of
+        organization that you work for, plus all organizations that have control over,
+        are under the control of, or are under common control with that
+        organization. **control** means ownership of substantially all the assets of an
+        entity, or the power to direct its management and policies by vote, contract, or
+        otherwise. Control can be direct or indirect.
+      </p>
+      <p>
+        **your licenses** are all the licenses granted to you for the software under
+        these terms.
+      </p>
+      <p>**use** means anything you do with the software requiring one of your licenses.</p>
+      <p>**trademark** means trademarks, service marks, and similar rights.</p>
+      <optional>
+         <standardLicenseHeader>
+           <p>Copyright [name of copyright owner].</p>
+           <p>Licensed under the Elastic License 2.0;</p>
+           <p>you may not use this file except in compliance with the Elastic License 2.0.</p>
+        </standardLicenseHeader>
+      </optional>
+    </text>
+  </license>
+</SPDXLicenseCollection>

--- a/src/Elastic-2.0.xml
+++ b/src/Elastic-2.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isOsiApproved="false" licenseId="Elastic-2.0" name="Elastic License 2.0">
+   <license isOsiApproved="false" licenseId="Elastic-2.0" name="Elastic License 2.0" listVersionAdded="3.16">
       <crossRefs>
          <crossRef>https://www.elastic.co/licensing/elastic-license</crossRef>
          <crossRef>https://github.com/elastic/elasticsearch/blob/master/licenses/ELASTIC-LICENSE-2.0.txt</crossRef>

--- a/src/Elastic-2.0.xml
+++ b/src/Elastic-2.0.xml
@@ -10,7 +10,7 @@
       <titleText>
         <p>Elastic License 2.0</p>
       </titleText>
-      <p>URL: https://www.elastic.co/licensing/elastic-license</p>
+      <optional><p>URL: https://www.elastic.co/licensing/elastic-license</p></optional>
       <p>## Acceptance</p>
       <p>By using the software, you agree to all of the terms and conditions below.</p>
       <p>## Copyright License</p>

--- a/src/Elastic-2.0.xml
+++ b/src/Elastic-2.0.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isOsiApproved="false" licenseId="Elastic-2.0" name="Elastic License 2.0" listVersionAdded="3.16">
-      <crossRefs>
-         <crossRef>https://www.elastic.co/licensing/elastic-license</crossRef>
-         <crossRef>https://github.com/elastic/elasticsearch/blob/master/licenses/ELASTIC-LICENSE-2.0.txt</crossRef>
-      </crossRefs>
-      <notes>This license was released on February 3, 2021</notes>
+  <license isOsiApproved="false" licenseId="Elastic-2.0" name="Elastic License 2.0" listVersionAdded="3.16">
+    <crossRefs>
+      <crossRef>https://www.elastic.co/licensing/elastic-license</crossRef>
+      <crossRef>https://github.com/elastic/elasticsearch/blob/master/licenses/ELASTIC-LICENSE-2.0.txt</crossRef>
+    </crossRefs>
+    <notes>This license was released on February 3, 2021</notes>
     <text>
       <titleText>
         <p>Elastic License 2.0</p>

--- a/src/Elastic-2.0.xml
+++ b/src/Elastic-2.0.xml
@@ -101,13 +101,6 @@
       </p>
       <p>**use** means anything you do with the software requiring one of your licenses.</p>
       <p>**trademark** means trademarks, service marks, and similar rights.</p>
-      <optional>
-         <standardLicenseHeader>
-           <p>Copyright [name of copyright owner].</p>
-           <p>Licensed under the Elastic License 2.0;</p>
-           <p>you may not use this file except in compliance with the Elastic License 2.0.</p>
-        </standardLicenseHeader>
-      </optional>
     </text>
   </license>
 </SPDXLicenseCollection>

--- a/test/simpleTestForGenerator/Elastic-2.0.txt
+++ b/test/simpleTestForGenerator/Elastic-2.0.txt
@@ -1,0 +1,93 @@
+Elastic License 2.0
+
+URL: https://www.elastic.co/licensing/elastic-license
+
+## Acceptance
+
+By using the software, you agree to all of the terms and conditions below.
+
+## Copyright License
+
+The licensor grants you a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute, make
+available, and prepare derivative works of the software, in each case subject to
+the limitations and conditions below.
+
+## Limitations
+
+You may not provide the software to third parties as a hosted or managed
+service, where the service provides users with access to any substantial set of
+the features or functionality of the software.
+
+You may not move, change, disable, or circumvent the license key functionality
+in the software, and you may not remove or obscure any functionality in the
+software that is protected by the license key.
+
+You may not alter, remove, or obscure any licensing, copyright, or other notices
+of the licensor in the software. Any use of the licensor’s trademarks is subject
+to applicable law.
+
+## Patents
+
+The licensor grants you a license, under any patent claims the licensor can
+license, or becomes able to license, to make, have made, use, sell, offer for
+sale, import and have imported the software, in each case subject to the
+limitations and conditions in this license. This license does not cover any
+patent claims that you cause to be infringed by modifications or additions to
+the software. If you or your company make any written claim that the software
+infringes or contributes to infringement of any patent, your patent license for
+the software granted under these terms ends immediately. If your company makes
+such a claim, your patent license ends immediately for work on behalf of your
+company.
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you
+also gets a copy of these terms.
+
+If you modify the software, you must include in any modified copies of the
+software prominent notices stating that you have modified the software.
+
+## No Other Rights
+
+These terms do not imply any licenses other than those expressly granted in
+these terms.
+
+## Termination
+
+If you use the software in violation of these terms, such use is not licensed,
+and your licenses will automatically terminate. If the licensor provides you
+with a notice of your violation, and you cease all violation of this license no
+later than 30 days after you receive that notice, your licenses will be
+reinstated retroactively. However, if you violate these terms after such
+reinstatement, any additional violation of these terms will cause your licenses
+to terminate automatically and permanently.
+
+## No Liability
+
+*As far as the law allows, the software comes as is, without any warranty or
+condition, and the licensor will not be liable to you for any damages arising
+out of these terms or the use or nature of the software, under any kind of
+legal claim.*
+
+## Definitions
+
+The **licensor** is the entity offering these terms, and the **software** is the
+software the licensor makes available under these terms, including any portion
+of it.
+
+**you** refers to the individual or entity agreeing to these terms.
+
+**your company** is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control over,
+are under the control of, or are under common control with that
+organization. **control** means ownership of substantially all the assets of an
+entity, or the power to direct its management and policies by vote, contract, or
+otherwise. Control can be direct or indirect.
+
+**your licenses** are all the licenses granted to you for the software under
+these terms.
+
+**use** means anything you do with the software requiring one of your licenses.
+
+**trademark** means trademarks, service marks, and similar rights.


### PR DESCRIPTION
Tests are passing locally, so I hope this is all good :)

```
./test-one-license Elastic-2.0                                                                                     22:55:16
gpg --verify --no-default-keyring --keyring ./goneall.gpg licenseListPublisher-2.2.5.jar.asc
gpg: assuming signed data in 'licenseListPublisher-2.2.5.jar'
gpg: Signature made So 26 Dez 22:20:49 2021 CET
gpg:                using RSA key 69B8E32E23138662
gpg: Good signature from "Gary O'Neall (GPG Key created on Aug 26 2016) <gary@sourceauditor.com>" [unknown]
gpg: WARNING: This key is not certified with a trusted signature!
gpg:          There is no indication that the signature belongs to the owner.
Primary key fingerprint: F06E 94A0 1B83 5825 E6AB  4DA3 69B8 E32E 2313 8662
echo Validating source files from src;
Validating source files from src
java -jar -DLocalFsfFreeJson=true -DlistedLicenseSchema="schema/ListedLicense.xsd" licenseListPublisher-2.2.5.jar LicenseRDFAGenerator 'src' '.tmp' 1.0 2000-01-01 test/simpleTestForGenerator expected-warnings
WARNING: sun.reflect.Reflection.getCallerClass is not supported. This will impact performance.
Processing License List.
Processing Exceptions
Writing table of contents
Completed processing licenses
```