### PR TITLE
Replace GPL-2.0+ by GPL-2.0-or-later.

### DIFF
--- a/src/exceptions/GCC-exception-2.0.xml
+++ b/src/exceptions/GCC-exception-2.0.xml
@@ -4,7 +4,7 @@
       <crossRefs>
          <crossRef>https://gcc.gnu.org/git/?p=gcc.git;a=blob;f=gcc/libgcc1.c;h=762f5143fc6eed57b6797c82710f3538aa52b40b;hb=cb143a3ce4fb417c68f5fa2691a1b1b1053dfba9#l10</crossRef>
       </crossRefs>
-      <notes>Typically used with GPL-2.0+.  Sometimes also referred to a
+      <notes>Typically used with GPL-2.0-or-later.  Sometimes also referred to a
          "linking exception."
   </notes>
     <text>


### PR DESCRIPTION
Replace deprecated license GPL-2.0+ by GPL-2.0-or-later.

Partial fix for #1662

Signed-off-by: Marc-Etienne Vargenau <marc-etienne.vargenau@nokia.com>