### PR TITLE
Remove extraneous comma from SugarCrM-1.1.3

### DIFF
--- a/src/SugarCRM-1.1.3.xml
+++ b/src/SugarCRM-1.1.3.xml
@@ -443,7 +443,7 @@
         <list>
             <item>
                 <bullet>I.</bullet>
-                Effect.,
+                Effect.
                 <p>These additional terms described in this SugarCRM Public License - Additional Terms shall
                  apply to the Covered Code under this License.</p>
             </item>


### PR DESCRIPTION
Note that this will cause the CI to fail once the next release of the LicenseListPublisher is released.
