### PR TITLE
Update MIT-testregex.xml

### DIFF
--- a/src/MIT-testregex.xml
+++ b/src/MIT-testregex.xml
@@ -3,12 +3,10 @@
    <license isOsiApproved="false" licenseId="MIT-testregex"
    name="MIT testregex Variant" listVersionAdded="3.22">
       <crossRefs>
-         <crossRef>https://github.com/dotnet/runtime/blob/55e1ac7c07df62c4108d4acedf78f77574470ce5/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/AttRegexTests.cs#L12-L28</crossRef>
+<crossRef>https://github.com/dotnet/runtime/blob/55e1ac7c07df62c4108d4acedf78f77574470ce5/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/AttRegexTests.cs#L12-L28</crossRef>
       </crossRefs>
       <text>
-         <list>
-            <item>
-               <bullet>*</bullet>
+
                <p>
                   Permission is hereby granted, free of charge, to any person
                   obtaining a copy of THIS SOFTWARE FILE (the "Software"),
@@ -16,7 +14,8 @@
                   without limitation the rights to use, copy, modify, merge,
                   publish, distribute, and/or sell copies of the Software, and
                   to permit persons to whom the Software is furnished to do
-                  so, subject to the following disclaimer: THIS SOFTWARE IS
+                  so, subject to the following disclaimer: </p>
+               <p>THIS SOFTWARE IS
                   PROVIDED BY AT&amp;T ``AS IS'' AND ANY EXPRESS OR IMPLIED
                   WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
                   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
@@ -30,8 +29,6 @@
                   OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
                   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                </p>
-            </item>
-         </list>
       </text>
    </license>
 </SPDXLicenseCollection>


### PR DESCRIPTION
fixed incorrect XML list tags due to how license was entered into SPDX submission form.

FYI @xsuchy  (I merged this too quickly and caught it afterwards)


@swinslow - the txt file for this license includes the code * at the start of each line. I usually remove these, but made me wonder if that is necessary or we have any guideline around that? https://github.com/spdx/license-list-XML/blob/main/test/simpleTestForGenerator/MIT-testregex.txt