### PR TITLE
Clean up Soundex license

### DIFF
--- a/src/Soundex.xml
+++ b/src/Soundex.xml
@@ -6,14 +6,20 @@
          <crossRef>https://metacpan.org/release/RJBS/Text-Soundex-3.05/source/Soundex.pm#L3-11</crossRef>
       </crossRefs>
       <text>
+         <copyrightText>
+            <p>(c) Copyright 1998-2007 by Mark Mielke</p>
+         </copyrightText>
          <p>
-            # (c) Copyright 1998-2007 by Mark Mielke # # Freedom to use
-            these sources for whatever you want, as long as credit # is
+            Freedom to use
+            these sources for whatever you want, as long as credit is
             given where credit is due, is hereby granted. You may make
-            modifications # where you see fit but leave this copyright
-            somewhere visible. As well, try # to initial any changes you
-            make so that if I like the changes I can # incorporate them
-            into later versions. # # - Mark Mielke &lt;mark@mielke.cc&gt;
+            modifications where you see fit but leave this copyright
+            somewhere visible. As well, try to initial any changes you
+            make so that if I like the changes I can incorporate them
+            into later versions.
+         </p>
+         <p>
+            - Mark Mielke &lt;mark@mielke.cc&gt;
          </p>
       </text>
    </license>

--- a/test/simpleTestForGenerator/Soundex.txt
+++ b/test/simpleTestForGenerator/Soundex.txt
@@ -1,7 +1,9 @@
-# (c) Copyright 1998-2007 by Mark Mielke # # Freedom to use
-these sources for whatever you want, as long as credit # is
-given where credit is due, is hereby granted. You may make
-modifications # where you see fit but leave this copyright
-somewhere visible. As well, try # to initial any changes you
-make so that if I like the changes I can # incorporate them
-into later versions. # # - Mark Mielke <mark@mielke.cc>
+(c) Copyright 1998-2007 by Mark Mielke
+
+Freedom to use these sources for whatever you want, as long as credit
+is given where credit is due, is hereby granted. You may make modifications
+where you see fit but leave this copyright somewhere visible. As well, try
+to initial any changes you make so that if I like the changes I can
+incorporate them into later versions.
+
+     - Mark Mielke <mark@mielke.cc>


### PR DESCRIPTION
Clean up the prior work in #2054, which fixed #2018, a little, by marking up the copyright text and by removing superfluous comment chars.