### PR TITLE
Fix typo in PS/PDF font exception

### DIFF
--- a/src/exceptions/PS-or-PDF-font-exception-20170817.xml
+++ b/src/exceptions/PS-or-PDF-font-exception-20170817.xml
@@ -4,7 +4,7 @@
       <crossRefs>
         <crossRef>https://github.com/ArtifexSoftware/urw-base35-fonts/blob/65962e27febc3883a17e651cdb23e783668c996f/LICENSE</crossRef>
       </crossRefs>
-      <notes>Author-suggested standard header language recommends use with APGL-3.0</notes>
+      <notes>Author-suggested standard header language recommends use with AGPL-3.0</notes>
     <text>
       <optional>
         <p>The font and related files in this directory are distributed under the


### PR DESCRIPTION
The exception applies to the GNU Affero General Public License (AGPL) v3.0