### PR TITLE
LGPL-2.1+.xml: fix license name

### DIFF
--- a/src/LGPL-2.1+.xml
+++ b/src/LGPL-2.1+.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="LGPL-2.1+"  isDeprecated="true" deprecatedVersion="2.0rc2"
-            name="GNU Library General Public License v2.1 or later">
+            name="GNU Lesser General Public License v2.1 or later">
       <obsoletedBys>
          <obsoletedBy>LGPL-2.1-or-later</obsoletedBy>
       </obsoletedBys>


### PR DESCRIPTION
License name is "GNU Lesser General Public License", not "GNU Library General Public License".

Signed-off-by: Marc-Etienne Vargenau <marc-etienne.vargenau@nokia.com>