### PR TITLE
Fix APSL-2.0 exhibit text to match test code

### DIFF
--- a/src/APSL-2.0.xml
+++ b/src/APSL-2.0.xml
@@ -404,7 +404,7 @@
       <optional>
          <p>EXHIBIT A.</p>
          <standardLicenseHeader>
-         <p><optional spacing="none">"</optional> Copyright (c) 1999-2007 Apple Inc. All Rights Reserved.</p>
+         <p><optional spacing="none">"</optional>Portions Copyright (c) 1999-2007 Apple Inc. All Rights Reserved.</p>
          <p>This file contains Original Code and/or Modifications of Original Code as defined in and that are subject
          to the Apple Public Source License Version 2.0 (the 'License'). You may not use this file
          except in compliance with the License. Please obtain a copy of the License at


### PR DESCRIPTION
This was not caught previously due to an issue with the LicenseListPublisher.