### PR TITLE
Fix typo in PDDL

### DIFF
--- a/src/PDDL-1.0.xml
+++ b/src/PDDL-1.0.xml
@@ -326,7 +326,7 @@
         <item>
             <bullet>6.1</bullet>
           If any provision of this Document is held to be invalid or unenforceable, that must not affect
-             the cvalidity or enforceability of the remainder of the terms of this Document.
+             the validity or enforceability of the remainder of the terms of this Document.
         </item>
         <item>
             <bullet>6.2</bullet>

--- a/test/simpleTestForGenerator/PDDL-1.0.txt
+++ b/test/simpleTestForGenerator/PDDL-1.0.txt
@@ -127,7 +127,7 @@ Please note that some jurisdictions do not allow for the waiver of moral rights,
 
 6.0 General
 
-6.1 If any provision of this Document is held to be invalid or unenforceable, that must not affect the cvalidity or enforceability of the remainder of the terms of this Document.
+6.1 If any provision of this Document is held to be invalid or unenforceable, that must not affect the validity or enforceability of the remainder of the terms of this Document.
 
 6.2 This Document is the entire agreement between the parties with respect to the Work covered here. It replaces any earlier understandings, agreements or representations with respect to the Work not specified here.
 


### PR DESCRIPTION
This PR removes the letter "c" from the word "cvalidity" in Section 6.1 of the license text, that was not present in the license text at https://opendatacommons.org/licenses/pddl/1-0/.