### PR TITLE
Small corrections in NPL-1.0 text

### DIFF
--- a/src/NPL-1.0.xml
+++ b/src/NPL-1.0.xml
@@ -42,7 +42,7 @@
                <item>
                   <bullet>1.6.</bullet>
               ``Initial Developer'' means the individual or entity identified as the Initial Developer in
-                 the Source Code notice required byExhibit A.
+                 the Source Code notice required by Exhibit A.
             </item>
                <item>
                   <bullet>1.7.</bullet>
@@ -73,7 +73,7 @@
                <item>
                   <bullet>1.10.</bullet>
               ``Original Code'' means Source Code of computer software code which is described in the
-                 Source Code notice required byExhibit A as Original Code, and which, at the time of its
+                 Source Code notice required by Exhibit A as Original Code, and which, at the time of its
                  release under this License is not already Covered Code governed by this License.
             </item>
                <item>

--- a/src/NPL-1.0.xml
+++ b/src/NPL-1.0.xml
@@ -109,7 +109,7 @@
                  claims:
               <list>
                      <item>
-                        <bullet>a)</bullet>
+                        <bullet>(a)</bullet>
                   to use, reproduce, modify, display, perform, sublicense and distribute the
                      Original Code (or portions thereof) with or without Modifications, or as part of a
                      Larger Work; and

--- a/test/simpleTestForGenerator/NPL-1.0.txt
+++ b/test/simpleTestForGenerator/NPL-1.0.txt
@@ -8,13 +8,13 @@ NETSCAPE PUBLIC LICENSE Version 1.0
      1.3. ``Covered Code'' means the Original Code or Modifications or the combination of the Original Code and Modifications, in each case including portions thereof.
      1.4. ``Electronic Distribution Mechanism'' means a mechanism generally accepted in the software development community for the electronic transfer of data.
      1.5. ``Executable'' means Covered Code in any form other than Source Code.
-     1.6. ``Initial Developer'' means the individual or entity identified as the Initial Developer in the Source Code notice required byExhibit A.
+     1.6. ``Initial Developer'' means the individual or entity identified as the Initial Developer in the Source Code notice required by Exhibit A.
      1.7. ``Larger Work'' means a work which combines Covered Code or portions thereof with code not governed by the terms of this License.
      1.8. ``License'' means this document.
      1.9. ``Modifications'' means any addition to or deletion from the substance or structure of either the Original Code or any previous Modifications. When Covered Code is released as a series of files, a Modification is:
           A. Any addition to or deletion from the contents of a file containing Original Code or previous Modifications.           B. Any new file that contains any part of the Original Code or previous Modifications.
 
-     1.10. ``Original Code'' means Source Code of computer software code which is described in the Source Code notice required byExhibit A as Original Code, and which, at the time of its release under this License is not already Covered Code governed by this License.
+     1.10. ``Original Code'' means Source Code of computer software code which is described in the Source Code notice required by Exhibit A as Original Code, and which, at the time of its release under this License is not already Covered Code governed by this License.
      1.11. ``Source Code'' means the preferred form of the Covered Code for making modifications to it, including all modules it contains, plus any associated interface definition files, scripts used to control compilation and installation of an Executable, or a list of source code differential comparisons against either the Original Code or another well known, available Covered Code of the Contributor's choice. The Source Code can be in a compressed or archival form, provided the appropriate decompression or de-archiving software is widely available for no charge.
      1.12. ``You'' means an individual or a legal entity exercising rights under, and complying with all of the terms of, this License or a future version of this License issued under Section 6.1. For legal entities, ``You'' includes any entity which controls, is controlled by, or is under common control with You. For purposes of this definition, ``control'' means (a) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (b) ownership of fifty percent (50%) or more of the outstanding shares or beneficial ownership of such entity.
 

--- a/test/simpleTestForGenerator/NPL-1.0.txt
+++ b/test/simpleTestForGenerator/NPL-1.0.txt
@@ -21,7 +21,7 @@ NETSCAPE PUBLIC LICENSE Version 1.0
 2. Source Code License.
 
      2.1. The Initial Developer Grant. The Initial Developer hereby grants You a world-wide, royalty-free, non-exclusive license, subject to third party intellectual property claims:
-          a) to use, reproduce, modify, display, perform, sublicense and distribute the Original Code (or portions thereof) with or without Modifications, or as part of a Larger Work; and
+          (a) to use, reproduce, modify, display, perform, sublicense and distribute the Original Code (or portions thereof) with or without Modifications, or as part of a Larger Work; and
           (b) under patents now or hereafter owned or controlled by Initial Developer, to make, have made, use and sell (``Utilize'') the Original Code (or portions thereof), but solely to the extent that any such patent is reasonably necessary to enable You to Utilize the Original Code (or portions thereof) and not to any greater extent that may be necessary to Utilize further Modifications or combinations.
 
      2.2. Contributor Grant.  Each Contributor hereby grants You a world-wide, royalty-free, non-exclusive license, subject to third party intellectual property claims:


### PR DESCRIPTION
Since its addition to this repository (in commit d0d11d311f2e783615d162b0538f0213e9493dff), the text of `src/NPL-1.0.xml` has had some minor mistakes when compared to the URI in the cross reference (see the [upstream license text](https://web.archive.org/web/20160304040122/http://www.mozilla.org/MPL/NPL/1.0/) at the time when the license was imported).

This pull request fixes these mistakes. See the individual commits for details.