### PR TITLE
Update LicenseListPublish to version 2.2.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: CC0-1.0
 
-TOOL_VERSION = 2.2.9
+TOOL_VERSION = 2.2.10
 TEST_DATA = test/simpleTestForGenerator
 GIT_AUTHOR = License Publisher (maintained by Gary O'Neall) <gary@sourceauditor.com>
 GIT_AUTHOR_EMAIL = gary@sourceauditor.com


### PR DESCRIPTION
This publishes the license-list-XML source files to the license-list-data repository.  Fixes
https://github.com/spdx/LicenseListPublisher/issues/164

Also fixes one of the issues mentioned in https://github.com/spdx/spdx-spec/issues/853