### PR TITLE
Fix Alt regular expression in HPND

### DIFF
--- a/src/HPND.xml
+++ b/src/HPND.xml
@@ -40,7 +40,7 @@
       <optional>
         <p>
             <alt match=".*" name="copyrightHolder2">&lt;copyright holder&gt;</alt> DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE, INCLUDING
-           ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS<alt match="[.,]?" name="period">.</alt> IN NO EVENT SHALL
+           ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS<alt match="[.,]*" name="period">.</alt> IN NO EVENT SHALL
            <alt match=".*" name="copyrightHolder3">&lt;copyright holder&gt;</alt> BE LIABLE FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES
            OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
            NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.</p>


### PR DESCRIPTION
The current `<alt match ... name="period">` has an incorrect regex that will not match the pattern `.,` which is present in the test file.  This will cause test failures once the LicenseListPublisher is updated with https://github.com/spdx/Spdx-Java-Library/pull/97