### PR TITLE
Fix matching problem for APL-1.0.xml

### DIFF
--- a/src/APL-1.0.xml
+++ b/src/APL-1.0.xml
@@ -812,7 +812,7 @@
 	           <item>
 	              <bullet>PART 1:</bullet> INITIAL CONTRIBUTOR AND DESIGNATED WEB SITE
 <p>The Initial Contributor is: <br/>
-________________________________________________ <br/>
+____________________________________________________ <br/>
 [Enter full name of Initial Contributor]<br/>
                </p>
                <p>
@@ -824,7 +824,7 @@ ________________________________________________ <br/>
                </p>
                <p>
 The Designated Web Site is: <br/>
-________________________________________________ <br/>
+__________________________________________________ <br/>
 [Enter URL for Designated Web Site of Initial Contributor]<br/>
                </p>
                <p>NOTE: The Initial Contributor is to complete this Part 1, along with Parts 2, 3, and 5, and, if


### PR DESCRIPTION
Match the number of underscores to the test file for the form included in this license.

Note - we may want to update the license matching guidelines and the license matching software to cover this case. 

As an alternative to this PR, we could create an `alt` tag with any number of underscores.  If someone wants to take this on, please submit a PR and I'll close this one.

Note: once we update the licenseListPublisher for the Github actions, this license will fail the comparison test if this PR (or alternative) is not merged.