### PR TITLE
Add BSD-3-Clause-Sun license

### DIFF
--- a/src/BSD-3-Clause-Sun.xml
+++ b/src/BSD-3-Clause-Sun.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SPDXLicenseCollection xmlns="http://www.spdx.org/license">
+  <license isOsiApproved="false" licenseId="BSD-3-Clause-Sun" name="BSD 3-Clause Sun Microsystems">
+    <crossRefs>
+    <crossRef>https://github.com/xmlark/msv/blob/b9316e2f2270bc1606952ea4939ec87fbba157f3/xsdlib/src/main/java/com/sun/msv/datatype/regexp/InternalImpl.java</crossRef>
+    </crossRefs>
+    <notes>
+      This license is very similar to BSD-3-Clause-No-Nuclear-Warranty except it
+      has variations in the disclaimer and omits the no-nuclear-warranty at the
+      end.
+    </notes>
+    <text>
+      <copyrightText>
+        <p>Copyright (c) 2001-2013 Oracle and/or its affiliates. All rights reserved.</p>
+      </copyrightText>
+      <p>
+        Redistribution and  use in  source and binary  forms, with  or without
+        modification, are permitted provided that the following conditions are
+        met:
+      </p>
+      <list>
+        <item>
+          <bullet>-</bullet>
+          Redistributions  of  source code  must  retain  the above  copyright
+          notice, this list of conditions and the following disclaimer.
+        </item>
+        <item>
+          <bullet>-</bullet>
+          Redistribution  in binary  form must  reproduct the  above copyright
+          notice, this list of conditions  and the following disclaimer in the
+          documentation and/or other materials provided with the distribution.
+        </item>
+      </list>
+      <p>
+        Neither  the  name   of  Sun  Microsystems,  Inc.  or   the  names  of
+        contributors may be  used to endorse or promote  products derived from
+        this software without specific prior written permission.
+      </p>
+      <p>
+        This software is provided "AS IS," without a warranty of any kind. ALL
+        EXPRESS  OR   IMPLIED  CONDITIONS,  REPRESENTATIONS   AND  WARRANTIES,
+        INCLUDING  ANY  IMPLIED WARRANTY  OF  MERCHANTABILITY,  FITNESS FOR  A
+        PARTICULAR PURPOSE  OR NON-INFRINGEMENT, ARE HEREBY  EXCLUDED. SUN AND
+        ITS  LICENSORS SHALL  NOT BE  LIABLE  FOR ANY  DAMAGES OR  LIABILITIES
+        SUFFERED BY LICENSEE  AS A RESULT OF OR  RELATING TO USE, MODIFICATION
+        OR DISTRIBUTION OF  THE SOFTWARE OR ITS DERIVATIVES.  IN NO EVENT WILL
+        SUN OR ITS  LICENSORS BE LIABLE FOR ANY LOST  REVENUE, PROFIT OR DATA,
+        OR  FOR  DIRECT,   INDIRECT,  SPECIAL,  CONSEQUENTIAL,  INCIDENTAL  OR
+        PUNITIVE  DAMAGES, HOWEVER  CAUSED  AND REGARDLESS  OF  THE THEORY  OF
+        LIABILITY, ARISING  OUT OF  THE USE OF  OR INABILITY TO  USE SOFTWARE,
+        EVEN IF SUN HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+      </p>
+    </text>
+  </license>
+</SPDXLicenseCollection>

--- a/test/simpleTestForGenerator/BSD-3-Clause-Sun.txt
+++ b/test/simpleTestForGenerator/BSD-3-Clause-Sun.txt
@@ -1,0 +1,29 @@
+Copyright (c) 2001-2013 Oracle and/or its affiliates. All rights reserved.
+
+Redistribution and  use in  source and binary  forms, with  or without
+modification, are permitted provided that the following conditions are
+met:
+
+- Redistributions  of  source code  must  retain  the above  copyright
+  notice, this list of conditions and the following disclaimer.
+
+- Redistribution  in binary  form must  reproduct the  above copyright
+  notice, this list of conditions  and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+
+Neither  the  name   of  Sun  Microsystems,  Inc.  or   the  names  of
+contributors may be  used to endorse or promote  products derived from
+this software without specific prior written permission.
+
+This software is provided "AS IS," without a warranty of any kind. ALL
+EXPRESS  OR   IMPLIED  CONDITIONS,  REPRESENTATIONS   AND  WARRANTIES,
+INCLUDING  ANY  IMPLIED WARRANTY  OF  MERCHANTABILITY,  FITNESS FOR  A
+PARTICULAR PURPOSE  OR NON-INFRINGEMENT, ARE HEREBY  EXCLUDED. SUN AND
+ITS  LICENSORS SHALL  NOT BE  LIABLE  FOR ANY  DAMAGES OR  LIABILITIES
+SUFFERED BY LICENSEE  AS A RESULT OF OR  RELATING TO USE, MODIFICATION
+OR DISTRIBUTION OF  THE SOFTWARE OR ITS DERIVATIVES.  IN NO EVENT WILL
+SUN OR ITS  LICENSORS BE LIABLE FOR ANY LOST  REVENUE, PROFIT OR DATA,
+OR  FOR  DIRECT,   INDIRECT,  SPECIAL,  CONSEQUENTIAL,  INCIDENTAL  OR
+PUNITIVE  DAMAGES, HOWEVER  CAUSED  AND REGARDLESS  OF  THE THEORY  OF
+LIABILITY, ARISING  OUT OF  THE USE OF  OR INABILITY TO  USE SOFTWARE,
+EVEN IF SUN HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.


### PR DESCRIPTION
Related: #2081
Notes:
* **TODO** at `crossRefs`, I didn't know what to fill in
* `copyrightText / list / item number 3`, I am unsure if it qualifies as an item with an empty bullet or if the text belongs to the following `<p>`
* I used name **BSD 3-Clause Sun Microsystems** instead of **BSD 3-Clause Sun** because I think the word Sun itself is too vague.