### PR TITLE
New license: Latex2e-translated-notice

### DIFF
--- a/src/Latex2e-translated-notice.xml
+++ b/src/Latex2e-translated-notice.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SPDXLicenseCollection xmlns="http://www.spdx.org/license">
+   <license isOsiApproved="false" licenseId="Latex2e-translated-notice"
+   name="Latex2e with translated notice permission" listVersionAdded="3.21">
+      <crossRefs>
+         <crossRef>https://git.savannah.gnu.org/cgit/indent.git/tree/doc/indent.texi?id=a74c6b4ee49397cf330b333da1042bffa60ed14f#n74</crossRef>
+      </crossRefs>
+      <notes>The last section differs from Latex2e license.</notes>
+      <text>
+         <copyrightText>
+            <p>
+               Copyright @copyright{} 1989, 1992, 1993, 1994, 1995, 1996, 2014 Free Software
+               Foundation, Inc.
+            </p>
+            <p>
+               Copyright @copyright{} 1995, 1996 Joseph Arceneaux.
+            </p>
+            <p>
+               Copyright @copyright{} 1999, Carlo Wood.
+            </p>
+            <p>
+               Copyright @copyright{} 2001, David Ingamells.
+            </p>
+            <p>
+               Copyright @copyright{} 2013, Łukasz Stelmach.
+            </p>
+         </copyrightText>
+         <p>
+            Permission is granted to make and distribute verbatim copies of
+            this manual provided the copyright notice and this permission notice
+            are preserved on all copies.
+         </p>
+         <p>
+            Permission is granted to copy and distribute modified versions of this
+            manual under the conditions for verbatim copying, provided that the entire
+            resulting derived work is distributed under the terms of a permission
+            notice identical to this one.
+         </p>
+         <p>
+            Permission is granted to copy and distribute translations of this manual
+            into another language, under the above conditions for modified versions,
+            except that this permission notice may be stated in a translation approved
+            by the Foundation.
+         </p>
+      </text>
+   </license>
+</SPDXLicenseCollection>

--- a/test/simpleTestForGenerator/Latex2e-translated-notice.txt
+++ b/test/simpleTestForGenerator/Latex2e-translated-notice.txt
@@ -1,0 +1,26 @@
+Copyright @copyright{} 1989, 1992, 1993, 1994, 1995, 1996, 2014 Free Software
+Foundation, Inc.
+
+Copyright @copyright{} 1995, 1996 Joseph Arceneaux.
+
+Copyright @copyright{} 1999, Carlo Wood.
+
+Copyright @copyright{} 2001, David Ingamells.
+
+Copyright @copyright{} 2013, Łukasz Stelmach.
+
+Copyright @copyright{} 2015, Tim Hentenaar.
+
+Permission is granted to make and distribute verbatim copies of
+this manual provided the copyright notice and this permission notice
+are preserved on all copies.
+
+Permission is granted to copy and distribute modified versions of this
+manual under the conditions for verbatim copying, provided that the entire
+resulting derived work is distributed under the terms of a permission
+notice identical to this one.
+
+Permission is granted to copy and distribute translations of this manual
+into another language, under the above conditions for modified versions,
+except that this permission notice may be stated in a translation approved
+by the Foundation.


### PR DESCRIPTION
A new license similar, yet distinct from Latex2e.

https://github.com/spdx/license-list-XML/issues/1888