### PR TITLE
Removed the `isDeprecated` field form the licenses

### DIFF
--- a/src/AGPL-1.0.xml
+++ b/src/AGPL-1.0.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="false" licenseId="AGPL-1.0"
             name="Affero General Public License v1.0"
-            isDeprecated="true" deprecatedVersion="3.1">
+            deprecatedVersion="3.1">
       <obsoletedBys>
          <obsoletedBy>AGPL-1.0-only</obsoletedBy>
          <obsoletedBy expression="AGPL-1.0+">AGPL-1.0-or-later</obsoletedBy>

--- a/src/AGPL-3.0.xml
+++ b/src/AGPL-3.0.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
   <license licenseId="AGPL-3.0" isOsiApproved="true"
   name="GNU Affero General Public License v3.0"
-  isDeprecated="true" deprecatedVersion="3.0">
+  deprecatedVersion="3.0">
     <obsoletedBys>
       <obsoletedBy>AGPL-3.0-only</obsoletedBy>
       <obsoletedBy expression="AGPL-3.0+">AGPL-3.0-or-later</obsoletedBy>

--- a/src/BSD-2-Clause-FreeBSD.xml
+++ b/src/BSD-2-Clause-FreeBSD.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="false" licenseId="BSD-2-Clause-FreeBSD"
             name="BSD 2-Clause FreeBSD License"
-            isDeprecated="true" deprecatedVersion="3.10">
+            deprecatedVersion="3.10">
       <crossRefs>
          <crossRef>http://www.freebsd.org/copyright/freebsd-license.html</crossRef>
       </crossRefs>

--- a/src/BSD-2-Clause-NetBSD.xml
+++ b/src/BSD-2-Clause-NetBSD.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="false" licenseId="BSD-2-Clause-NetBSD"
             name="BSD 2-Clause NetBSD License"
-            isDeprecated="true" deprecatedVersion="3.9">
+            deprecatedVersion="3.9">
       <obsoletedBys>
         <obsoletedBy>BSD-2-Clause</obsoletedBy>
       </obsoletedBys>

--- a/src/GFDL-1.1.xml
+++ b/src/GFDL-1.1.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
   <license licenseId="GFDL-1.1" isOsiApproved="false"
   name="GNU Free Documentation License v1.1"
-  isDeprecated="true" deprecatedVersion="3.0">
+  deprecatedVersion="3.0">
     <obsoletedBys>
       <obsoletedBy>GFDL-1.1-only</obsoletedBy>
       <obsoletedBy expression="GFDL-1.1+">GFDL-1.1-or-later</obsoletedBy>

--- a/src/GFDL-1.2.xml
+++ b/src/GFDL-1.2.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
   <license licenseId="GFDL-1.2" isOsiApproved="false"
   name="GNU Free Documentation License v1.2"
-  isDeprecated="true" deprecatedVersion="3.0">
+  deprecatedVersion="3.0">
     <obsoletedBys>
       <obsoletedBy>GFDL-1.2-only</obsoletedBy>
       <obsoletedBy expression="GFDL-1.2+">GFDL-1.2-or-later</obsoletedBy>

--- a/src/GFDL-1.3.xml
+++ b/src/GFDL-1.3.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
   <license licenseId="GFDL-1.3" isOsiApproved="false"
   name="GNU Free Documentation License v1.3"
-  isDeprecated="true" deprecatedVersion="3.0">
+  deprecatedVersion="3.0">
     <obsoletedBys>
       <obsoletedBy>GFDL-1.3-only</obsoletedBy>
       <obsoletedBy expression="GFDL-1.3+">GFDL-1.3-or-later</obsoletedBy>

--- a/src/GPL-1.0+.xml
+++ b/src/GPL-1.0+.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isDeprecated="true" deprecatedVersion="2.0rc2" isOsiApproved="false" licenseId="GPL-1.0+"
+   <license deprecatedVersion="2.0rc2" isOsiApproved="false" licenseId="GPL-1.0+"
             name="GNU General Public License v1.0 or later">
       <obsoletedBys>
          <obsoletedBy>GPL-1.0-or-later</obsoletedBy>

--- a/src/GPL-1.0.xml
+++ b/src/GPL-1.0.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
   <license licenseId="GPL-1.0" isOsiApproved="false"
   name="GNU General Public License v1.0 only"
-  isDeprecated="true" deprecatedVersion="3.0">
+  deprecatedVersion="3.0">
     <obsoletedBys>
       <obsoletedBy>GPL-1.0-only</obsoletedBy>
       <obsoletedBy expression="GPL-1.0+">GPL-1.0-or-later</obsoletedBy>

--- a/src/GPL-2.0+.xml
+++ b/src/GPL-2.0+.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isOsiApproved="true" licenseId="GPL-2.0+" isDeprecated="true" deprecatedVersion="2.0rc2"
+   <license isOsiApproved="true" licenseId="GPL-2.0+" deprecatedVersion="2.0rc2"
             name="GNU General Public License v2.0 or later">
       <obsoletedBys>
          <obsoletedBy>GPL-2.0-or-later</obsoletedBy>

--- a/src/GPL-2.0-with-GCC-exception.xml
+++ b/src/GPL-2.0-with-GCC-exception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isDeprecated="true" deprecatedVersion="2.0rc2" licenseId="GPL-2.0-with-GCC-exception"
+   <license deprecatedVersion="2.0rc2" licenseId="GPL-2.0-with-GCC-exception"
             name="GNU General Public License v2.0 w/GCC Runtime Library exception">
       <obsoletedBys>
          <obsoletedBy>GPL-2.0 WITH GCC-exception-2.0</obsoletedBy>

--- a/src/GPL-2.0-with-autoconf-exception.xml
+++ b/src/GPL-2.0-with-autoconf-exception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isDeprecated="true" deprecatedVersion="2.0rc2" licenseId="GPL-2.0-with-autoconf-exception"
+   <license deprecatedVersion="2.0rc2" licenseId="GPL-2.0-with-autoconf-exception"
             name="GNU General Public License v2.0 w/Autoconf exception">
       <obsoletedBys>
          <obsoletedBy>GPL-2.0 WITH Autoconf-exception-2.0</obsoletedBy>

--- a/src/GPL-2.0-with-bison-exception.xml
+++ b/src/GPL-2.0-with-bison-exception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isDeprecated="true" deprecatedVersion="2.0rc2" licenseId="GPL-2.0-with-bison-exception"
+   <license deprecatedVersion="2.0rc2" licenseId="GPL-2.0-with-bison-exception"
             name="GNU General Public License v2.0 w/Bison exception">
       <obsoletedBys>
          <obsoletedBy>GPL-2.0 WITH Bison-exception-2.2</obsoletedBy>

--- a/src/GPL-2.0-with-classpath-exception.xml
+++ b/src/GPL-2.0-with-classpath-exception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isDeprecated="true" deprecatedVersion="2.0rc2" licenseId="GPL-2.0-with-classpath-exception"
+   <license deprecatedVersion="2.0rc2" licenseId="GPL-2.0-with-classpath-exception"
             name="GNU General Public License v2.0 w/Classpath exception">
       <obsoletedBys>
          <obsoletedBy>GPL-2.0 WITH Classpath-exception-2.0</obsoletedBy>

--- a/src/GPL-2.0-with-font-exception.xml
+++ b/src/GPL-2.0-with-font-exception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isDeprecated="true" deprecatedVersion="2.0rc2" licenseId="GPL-2.0-with-font-exception"
+   <license deprecatedVersion="2.0rc2" licenseId="GPL-2.0-with-font-exception"
             name="GNU General Public License v2.0 w/Font exception">
       <obsoletedBys>
          <obsoletedBy>GPL-2.0 WITH Font-exception-2.0</obsoletedBy>

--- a/src/GPL-2.0.xml
+++ b/src/GPL-2.0.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
   <license licenseId="GPL-2.0" isOsiApproved="true"
   name="GNU General Public License v2.0 only"
-  isDeprecated="true" deprecatedVersion="3.0">
+  deprecatedVersion="3.0">
     <obsoletedBys>
       <obsoletedBy>GPL-2.0-only</obsoletedBy>
       <obsoletedBy expression="GPL-2.0+">GPL-2.0-or-later</obsoletedBy>

--- a/src/GPL-3.0+.xml
+++ b/src/GPL-3.0+.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isOsiApproved="true" licenseId="GPL-3.0+" isDeprecated="true" deprecatedVersion="2.0rc2"
+   <license isOsiApproved="true" licenseId="GPL-3.0+" deprecatedVersion="2.0rc2"
             name="GNU General Public License v3.0 or later">
       <obsoletedBys>
          <obsoletedBy>GPL-3.0-or-later</obsoletedBy>

--- a/src/GPL-3.0-with-GCC-exception.xml
+++ b/src/GPL-3.0-with-GCC-exception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isOsiApproved="true" licenseId="GPL-3.0-with-GCC-exception" isDeprecated="true" deprecatedVersion="2.0rc2"
+   <license isOsiApproved="true" licenseId="GPL-3.0-with-GCC-exception" deprecatedVersion="2.0rc2"
             name="GNU General Public License v3.0 w/GCC Runtime Library exception">
       <obsoletedBys>
          <obsoletedBy>GPL-3.0 WITH GCC-exception-3.1</obsoletedBy>

--- a/src/GPL-3.0-with-autoconf-exception.xml
+++ b/src/GPL-3.0-with-autoconf-exception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isDeprecated="true" deprecatedVersion="2.0rc2" licenseId="GPL-3.0-with-autoconf-exception"
+   <license deprecatedVersion="2.0rc2" licenseId="GPL-3.0-with-autoconf-exception"
             name="GNU General Public License v3.0 w/Autoconf exception">
       <obsoletedBys>
          <obsoletedBy>GPL-3.0 WITH Autoconf-exception-3.0</obsoletedBy>

--- a/src/GPL-3.0.xml
+++ b/src/GPL-3.0.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
   <license licenseId="GPL-3.0" isOsiApproved="true"
   name="GNU General Public License v3.0 only"
-  isDeprecated="true" deprecatedVersion="3.0">
+  deprecatedVersion="3.0">
     <obsoletedBys>
       <obsoletedBy>GPL-3.0-only</obsoletedBy>
       <obsoletedBy expression="GPL-3.0+">GPL-3.0-or-later</obsoletedBy>

--- a/src/LGPL-2.0+.xml
+++ b/src/LGPL-2.0+.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isOsiApproved="true" licenseId="LGPL-2.0+" isDeprecated="true" deprecatedVersion="2.0rc2"
+   <license isOsiApproved="true" licenseId="LGPL-2.0+" deprecatedVersion="2.0rc2"
             name="GNU Library General Public License v2 or later">
       <obsoletedBys>
          <obsoletedBy>LGPL-2.0-or-later</obsoletedBy>

--- a/src/LGPL-2.0.xml
+++ b/src/LGPL-2.0.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
   <license licenseId="LGPL-2.0" isOsiApproved="true"
   name="GNU Library General Public License v2 only"
-  isDeprecated="true" deprecatedVersion="3.0">
+  deprecatedVersion="3.0">
     <obsoletedBys>
       <obsoletedBy>LGPL-2.0-only</obsoletedBy>
       <obsoletedBy expression="LGPL-2.0+">LGPL-2.0-or-later</obsoletedBy>

--- a/src/LGPL-2.1+.xml
+++ b/src/LGPL-2.1+.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isOsiApproved="true" licenseId="LGPL-2.1+"  isDeprecated="true" deprecatedVersion="2.0rc2"
+   <license isOsiApproved="true" licenseId="LGPL-2.1+" deprecatedVersion="2.0rc2"
             name="GNU Lesser General Public License v2.1 or later">
       <obsoletedBys>
          <obsoletedBy>LGPL-2.1-or-later</obsoletedBy>

--- a/src/LGPL-2.1.xml
+++ b/src/LGPL-2.1.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
   <license licenseId="LGPL-2.1" isOsiApproved="true"
   name="GNU Lesser General Public License v2.1 only"
-  isDeprecated="true" deprecatedVersion="3.0">
+  deprecatedVersion="3.0">
     <obsoletedBys>
       <obsoletedBy>LGPL-2.1-only</obsoletedBy>
       <obsoletedBy expression="LGPL-2.1+">LGPL-2.1-or-later</obsoletedBy>

--- a/src/LGPL-3.0+.xml
+++ b/src/LGPL-3.0+.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isOsiApproved="true" licenseId="LGPL-3.0+"  isDeprecated="true" deprecatedVersion="2.0rc2"
+   <license isOsiApproved="true" licenseId="LGPL-3.0+"  deprecatedVersion="2.0rc2"
             name="GNU Lesser General Public License v3.0 or later">
       <obsoletedBys>
          <obsoletedBy>LGPL-3.0-or-later</obsoletedBy>

--- a/src/LGPL-3.0.xml
+++ b/src/LGPL-3.0.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
   <license licenseId="LGPL-3.0" isOsiApproved="true"
   name="GNU Lesser General Public License v3.0 only"
-  isDeprecated="true" deprecatedVersion="3.0">
+  deprecatedVersion="3.0">
     <obsoletedBys>
       <obsoletedBy>LGPL-3.0-only</obsoletedBy>
       <obsoletedBy expression="LGPL-3.0+">LGPL-3.0-or-later</obsoletedBy>

--- a/src/Nunit.xml
+++ b/src/Nunit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isDeprecated="true" deprecatedVersion="3.0" licenseId="Nunit" name="Nunit License">
+   <license deprecatedVersion="3.0" licenseId="Nunit" name="Nunit License">
       <obsoletedBys>
          <obsoletedBy>zlib-acknowledgement</obsoletedBy>
       </obsoletedBys>

--- a/src/StandardML-NJ.xml
+++ b/src/StandardML-NJ.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isOsiApproved="false" licenseId="StandardML-NJ" isDeprecated="true" deprecatedVersion="2.0rc2"
+   <license isOsiApproved="false" licenseId="StandardML-NJ" deprecatedVersion="2.0rc2"
             name="Standard ML of New Jersey License">
       <obsoletedBys>
          <obsoletedBy>SMLNJ</obsoletedBy>

--- a/src/bzip2-1.0.5.xml
+++ b/src/bzip2-1.0.5.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="false" licenseId="bzip2-1.0.5"
             name="bzip2 and libbzip2 License v1.0.5"
-            isDeprecated="true" deprecatedVersion="3.16">
+            deprecatedVersion="3.16">
       <crossRefs>
          <crossRef>https://sourceware.org/bzip2/1.0.5/bzip2-manual-1.0.5.html</crossRef>
           <crossRef>http://bzip.org/1.0.5/bzip2-manual-1.0.5.html</crossRef>

--- a/src/eCos-2.0.xml
+++ b/src/eCos-2.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isDeprecated="true" deprecatedVersion="2.0rc2" licenseId="eCos-2.0" name="eCos license version 2.0">
+   <license deprecatedVersion="2.0rc2" licenseId="eCos-2.0" name="eCos license version 2.0">
       <obsoletedBys>
           <obsoletedBy>GPL-2.0-or-later WITH eCos-exception-2.0</obsoletedBy>
       </obsoletedBys>

--- a/src/exceptions/Nokia-Qt-exception-1.1.xml
+++ b/src/exceptions/Nokia-Qt-exception-1.1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <exception licenseId="Nokia-Qt-exception-1.1" name="Nokia Qt LGPL exception 1.1" isDeprecated="true" deprecatedVersion="3.1">
+   <exception licenseId="Nokia-Qt-exception-1.1" name="Nokia Qt LGPL exception 1.1" deprecatedVersion="3.1">
       <obsoletedBys>
          <obsoletedBy>Qt-LGPL-exception-1.1</obsoletedBy>
       </obsoletedBys>

--- a/src/wxWindows.xml
+++ b/src/wxWindows.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license licenseId="wxWindows" isOsiApproved="true" name="wxWindows Library License"  isDeprecated="true" deprecatedVersion="2.0rc2">
+   <license licenseId="wxWindows" isOsiApproved="true" name="wxWindows Library License"  deprecatedVersion="2.0rc2">
       <obsoletedBys>
          <obsoletedBy>GPL-2.0-or-later WITH WxWindows-exception-3.1</obsoletedBy>
       </obsoletedBys>


### PR DESCRIPTION
Fixes #1545 
Compared all the licenses in the `src` folder and `src/exceptions` folder and removed the `isDeprecated` field from the XML format as each license had `deprecatedVersion` field