### PR TITLE
Add markup to mpich2

### DIFF
--- a/src/mpich2.xml
+++ b/src/mpich2.xml
@@ -10,15 +10,22 @@
       </copyrightText>
 
       <p>The following is a notice of limited availability of the code, and disclaimer which must be included in
-         the prologue of the code and in all source listings of the code.</p>
-      <p>Copyright Notice
-        <br/>+ 2002 University of Chicago
-      </p>
+	      the prologue of the code and in all source listings of the code.</p>
+      <copyrightText>
+	      <p>Copyright Notice</p>
+	      <p>1998--2020, Argonne National Laboratory</p>
+      </copyrightText>
       <p>Permission is hereby granted to use, reproduce, prepare derivative works, and to redistribute to others.
          This software was authored by:</p>
-      <p><alt match=".+" name="author">Argonne National Laboratory Group W. Gropp: (630) 252-4318; FAX: (630) 252-5986; e-mail:
-         gropp@mcs.anl.gov E. Lusk: (630) 252-7852; FAX: (630) 252-5986; e-mail: lusk@mcs.anl.gov Mathematics
-         and Computer Science Division Argonne National Laboratory, Argonne IL 60439</alt></p>
+      <alt match=".+" name="author">
+	 <p>Mathematics and Computer Science Division</p>
+	 <p>Argonne National Laboratory, Argonne IL 60439</p>
+
+	 <p>(and)</p>
+
+	 <p>Department of Computer Science</p>
+	 <p>University of Illinois at Urbana-Champaign</p>
+      </alt>
       <p>GOVERNMENT LICENSE</p>
       <p>Portions of this material resulted from work developed under a U.S. Government Contract and are subject
          to the following license: the Government is granted for itself and others acting on its behalf a

--- a/src/mpich2.xml
+++ b/src/mpich2.xml
@@ -16,9 +16,9 @@
       </p>
       <p>Permission is hereby granted to use, reproduce, prepare derivative works, and to redistribute to others.
          This software was authored by:</p>
-      <p>Argonne National Laboratory Group W. Gropp: (630) 252-4318; FAX: (630) 252-5986; e-mail:
+      <p><alt match=".+" name="author">Argonne National Laboratory Group W. Gropp: (630) 252-4318; FAX: (630) 252-5986; e-mail:
          gropp@mcs.anl.gov E. Lusk: (630) 252-7852; FAX: (630) 252-5986; e-mail: lusk@mcs.anl.gov Mathematics
-         and Computer Science Division Argonne National Laboratory, Argonne IL 60439</p>
+         and Computer Science Division Argonne National Laboratory, Argonne IL 60439</alt></p>
       <p>GOVERNMENT LICENSE</p>
       <p>Portions of this material resulted from work developed under a U.S. Government Contract and are subject
          to the following license: the Government is granted for itself and others acting on its behalf a

--- a/test/simpleTestForGenerator/mpich2.txt
+++ b/test/simpleTestForGenerator/mpich2.txt
@@ -3,11 +3,17 @@ COPYRIGHT
 The following is a notice of limited availability of the code, and disclaimer which must be included in the prologue of the code and in all source listings of the code.
 
 Copyright Notice
-+ 2002 University of Chicago
+1998--2020, Argonne National Laboratory
 
 Permission is hereby granted to use, reproduce, prepare derivative works, and to redistribute to others. This software was authored by:
 
-Argonne National Laboratory Group W. Gropp: (630) 252-4318; FAX: (630) 252-5986; e-mail: gropp@mcs.anl.gov E. Lusk: (630) 252-7852; FAX: (630) 252-5986; e-mail: lusk@mcs.anl.gov Mathematics and Computer Science Division Argonne National Laboratory, Argonne IL 60439
+Mathematics and Computer Science Division
+Argonne National Laboratory, Argonne IL 60439
+
+(and)
+
+Department of Computer Science
+University of Illinois at Urbana-Champaign
 
 GOVERNMENT LICENSE
 


### PR DESCRIPTION
Replaces mpich2 portion of #1554 

Something about the original notice language didn't like being included within an `<alt>` tag for some reason, so replacing it with another example notice from use in the wild.

Signed-off-by: Steve Winslow <steve@swinslow.net>