### PR TITLE
Improve notes for `GPL-x.0-only` and `GPL-x.0-or-later`

### DIFF
--- a/src/GPL-1.0-only.xml
+++ b/src/GPL-1.0-only.xml
@@ -29,7 +29,7 @@
       to use the code under GPL-1.0-only, as distinguished from the use of code under GPL-1.0-or-later
       (i.e., GPL-1.0 or some later version). The license notice (as seen in the Standard License
       Header field below) states which of these applies to the code in the file. The example
-      in the How to Apply These Terms section of the license shows the "or later" approach.
+      in the How to Apply These Terms appendix of the license shows the "or later" approach.
     </notes>
     <text>
     <titleText>

--- a/src/GPL-1.0-only.xml
+++ b/src/GPL-1.0-only.xml
@@ -26,11 +26,10 @@
     </standardLicenseHeader>
     <notes>
       This license was released: February 1989. This license identifier refers to the choice
-      to use the code under GPL-1.0-only, as distinguished from use of code under GPL-1.0-or-later
+      to use the code under GPL-1.0-only, as distinguished from the use of code under GPL-1.0-or-later
       (i.e., GPL-1.0 or some later version). The license notice (as seen in the Standard License
-      Header field below)  states which of these applies to the code in the file. The example
-      in the exhibit to the license shows the license notice for the "or later" approach.
-
+      Header field below) states which of these applies to the code in the file. The example
+      in the How to Apply These Terms section of the license shows the "or later" approach.
     </notes>
     <text>
     <titleText>

--- a/src/GPL-1.0-or-later.xml
+++ b/src/GPL-1.0-or-later.xml
@@ -8,10 +8,10 @@
     <notes>
       This license was released: February 1989. This license identifier refers to the
       choice to use code under GPL-1.0-or-later (i.e., GPL-1.0 or some later version),
-      as distinguished from use of code under GPL-1.0-only. The license notice (as seen
-      in the Standard License Header field below)  states which of these applies
-      the code in the file. The example in the exhibit to the license shows the license
-      notice for the "or later" approach.
+      as distinguished from the use of code under GPL-1.0-only. The license notice (as seen
+      in the Standard License Header field below) states which of these applies to
+      the code in the file. The example in the How to Apply These Terms section of the 
+      license shows the "or later" approach.
     </notes>
     <text>
     <titleText>

--- a/src/GPL-1.0-or-later.xml
+++ b/src/GPL-1.0-or-later.xml
@@ -10,7 +10,7 @@
       choice to use code under GPL-1.0-or-later (i.e., GPL-1.0 or some later version),
       as distinguished from the use of code under GPL-1.0-only. The license notice (as seen
       in the Standard License Header field below) states which of these applies to
-      the code in the file. The example in the How to Apply These Terms section of the 
+      the code in the file. The example in the How to Apply These Terms appendix of the 
       license shows the "or later" approach.
     </notes>
     <text>

--- a/src/GPL-2.0-only.xml
+++ b/src/GPL-2.0-only.xml
@@ -31,7 +31,7 @@
       to use the code under GPL-2.0-only, as distinguished from the use of code under GPL-2.0-or-later
       (i.e., GPL-2.0 or some later version). The license notice (as seen in the Standard License
       Header field below) states which of these applies to the code in the file. The example
-      in the How to Apply These Terms section of the license shows the "or later" approach.
+      in the How to Apply These Terms appendix of the license shows the "or later" approach.
     </notes>
     <text>
     <titleText>

--- a/src/GPL-2.0-only.xml
+++ b/src/GPL-2.0-only.xml
@@ -28,10 +28,10 @@
     </standardLicenseHeader>
     <notes>
       This license was released: June 1991. This license identifier refers to the choice
-      to use the code under GPL-2.0-only, as distinguished from use of code under GPL-2.0-or-later
+      to use the code under GPL-2.0-only, as distinguished from the use of code under GPL-2.0-or-later
       (i.e., GPL-2.0 or some later version). The license notice (as seen in the Standard License
-      Header field below)  states which of these applies to the code in the file. The example
-      in the exhibit to the license shows the license notice for the "or later" approach.
+      Header field below) states which of these applies to the code in the file. The example
+      in the How to Apply These Terms section of the license shows the "or later" approach.
     </notes>
     <text>
     <titleText>

--- a/src/GPL-2.0-or-later.xml
+++ b/src/GPL-2.0-or-later.xml
@@ -11,7 +11,7 @@
       choice to use code under GPL-2.0-or-later (i.e., GPL-2.0 or some later version),
       as distinguished from the use of code under GPL-2.0-only. The license notice (as seen
       in the Standard License Header field below) states which of these applies to
-      the code in the file. The example in the How to Apply These Terms section of the 
+      the code in the file. The example in the How to Apply These Terms appendix of the 
       license shows the "or later" approach.
     </notes>
     <text>

--- a/src/GPL-2.0-or-later.xml
+++ b/src/GPL-2.0-or-later.xml
@@ -9,10 +9,10 @@
     <notes>
       This license was released: June 1991. This license identifier refers to the
       choice to use code under GPL-2.0-or-later (i.e., GPL-2.0 or some later version),
-      as distinguished from use of code under GPL-2.0-only. The license notice (as seen
-      in the Standard License Header field below)  states which of these applies
-      the code in the file. The example in the exhibit to the license shows the license
-      notice for the "or later" approach.
+      as distinguished from the use of code under GPL-2.0-only. The license notice (as seen
+      in the Standard License Header field below) states which of these applies to
+      the code in the file. The example in the How to Apply These Terms section of the 
+      license shows the "or later" approach.
     </notes>
     <text>
     <titleText>

--- a/src/GPL-3.0-only.xml
+++ b/src/GPL-3.0-only.xml
@@ -31,7 +31,7 @@
       to use the code under GPL-3.0-only, as distinguished from the use of code under GPL-3.0-or-later
       (i.e., GPL-3.0 or some later version). The license notice (as seen in the Standard License
       Header field below) states which of these applies to the code in the file. The example
-      in the How to Apply These Terms section of the license shows the "or later" approach.
+      in the How to Apply These Terms appendix of the license shows the "or later" approach.
     </notes>
     <text>
     <titleText>

--- a/src/GPL-3.0-only.xml
+++ b/src/GPL-3.0-only.xml
@@ -28,10 +28,10 @@
     </standardLicenseHeader>
     <notes>
       This license was released: 29 June 2007. This license identifier refers to the choice
-      to use the code under GPL-3.0-only, as distinguished from use of code under GPL-3.0-or-later
+      to use the code under GPL-3.0-only, as distinguished from the use of code under GPL-3.0-or-later
       (i.e., GPL-3.0 or some later version). The license notice (as seen in the Standard License
-      Header field below)  states which of these applies to the code in the file. The example
-      in the exhibit to the license shows the license notice for the "or later" approach.
+      Header field below) states which of these applies to the code in the file. The example
+      in the How to Apply These Terms section of the license shows the "or later" approach.
     </notes>
     <text>
     <titleText>

--- a/src/GPL-3.0-or-later.xml
+++ b/src/GPL-3.0-or-later.xml
@@ -9,10 +9,10 @@
     <notes>
       This license was released: 29 June 2007. This license identifier refers to the
       choice to use code under GPL-3.0-or-later (i.e., GPL-3.0 or some later version),
-      as distinguished from use of code under GPL-3.0-only. The license notice (as seen
-      in the Standard License Header field below)  states which of these applies
-      the code in the file. The example in the exhibit to the license shows the license
-      notice for the "or later" approach.
+      as distinguished from the use of code under GPL-3.0-only. The license notice (as seen
+      in the Standard License Header field below) states which of these applies to
+      the code in the file. The example in the How to Apply These Terms section of the 
+      license shows the "or later" approach.
     </notes>
     <text>
     <titleText>

--- a/src/GPL-3.0-or-later.xml
+++ b/src/GPL-3.0-or-later.xml
@@ -11,7 +11,7 @@
       choice to use code under GPL-3.0-or-later (i.e., GPL-3.0 or some later version),
       as distinguished from the use of code under GPL-3.0-only. The license notice (as seen
       in the Standard License Header field below) states which of these applies to
-      the code in the file. The example in the How to Apply These Terms section of the 
+      the code in the file. The example in the How to Apply These Terms appendix of the 
       license shows the "or later" approach.
     </notes>
     <text>


### PR DESCRIPTION
- Clarify which part of the license the notes are referring to
- Small corrections of grammar

Closes #1682