### PR TITLE
APSL-2.0: add standard header markup

### DIFF
--- a/src/APSL-2.0.xml
+++ b/src/APSL-2.0.xml
@@ -413,6 +413,11 @@
          WARRANTIES, INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
          PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT. Please see the License for the specific language
          governing rights and limitations under the License."</p>
+			<standardLicenseHeader>
+				<p><optional spacing="none">"</optional>Portions Copyright (c) 1999-2007 Apple Inc. All Rights Reserved.</p>
+				<p>This file contains Original Code and/or Modifications of Original Code as defined in and that are subject to the Apple Public Source License Version 2.0 (the 'License'). You may not use this file except in compliance with the License. Please obtain a copy of the License at http://www.opensource.apple.com/apsl/ and read it before using this file.</p>
+				<p>The Original Code and all software distributed under the License are distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES, INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT. Please see the License for the specific language governing rights and limitations under the License.</p>
+			</standardLicenseHeader>
       </optional>
     </text>
   </license>


### PR DESCRIPTION
added the Standard License Header for APSL-2.0