### PR TITLE
Conforming edits for main branch name change

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,7 +1,7 @@
 on: 
   push:
     branches:
-      - master
+      - main
     tags:
       - "*"
 jobs:

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -2,7 +2,7 @@ on:
   pull_request:
   workflow_dispatch:
   push:
-    branches-ignore: master
+    branches-ignore: main
 jobs:
   validate_schema:
     name: Validate schema

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Please familiarize yourself with the SPDX License List and its supporting docume
 
 The SPDX License List is maintained by the SPDX Legal Team. Work and discussion is primarily done via:
 * **join the mailing list**: Please introduce yourself and let us know a bit about your interest in SPDX! The mailing list is our traditional form of communication. Join the mailing list, see archive, and manage your subscription at [lists.spdx.org](https://lists.spdx.org/g/Spdx-legal).
-* **join the bi-weekly calls**: Bi-weekly conference call info is sent prior to the calls via the mailing list. If you join the mailing list, you should get a recurring invite at the beginning of each calendar year. Meeting minutes for the calls are in the [SPDX meetings repo](https://github.com/spdx/meetings/tree/master/legal); historical meeting minutes can be found at http://wiki.spdx.org/
+* **join the bi-weekly calls**: Bi-weekly conference call info is sent prior to the calls via the mailing list. If you join the mailing list, you should get a recurring invite at the beginning of each calendar year. Meeting minutes for the calls are in the [SPDX meetings repo](https://github.com/spdx/meetings/tree/main/legal); historical meeting minutes can be found at http://wiki.spdx.org/
 
 # Getting started 
 Below are some ways you can get started participating and contributing!
@@ -21,11 +21,11 @@ Below are some ways you can get started participating and contributing!
 
 * Make suggestions to improvement for documentation: Newcomers have a great perspective as to the effectiveness of documentation! You can make suggestions via an issue, if you want to discuss the changes or if there is something specific that could be updated, then create a PR
 
-* Help prepare files for licenses approved to be added to the SPDX License List by following the [new license workflow](https://github.com/spdx/license-list-XML/blob/master/DOCS/new-license-workflow.md)
+* Help prepare files for licenses approved to be added to the SPDX License List by following the [new license workflow](https://github.com/spdx/license-list-XML/blob/main/DOCS/new-license-workflow.md)
 
 * Review PRs 
 
-* Request a new license be added to the SPDX License List by following the [request new license](https://github.com/spdx/license-list-XML/blob/master/DOCS/request-new-license.md) instructions
+* Request a new license be added to the SPDX License List by following the [request new license](https://github.com/spdx/license-list-XML/blob/main/DOCS/request-new-license.md) instructions
 
 * Email the [mailing list](https://lists.spdx.org/g/spdx-legal) about how you are using or questions about the SPDX License List 
 * Recommend additional markup for matching purposes

--- a/DOCS/faq.md
+++ b/DOCS/faq.md
@@ -150,7 +150,7 @@ expression: `Apache-2.0 AND MIT AND GPL-2.0`.
 ### <span id="request"></span>How do I request adding a license to SPDX License List?
 
 Follow the instructions here:
-https://github.com/spdx/license-list-XML/blob/master/CONTRIBUTING.md
+https://github.com/spdx/license-list-XML/blob/main/CONTRIBUTING.md
 
 ##### <a href="#top"> Back to Top</a>
 

--- a/DOCS/git-usage.md
+++ b/DOCS/git-usage.md
@@ -48,9 +48,9 @@ After all of this is done, you should be all set to start adding new licenses.
 
 For the following steps, we'll assume that you're adding a new license called the XYZ license.
 
-1. In the terminal, make sure you're starting on the master branch, and that it's up to date with the upstream's master:
-  * **Change to the master branch**: `git checkout master`
-  * **Pull in any updates from upstream**: `git pull upstream master`
+1. In the terminal, make sure you're starting on the main branch, and that it's up to date with the upstream's main:
+  * **Change to the main branch**: `git checkout main`
+  * **Pull in any updates from upstream**: `git pull upstream main`
 2. Now that it's synced with upstream, you'll create a branch into which you'll commit your changes. I'm calling it "xyz" here for the new license, but you can name it anything unique.
   * **Create new branch**: `git checkout -b xyz`
 3. When the new branch is created, git will also automatically change it so that the new branch is your working branch. You can type `git status` to see your current working branch: ![screenshot from typing `git status` on clean repo](/DOCS/images/git-usage-git-status-clean.png)
@@ -64,10 +64,10 @@ For the following steps, we'll assume that you're adding a new license called th
 8. Next, you'll "commit" the changes, which actually inserts them into your local branch:
   * **Commit the files**: `git commit -m "Add XYZ license"`
   * In the commit command, the `-m` flag lets you add a one-line message to the commit. If you omit `-m` and the quoted message, it will take you to a text editor where you can type a longer message.
-9. At this point, your local copy of the "xyz" branch is 1 commit ahead of the "master" branch, because you've created and inserted the commit with these files into the xyz branch. The next thing you'll do is push the "xyz" branch up to your personal repo on GitHub:
+9. At this point, your local copy of the "xyz" branch is 1 commit ahead of the "main" branch, because you've created and inserted the commit with these files into the xyz branch. The next thing you'll do is push the "xyz" branch up to your personal repo on GitHub:
   * **Push to personal (origin) repo on GitHub**: `git push origin xyz`
   * If you go to your personal GitHub repo, it will alert to you that the branch was pushed: ![screenshot of pushed branch on GitHub UI](/DOCS/images/git-usage-push-ui.png)
-10. Finally, the last step is to create a Pull Request from the "xyz" branch in your personal repo, into the "master" branch in the main upstream repo:
+10. Finally, the last step is to create a Pull Request from the "xyz" branch in your personal repo, into the "main" branch in the main upstream repo:
   * **Initiate the pull request**: click the "Compare and pull request" button shown above
   * From there, it will show you the same Pull Request editor screen that you've seen before in the GitHub UI. Edit the PR message if desired, and when you're ready, click "Create pull request".
 

--- a/DOCS/new-license-workflow.md
+++ b/DOCS/new-license-workflow.md
@@ -35,7 +35,7 @@
     2. If it’s a case that additional markup would create match, then may want to discuss with legal team to ensure markup is non-substantive or differences in text do not alter legal meaning (if so, this cuts towards adding a new license). For more on this see the [Matching Guidelines](https://spdx.org/spdx-license-list/matching-guidelines), guideline #2 in particular.
     3. If additional markup can accommodate the license, then the license does not need to be added: inform the requester, comment on the issue as such, then create a PR for the existing license with the additional markup, and close issue once the PR has been merged.
 3. If the submitter is not the license author or steward, ask for that contact or try to find that person or organization to make them aware the license has been submitted.
-4. Check the submission for any other missing information, e.g., working URL, examples of use, full text, standard header, etc. You can find the field definitions in the [DOCS/license-fields](https://github.com/spdx/license-list-XML/blob/master/DOCS/license-fields.md) document.
+4. Check the submission for any other missing information, e.g., working URL, examples of use, full text, standard header, etc. You can find the field definitions in the [DOCS/license-fields](https://github.com/spdx/license-list-XML/blob/main/DOCS/license-fields.md) document.
 Ask the submitter for any additional info needed, preferably via the GitHub issue, if possible. Record any updates there.
     1. The "standard header" or "official license header" is defined in section 1.1.1 of the [SPDX Matching Guidelines](https://spdx.github.io/spdx-spec/appendix-II-license-matching-guidelines-and-templates/) as "specific text specified within the license itself to be put in the header of files."
 5. Review the following, bring any questions to legal team:
@@ -176,7 +176,7 @@ If you don't feel like a cup of tea right now, you can run the `make validate-ca
 
 ### Handling Duplicate Licenses
 
-The CI/CD pipeline will fail if it detects an existing license with matching license text.  If this occurs, manually review the duplicate license.  If this is expected (e.g. if the duplicate license is a deprecated version of the same license), add the following to the [expected-warnings](https://github.com/spdx/license-list-XML/blob/master/expected-warnings) file:
+The CI/CD pipeline will fail if it detects an existing license with matching license text.  If this occurs, manually review the duplicate license.  If this is expected (e.g. if the duplicate license is a deprecated version of the same license), add the following to the [expected-warnings](https://github.com/spdx/license-list-XML/blob/main/expected-warnings) file:
 
 ```
 ,"Duplicates licenses: DUPLICATE_LICENSE_ID, MY_LICENSE_ID","Duplicates licenses: MY_LICENSE_ID, DUPLICATE_LICENSE_ID"
@@ -210,7 +210,7 @@ The [SPDX Online tools](https://tools.spdx.org/) are an option for editing the X
     1. The current XML output does not implement some of XML tagging and may mark every new line with a paragraph tag depending on input. If this has happened, it may be more efficient to re-submit the license text, using a wrapped text version.
     2. Make sure to include listVersionAdded= and the correct license list version number for the upcoming release
     3. Check for a standard license header
-    4. Check if any notes should be added (see the field description in the [DOCS/license-fields](https://github.com/spdx/license-list-XML/blob/master/DOCS/license-fields.md) document for more information)
+    4. Check if any notes should be added (see the field description in the [DOCS/license-fields](https://github.com/spdx/license-list-XML/blob/main/DOCS/license-fields.md) document for more information)
     5. Check that we have a working URL for the license text in the wild. If using a link in GitHub, include a link to a specific commit
     6. Check all the XML formatting: the current XML output does not insert the bullet or list tags. Use a previously submitted license as reference for how to format
     7. If you have questions about text that could be optional or could be replaceable, add a comment to the PR, once made or add a reviewer to check it


### PR DESCRIPTION
This commit makes some conforming edits for the renaming of the
"master" branch to "main". In particular it updates the GitHub
workflow files to pull from the main branch.

Fixes #1403

Signed-off-by: Steve Winslow <steve@swinslow.net>