### PR TITLE
GFDL-1.1.xml: fix license name

### DIFF
--- a/src/GFDL-1.1.xml
+++ b/src/GFDL-1.1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
   <license licenseId="GFDL-1.1" isOsiApproved="false"
-  name="GNU Free Documentation License v1.1"
+  name="GNU Free Documentation License v1.1 only"
   isDeprecated="true" deprecatedVersion="3.0">
     <obsoletedBys>
       <obsoletedBy>GFDL-1.1-only</obsoletedBy>


### PR DESCRIPTION
Change license name from "GNU Free Documentation License v1.1" to "GNU Free Documentation License v1.1 only". Then we have the same license name for GFDL-1.1.xml and GFDL-1.1-only.xml (as it is already the case for the GPL licenses).

Signed-off-by: Marc-Etienne Vargenau <marc-etienne.vargenau@nokia.com>