### PR TITLE
Remove extraneous > from MPL-2.0-no-copyleft-exception

### DIFF
--- a/src/MPL-2.0-no-copyleft-exception.xml
+++ b/src/MPL-2.0-no-copyleft-exception.xml
@@ -468,7 +468,7 @@
          <p>You may add additional accurate notices of copyright ownership.</p>
          <p>Exhibit B - "Incompatible With Secondary Licenses" Notice</p>
          <optional><p>---------------------------------------------------------</p></optional>
-         <standardLicenseHeader>>
+         <standardLicenseHeader>
 	 <p>This Source Code Form is "Incompatible With Secondary Licenses", as defined by the Mozilla
          Public License, v. 2.0.</p>
          </standardLicenseHeader>


### PR DESCRIPTION
Note that this was not flagged previously due to an issue in the LicenseListPublisher.