### PR TITLE
AGPL-1.0.xml: fix license name

### DIFF
--- a/src/AGPL-1.0.xml
+++ b/src/AGPL-1.0.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="false" licenseId="AGPL-1.0"
-            name="Affero General Public License v1.0"
+            name="Affero General Public License v1.0 only"
             isDeprecated="true" deprecatedVersion="3.1">
       <obsoletedBys>
          <obsoletedBy>AGPL-1.0-only</obsoletedBy>


### PR DESCRIPTION
Change license name from "Affero General Public License v1.0" to "Affero General Public License v1.0 only". Then we have the same license name for AGPL-1.0.xml and AGPL-1.0-only.xml (as it is already the case for the GPL licenses).

Signed-off-by: Marc-Etienne Vargenau <marc-etienne.vargenau@nokia.com>