### PR TITLE
Fix formatting of Artistic-1.0-cl8

### DIFF
--- a/src/Artistic-1.0-cl8.xml
+++ b/src/Artistic-1.0-cl8.xml
@@ -120,10 +120,13 @@
             <bullet>7.</bullet>
           C or perl subroutines supplied by you and linked into this Package shall not be considered part
              of this Package.
-          <p>8.Aggregation of this Package with a commercial distribution is always permitted provided that
+        </item>
+        <item>
+            <bullet>8.</bullet>
+          Aggregation of this Package with a commercial distribution is always permitted provided that
              the use of this Package is embedded; that is, when no overt attempt is made to make this
              Package's interfaces visible to the end user of the commercial distribution. Such use
-             shall not be construed as a distribution of this Package.</p>
+             shall not be construed as a distribution of this Package.
         </item>
         <item>
             <bullet>9.</bullet>


### PR DESCRIPTION
Fix the formatting of Artistic-1.0-cl8 to list the 8th clause as a bullet point rather than an additional paragraph to the 7th clause.

Signed-off-by: Michał Górny <mgorny@gentoo.org>