### PR TITLE
HPND-sell-variant-MIT-disclaimer - add line breaks

### DIFF
--- a/src/HPND-sell-variant-MIT-disclaimer.xml
+++ b/src/HPND-sell-variant-MIT-disclaimer.xml
@@ -12,7 +12,7 @@
       <text>
          <copyrightText>
             by Jim Knoble &lt;jmknoble@pobox.com&gt;
-            Copyright (C) 1999,2000,2001 Jim Knoble
+            <br/>Copyright (C) 1999,2000,2001 Jim Knoble
          </copyrightText>
          <p>
             Permission to use, copy, modify, distribute, and sell this
@@ -22,7 +22,9 @@
             this permission notice appear in supporting documentation.
          </p>
          <p>
-            +------------+ | Disclaimer | +------------+
+            +------------+ 
+            <br/>| Disclaimer | 
+            <br/>+------------+
          </p>
          <p>
             THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,


### PR DESCRIPTION
displaying weird where line breaks are needed, see https://spdx.org/licenses/HPND-sell-variant-MIT-disclaimer.html

still need extra line btw copyright notice and start of license? would that mean a <p> tag around copyright notice??

@swinslow  thoughts on this one?

Signed-off-by: Jilayne Lovejoy