### PR TITLE
Improve Apache-2.0 markup: align the structure with its origin

### DIFF
--- a/src/Apache-2.0.xml
+++ b/src/Apache-2.0.xml
@@ -138,13 +138,13 @@
                  License. You may add Your own attribution notices within Derivative Works that You
                  distribute, alongside or as an addendum to the NOTICE text from the Work, provided that
                  such additional attribution notices cannot be construed as modifying the License.
+               </item>
+            </list>
               <p>You may add Your own copyright statement to Your modifications and may provide additional or
                  different license terms and conditions for use, reproduction, or distribution of Your
                  modifications, or for any such Derivative Works as a whole, provided Your use,
                  reproduction, and distribution of the Work otherwise complies with the conditions stated
                  in this License.</p>
-               </item>
-            </list>
         </item>
         <item>
             <bullet>5.</bullet>


### PR DESCRIPTION
## Background

I have noticed that the markup in Apache-2.0 in this repo is not optimal when compared to the [plain text license version](https://www.apache.org/licenses/LICENSE-2.0.txt) available from ASF. When examining the [HTML version](https://www.apache.org/licenses/LICENSE-2.0) of the license over at apache.org, it became obvious that that HTML document had the difference to the text document as well. (I assumed that the markup in this repo might have been imported directly or indirectly from that [HTML version in 2016](https://web.archive.org/web/20160330133453/https://www.apache.org/licenses/LICENSE-2.0).)

Result was filing of apache/www-site#285, which has been merged a few hours ago.

## This pull request
With abovementioned change merged, even though I’m perfectly aware that it is the [text of the license and not the indentation](https://github.com/spdx/license-list-XML/pull/1396#issuecomment-1112651742) which matters, **I suggest to change the markup of Apache-2.0 in this SPDX repo to reflect the upstream document structure.**

## Remarks
Side note: the [OSI page for Apache-2.0](https://opensource.org/license/apache-2-0/) is fine in this respect, and seems to have always been: <https://web.archive.org/web/*/http://opensource.org/licenses/Apache-2.0>. 

Please see the commit message for a more detailed description of the change.