### PR TITLE
KiCad-libraries-exception: Add note on base license

### DIFF
--- a/src/exceptions/KiCad-libraries-exception.xml
+++ b/src/exceptions/KiCad-libraries-exception.xml
@@ -3,6 +3,9 @@
     <crossRefs>
       <crossRef>https://www.kicad.org/libraries/license/</crossRef>
     </crossRefs>
+    <notes>
+      Typically used with CC-BY-SA-4.0
+    </notes>
     <text>
       <p>To the extent that the creation of electronic designs that use 'Licensed Material' can be considered to be 'Adapted Material', then the copyright holder waives article 3 of the license with respect to these designs and any generated files which use data provided as part of the 'Licensed Material'.</p>
     </text>


### PR DESCRIPTION
Several of the exceptions, where applicable, indicate in their "notes" section which license(s) they are typically used with. This PR adds a corresponding note for the newly-added exception KiCad-libraries-exception to indicate that it's intended for use with CC-BY-SA-4.0.

Signed-off-by: Steve Winslow <steve@swinslow.net>