### PR TITLE
Remove extraneous line at the end of the fair text file

### DIFF
--- a/test/simpleTestForGenerator/Fair.txt
+++ b/test/simpleTestForGenerator/Fair.txt
@@ -5,5 +5,3 @@ Fair License
 Usage of the works is permitted provided that this instrument is retained with the works, so that any entity that uses the works is notified of this instrument.
 
 DISCLAIMER: THE WORKS ARE WITHOUT WARRANTY.
-
-[2004, Fair License: rhid.com/fair (this URL no longer works)]


### PR DESCRIPTION
An extra line present in the test file.  This will cause test failures once the LicenseListPublisher is updated with https://github.com/spdx/Spdx-Java-Library/pull/97