### PR TITLE
New license: TTYP0

### DIFF
--- a/src/TTYP0.xml
+++ b/src/TTYP0.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SPDXLicenseCollection xmlns="http://www.spdx.org/license">
+   <license isOsiApproved="false" licenseId="TTYP0"
+   name="TTYP0 License" listVersionAdded="3.22">
+      <crossRefs>
+         <crossRef>https://people.mpi-inf.mpg.de/~uwe/misc/uw-ttyp0/</crossRef>
+      </crossRefs>
+      <text>
+         <titleText>
+            <p>THE TTYP0 LICENSE</p>
+         </titleText>
+         <p>
+            Permission is hereby granted, free of charge, to any person
+            obtaining a copy of this font software and associated files
+            (the "Software"), to deal in the Software without restriction,
+            including without limitation the rights to use, copy, modify,
+            merge, publish, distribute, embed, sublicense, and/or sell copies
+            of the Software, and to permit persons to whom the Software
+            is furnished to do so, subject to the following conditions:
+         </p>
+         <list>
+            <item>
+               <bullet>(1)</bullet>
+               <p>
+                  The above copyright notice, this permission notice,
+                  and the disclaimer below shall be included in all
+                  copies or substantial portions of the Software.
+               </p>
+            </item>
+            <item>
+               <bullet>(2)</bullet>
+               <p>
+                  If the design of any glyphs in the fonts that are contained
+                  in the Software or generated during the installation process
+                  is modified or if additional glyphs are added to the fonts,
+                  the fonts must be renamed. The new names may not contain the
+                  word "UW", irrespective of capitalisation; the new names may
+                  contain the word "ttyp0", irrespective of capitalisation,
+                  only if preceded by a foundry name different from "UW".
+               </p>
+               <p>
+                  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+                  KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+                  WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+                  PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+                  OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+                  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT
+                  OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH
+                  THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+               </p>
+            </item>
+         </list>
+      </text>
+   </license>
+</SPDXLicenseCollection>

--- a/test/simpleTestForGenerator/TTYP0.txt
+++ b/test/simpleTestForGenerator/TTYP0.txt
@@ -1,0 +1,30 @@
+THE TTYP0 LICENSE
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this font software and associated files (the "Software"),
+to deal in the Software without restriction, including without
+limitation the rights to use, copy, modify, merge, publish,
+distribute, embed, sublicense, and/or sell copies of the Software,
+and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+(1) The above copyright notice, this permission notice, and the
+    disclaimer below shall be included in all copies or substantial
+    portions of the Software.
+
+(2) If the design of any glyphs in the fonts that are contained in the
+    Software or generated during the installation process is modified
+    or if additional glyphs are added to the fonts, the fonts
+    must be renamed. The new names may not contain the word "UW",
+    irrespective of capitalisation; the new names may contain the word
+    "ttyp0", irrespective of capitalisation, only if preceded by a
+    foundry name different from "UW".
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+


### PR DESCRIPTION
Fixes: #2026

I updated the licenseName and moved the title to titleText (compared to what SPDX online tool generated).