### PR TITLE
Add optional text to the end of SSPL-1.0

### DIFF
--- a/src/SSPL-1.0.xml
+++ b/src/SSPL-1.0.xml
@@ -252,7 +252,12 @@ IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY C
                     <p>
 If the disclaimer of warranty and limitation of liability provided above cannot be given local legal effect according to their terms, reviewing courts shall apply local law that most closely approximates an absolute waiver of all civil liability in connection with the Program, unless a warranty or assumption of liability accompanies a copy of the Program in return for a fee.</p>
                 </item>
-            </list>
+              </list>
+              <optional>
+                <p>
+                  END OF TERMS AND CONDITIONS
+                </p>
+              </optional>
         </text>
     </license>
 </SPDXLicenseCollection>


### PR DESCRIPTION
This commit adds an optional section to the XML for SSPL-1.0 containing a paragraph present in the authoritative copy of the license, resolving GitHub issue https://github.com/spdx/license-list-XML/issues/1591.

Signed-off-by: Sebastian Crane <seabass-labrax@gmx.com>