### PR TITLE
More directly draw attention to rest of list

### DIFF
--- a/DOCS/faq.md
+++ b/DOCS/faq.md
@@ -11,15 +11,10 @@ hardware, or documentation. The SPDX License List includes a
 standardized short identifier, the full name, the license text, and a
 canonical permanent URL for each license and exception.
 
-It is more than just a list, though. The SPDX License List incorporates
-* [license inclusion principles](license-inclusion-principles.md)
-regarding what is eligible for inclusion on the SPDX License List
-* [matching guidelines](https://spdx.github.io/spdx-spec/v2.3/license-matching-guidelines-and-templates/) 
-provide parameters as to what constitutes a match to a license or exception on the SPDX License List
-* an [explanation of the fields](license-fields.md)
-used in the SPDX License List
-* [license expression syntax](LINK) 
-enable expressing composite licensing scenarios, such as when more than one license applies, there is a choice of license, or an exception or additional terms apply to the license
+It is more than just a list, though. Don’t just gloss over what’s written before
+[each](https://spdx.org/licenses/#preamble) [section](https://spdx.org/licenses/#deprecated)
+of the list. That information will help you use and contribute to the SPDX
+License List.
 
 The authoritative files for the SPDX License List are stored in XML source files 
 in a [Github repo](https://github.com/spdx/license-list-XML). These files are 


### PR DESCRIPTION
[Before this change, there was an awkward and slightly incorrect part of the FAQ.][1] [It was trying to draw attention to specific parts of the License List Web page that typically get ignored.][2]

This replaces that part of the FAQ with a more direct call out. Hopefully, this will make people pay more attention to those parts of the License List.

This change also removes an invalid link.

[1]: <https://github.com/spdx/license-list-XML/pull/1809#issue-1574869665>
[2]: <https://github.com/spdx/license-list-XML/pull/1809#issuecomment-1426582567>

---

This PR depends on another PR. Before this one is merged, the following needs to happen:

1. [x] spdx/LicenseListPublisher#154 needs to be finished.
2. [x] spdx/LicenseListPublisher#154 needs to be merged.
3. [ ] A new version of [the LicenseListPublisher](https://github.com/spdx/LicenseListPublisher) needs to be released.
4. [ ] A commit needs to get added to license-list-XML that makes it use the new version of the LicenseListPublisher.
5. [ ] A new version of the License List needs to be released and published at <https://spdx.org/licenses/>.

Until those things happen, the links that this PR adds won’t work properly.

---

This PR is an alternative to #1809.