### PR TITLE
Update License List Publisher to version 2.2.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: CC0-1.0
 
-TOOL_VERSION = 2.2.6
+TOOL_VERSION = 2.2.7
 TEST_DATA = test/simpleTestForGenerator
 GIT_AUTHOR = License Publisher (maintained by Gary O'Neall) <gary@sourceauditor.com>
 GIT_AUTHOR_EMAIL = gary@sourceauditor.com


### PR DESCRIPTION
See https://github.com/spdx/LicenseListPublisher/releases/tag/v2.2.7 for release notes

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>