### PR TITLE
Remove incorrect bullet

### DIFF
--- a/DOCS/faq.md
+++ b/DOCS/faq.md
@@ -18,8 +18,6 @@ regarding what is eligible for inclusion on the SPDX License List
 provide parameters as to what constitutes a match to a license or exception on the SPDX License List
 * an [explanation of the fields](https://github.com/spdx/license-list-XML/blob/main/DOCS/license-fields.md) 
 used in the SPDX License List
-* [license expression syntax](LINK) 
-enable expressing composite licensing scenarios, such as when more than one license applies, there is a choice of license, or an exception or additional terms apply to the license
 
 The authoritative files for the SPDX License List are stored in XML source files 
 in a [Github repo](https://github.com/spdx/license-list-XML). These files are 


### PR DESCRIPTION
Before this change, the `DOCS/faq.md` said that the License List incorporated the syntax for license expressions. That’s not accurate. [The syntax for license expressions is in the SPDX Spec][1]. Also, the link in that bullet point was invalid.

[1]: <https://spdx.github.io/spdx-spec/v2.3/SPDX-license-expressions/>