### PR TITLE
AGPL-3.0: Add missing period in standard license header

### DIFF
--- a/src/AGPL-3.0.xml
+++ b/src/AGPL-3.0.xml
@@ -21,7 +21,7 @@
       PURPOSE. See the GNU Affero General Public License for more details.
       You should have received a copy of the GNU Affero General Public License
       along with this program. If not, see
-      &lt;https://www.gnu.org/licenses/&gt;
+      &lt;https://www.gnu.org/licenses/&gt;.
     </standardLicenseHeader>
     <text>
     <titleText>


### PR DESCRIPTION
Fixing same issue as for AGPL-3.0-only from #1920 

Signed-off-by: Steve Winslow <steve@swinslow.net>