### PR TITLE
Accept any copyright holders in BSD-4.3TAHOE

### DIFF
--- a/src/BSD-4.3TAHOE.xml
+++ b/src/BSD-4.3TAHOE.xml
@@ -4,6 +4,7 @@
    name="BSD 4.3 TAHOE License" listVersionAdded="3.20">
       <crossRefs>
          <crossRef>https://github.com/389ds/389-ds-base/blob/main/ldap/include/sysexits-compat.h#L15</crossRef>
+         <crossRef>https://git.savannah.gnu.org/cgit/indent.git/tree/doc/indent.texi?id=a74c6b4ee49397cf330b333da1042bffa60ed14f#n1788</crossRef>
       </crossRefs>
       <notes>
       </notes>
@@ -18,8 +19,10 @@
             are duplicated in all such forms and that any documentation,
             advertising materials, and other materials related to such
             distribution and use acknowledge that the software was developed
-            by the University of California, Berkeley. The name of the
-            University may not be used to endorse or promote products derived
+            by <alt match="[^.]+\." name="acknowledgedDeveloperNames">the
+            University of California, Berkeley.</alt> The name of
+            <alt match="[^.]+" name="noEndorseNames">the University</alt>
+            may not be used to endorse or promote products derived
             from this software without specific prior written permission.
             THIS SOFTWARE IS PROVIDED ``AS IS'' AND WITHOUT ANY EXPRESS OR
             IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED


### PR DESCRIPTION
indent software has this license with more copyright holders <https://git.savannah.gnu.org/cgit/indent.git/tree/doc/indent.texi?id=a74c6b4ee49397cf330b333da1042bffa60ed14f#n1788> that originally listed. Augmenting the license markup was proposed in Fedora license review <https://gitlab.com/fedora/legal/fedora-license-data/-/issues/174>.