### PR TITLE
Fix matching error to original license for CPAL-1.0

### DIFF
--- a/src/CPAL-1.0.xml
+++ b/src/CPAL-1.0.xml
@@ -612,7 +612,7 @@
         <br/>Software distributed under the License is distributed on an "AS IS" basis, WITHOUT
              WARRANTY OF ANY KIND, either express or implied. See the License for the specific language
              governing rights and limitations under the License.
-        <br/>The Original Code is <alt name="code" match=".+">______________________</alt>.
+        <br/>The Original Code <alt name="code" match=".+">is______________________</alt>.
         <br/>The Original Developer is not the Initial Developer and is <alt name="originalDeveloper" match=".+">__________</alt>. If left blank, the Original
              Developer is the Initial Developer.
         <br/>The Initial Developer of the Original Code is <alt name="initialDeveloper" match=".+">____________</alt>. All portions of the code written by


### PR DESCRIPTION
There is no space before the underscores in the original code for the line `The Original Code is___`.  This PR will allow matches for either no space or a space between the `is` and the underscores.

Note that once the next release of the LicenseListPublisher is used for checking, a match failure will occur if this PR is not merged.