### PR TITLE
StandardML-NJ.xml: fix URL

### DIFF
--- a/src/StandardML-NJ.xml
+++ b/src/StandardML-NJ.xml
@@ -6,7 +6,7 @@
          <obsoletedBy>SMLNJ</obsoletedBy>
       </obsoletedBys>
       <crossRefs>
-         <crossRef>http://www.smlnj.org//license.html</crossRef>
+         <crossRef>https://www.smlnj.org/license.html</crossRef>
       </crossRefs>
        <notes>DEPRECATED: Duplicate license, use identifier: SMLNJ</notes>
     <text>


### PR DESCRIPTION
Remove double slash in URL, use https.
This makes the URL the same as in SMLNJ.xml

Signed-off-by: Marc-Etienne Vargenau <marc-etienne.vargenau@nokia.com>