### PR TITLE
Fix license URL of Ruby

### DIFF
--- a/src/Ruby.xml
+++ b/src/Ruby.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="false" licenseId="Ruby" name="Ruby License">
       <crossRefs>
-         <crossRef>http://www.ruby-lang.org/en/LICENSE.txt</crossRef>
+         <crossRef>https://www.ruby-lang.org/en/about/license.txt</crossRef>
       </crossRefs>
       <notes>Ruby is disjunctively licensed project that allows the choice of this license and another. The other license
          choice has changed over time (from GPL originally, to BSD-2-Clause currently), so one needs to be


### PR DESCRIPTION
Hello, I'm administrator of ruby-lang.org. I fixed distribution URL of Ruby's license.