### PR TITLE
Python-2.0.1 is FSF approved but not OSI approved

### DIFF
--- a/src/Python.xml
+++ b/src/Python.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license licenseId="Python-2.0.1" name="Python License 2.0.1" listVersionAdded="3.18">
+   <license licenseId="Python" name="License of Python 2.0.1, 2.1.1, and newer versions" listVersionAdded="3.18">
       <crossRefs>
          <crossRef>https://www.python.org/download/releases/2.0.1/license/</crossRef>
          <crossRef>https://docs.python.org/3/license.html</crossRef>


### PR DESCRIPTION
License was added with #1549 as a follow up on #1200

renaming license to match FSF identifier [1][2]

<del>In #1200 it is stated that the license is FSF approved but no OSI
approved or at least not with the right name. With a link to the FSF
website [1].</del>

<del>So I'm adding this attribute to the license for it to be properly tagged
as FSF approved.</del>

[1] https://www.gnu.org/licenses/license-list.en.html#Python
[2] https://wking.github.io/fsf-api/licenses-full.json