### PR TITLE
CI: fix auto-comment configuration

### DIFF
--- a/auto-comment.yaml
+++ b/auto-comment.yaml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: 0BSD OR CC0-1.0
 
 repo: spdx/license-list-XML
-startAt: 2023-02-23
+startAt: 2023-04-24
 pullRequests: false
 filters:
   - type: issue
@@ -9,8 +9,9 @@ filters:
       state: closed
       labels:
         $and:
-          - $in: 'new license/exception: Accepted'
-          - $nin: 'Acceptance Notification Sent'
+          - $includes: 'new license/exception: Accepted'
+          - $not:
+              $includes: 'Acceptance Notification Sent'
 
 actions:
   - type: add_comment


### PR DESCRIPTION
This auto-comment has been introduced in #1625

However I think the configuration is faulty, since I couldn't find any such comment.

With the following change, here is the output of a dry-run:
```
> git3po --dry-run -c config.yml

⤺  Issue #1953 did not match issue filter, skipping
⤺  Issue #1949 did not match issue filter, skipping
⤺  Issue #1948 did not match issue filter, skipping
⤺  Issue #1945 is a pull request, skipping
⤺  Issue #1937 did not match issue filter, skipping
⤺  Issue #1936 did not match issue filter, skipping
⤺  Issue #1930 is a pull request, skipping
💎  Found #1888 (New license request: Latex2e with translated notice permission) at 2023-03-22T09:12:37Z, processing...
🔗  https://github.com/spdx/license-list-XML/issues/1888
     Applying add comment...             ⏳
     Applying add label...               ⏳
✅  Done with #1888
💎  Found #1880 (New license request: Open Logistics Foundation License v1.3) at 2023-03-19T16:11:57Z, processing...
🔗  https://github.com/spdx/license-list-XML/issues/1880
     Applying add comment...             ⏳
     Applying add label...               ⏳
✅  Done with #1880
💎  Found #1863 (New license request: Metamail license) at 2023-03-08T12:31:16Z, processing...
🔗  https://github.com/spdx/license-list-XML/issues/1863
     Applying add comment...             ⏳
     Applying add label...               ⏳
✅  Done with #1863
⤺  Issue #1856 did not match issue filter, skipping
⤺  Issue #1625 did not match issue filter, skipping
⤺  Issue #1574 did not match issue filter, skipping
🎉  Finished!
```

cc @seabass-labrax 