### PR TITLE
AGPL-3.0.xml: fix license name

### DIFF
--- a/src/AGPL-3.0.xml
+++ b/src/AGPL-3.0.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
   <license licenseId="AGPL-3.0" isOsiApproved="true"
-  name="GNU Affero General Public License v3.0"
+  name="GNU Affero General Public License v3.0 only"
   isDeprecated="true" deprecatedVersion="3.0">
     <obsoletedBys>
       <obsoletedBy>AGPL-3.0-only</obsoletedBy>


### PR DESCRIPTION
Change license name from "GNU Affero General Public License v3.0" to "GNU Affero General Public License v3.0 only". Then we have the same license name for AGPL-3.0.xml and AGPL-3.0-only.xml (as it is already the case for the GPL licenses).

Signed-off-by: Marc-Etienne Vargenau <marc-etienne.vargenau@nokia.com>