### PR TITLE
Fix OSET-PL-2.1 matching issue

### DIFF
--- a/src/OSET-PL-2.1.xml
+++ b/src/OSET-PL-2.1.xml
@@ -610,7 +610,7 @@
        <optional>
               <p>EXHIBIT A - Source Code Form License Notice</p>
               <p>This Source Code Form is subject to the terms of the OSET Public
-        	      License, v.2.1 ("OPL").
+        	      License, v.2.1 ("OSET-PL-2.1").
         	      If a copy of the OPL was not distributed with this file,
         	      You can obtain one at: www.OSETFoundation.org/public-license.</p>
               <p>If it is not possible or desirable to put the Notice in a


### PR DESCRIPTION
Correct the OSET-PL license reference on line 613 of the XML file.

Changes `License, v.2.1 ("OPL").` to `License, v.2.1 ("OSET-PL-2.1").`

Note that this was not caught previously due to an issue in the LicenseListPublisher.