### PR TITLE
Update to use licenseListPublisher version 2.2.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: CC0-1.0
 
-TOOL_VERSION = 2.2.5
+TOOL_VERSION = 2.2.6
 TEST_DATA = test/simpleTestForGenerator
 GIT_AUTHOR = License Publisher (maintained by Gary O'Neall) <gary@sourceauditor.com>
 GIT_AUTHOR_EMAIL = gary@sourceauditor.com


### PR DESCRIPTION
Resolves https://github.com/spdx/LicenseListPublisher/issues/127

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>