### PR TITLE
Match test text or SPL-1.0

### DIFF
--- a/src/SPL-1.0.xml
+++ b/src/SPL-1.0.xml
@@ -500,7 +500,7 @@
          http://www.sun.com/</p>
          <p>The Original Code is <alt name="code" match=".+">_________________</alt>.
          The Initial Developer of the Original Code is <alt name="initialDeveloper" match=".+">___________</alt>.
-         Portions created by <alt name="createdBy" match=".+">______</alt> are Copyright (C) <alt name="copyright" match=".+">_________</alt>.
+         Portions created by <alt name="createdBy" match=".+">______</alt> are Copyright <alt name="copyright" match=".+">(C)_________</alt>.
          All Rights Reserved.</p>
          <p>Contributor(s): <alt name="contributor" match=".+">______________________________________</alt>.</p>
          <p>Alternatively, the contents of this file may be used under the terms of the <alt name="altLicense" match=".+">_____ license</alt> (the <alt name="altLicenseShort1" match=".+">?[___] License?</alt>), in which case the provisions of <alt name="altLicenseShort2" match=".+">[______]</alt> License are applicable instead of those above. If


### PR DESCRIPTION
Allow matching to the original text by allowing no spaces between `(C)` and the underscores on line 503.

Note that this PR needs to be merged before the next release of the LicenseListPublisher which resolves an issue where we didn't flag errors in the XML if it was the last optional text.