### PR TITLE
Add markup to GCC-exception-2.0.xml

### DIFF
--- a/src/exceptions/GCC-exception-2.0.xml
+++ b/src/exceptions/GCC-exception-2.0.xml
@@ -7,11 +7,11 @@
       <notes>Typically used with GPL-2.0-or-later.  Sometimes also referred to as "linking exception."</notes>
     <text>
       <p>In addition to the permissions in the GNU
-        <optional>Library</optional> General Public License, the <alt match=".+" name="authors">authors</alt>
+       <alt match="Library|Lesser</alt> General Public License, the <alt match=".+" name="authors">authors</alt>
         <alt match="give(s)?" name="gives">give</alt> you unlimited permission to link the compiled version of this
         <alt name="file" match="file|library">file</alt><optional> into combinations</optional> with other programs,
         and to distribute those <alt name="programs" match="combinations|programs">programs</alt> without any restriction
-        coming from the use of this file.  (The <alt name="general" match="General|Library">General</alt> Public License
+        coming from the use of this file.  (The <alt name="general" match="General|Library|GNU Lesser">General</alt> Public License
         restrictions do apply in other respects; for example, they cover modification of the file, and distribution
         when not linked into
         <alt name="anotherProgram" match="a combined? executable|another program">another program</alt>.)</p>

--- a/src/exceptions/GCC-exception-2.0.xml
+++ b/src/exceptions/GCC-exception-2.0.xml
@@ -8,7 +8,7 @@
       <notes>Typically used with GPL-2.0-or-later.  Sometimes also referred to as "linking exception."</notes>
     <text>
       <p>In addition to the permissions in the GNU
-       <alt match="Library|Lesser"</alt> General Public License, the <alt match=".+" name="authors">authors</alt>
+       <alt match="Library|Lesser" name"Library"> </alt> General Public License, the <alt match=".+" name="authors">authors</alt>
         <alt match="give(s)?" name="gives">give</alt> you unlimited permission to link the compiled version of this
         <alt name="file" match="file|library">file</alt><optional> into combinations</optional> with other programs,
         and to distribute those <alt name="programs" match="combinations|programs">programs</alt> without any restriction

--- a/src/exceptions/GCC-exception-2.0.xml
+++ b/src/exceptions/GCC-exception-2.0.xml
@@ -3,11 +3,12 @@
    <exception licenseId="GCC-exception-2.0" name="GCC Runtime Library exception 2.0">
       <crossRefs>
          <crossRef>https://gcc.gnu.org/git/?p=gcc.git;a=blob;f=gcc/libgcc1.c;h=762f5143fc6eed57b6797c82710f3538aa52b40b;hb=cb143a3ce4fb417c68f5fa2691a1b1b1053dfba9#l10</crossRef>
+         <crossRef>https://sourceware.org/git/?p=glibc.git;a=blob;f=csu/abi-note.c;h=c2ec208e94fbe91f63d3c375bd254b884695d190;hb=HEAD</crossRef
       </crossRefs>
       <notes>Typically used with GPL-2.0-or-later.  Sometimes also referred to as "linking exception."</notes>
     <text>
       <p>In addition to the permissions in the GNU
-       <alt match="Library|Lesser</alt> General Public License, the <alt match=".+" name="authors">authors</alt>
+       <alt match="Library|Lesser"</alt> General Public License, the <alt match=".+" name="authors">authors</alt>
         <alt match="give(s)?" name="gives">give</alt> you unlimited permission to link the compiled version of this
         <alt name="file" match="file|library">file</alt><optional> into combinations</optional> with other programs,
         and to distribute those <alt name="programs" match="combinations|programs">programs</alt> without any restriction

--- a/src/exceptions/GCC-exception-2.0.xml
+++ b/src/exceptions/GCC-exception-2.0.xml
@@ -3,12 +3,12 @@
    <exception licenseId="GCC-exception-2.0" name="GCC Runtime Library exception 2.0">
       <crossRefs>
          <crossRef>https://gcc.gnu.org/git/?p=gcc.git;a=blob;f=gcc/libgcc1.c;h=762f5143fc6eed57b6797c82710f3538aa52b40b;hb=cb143a3ce4fb417c68f5fa2691a1b1b1053dfba9#l10</crossRef>
-         <crossRef>https://sourceware.org/git/?p=glibc.git;a=blob;f=csu/abi-note.c;h=c2ec208e94fbe91f63d3c375bd254b884695d190;hb=HEAD</crossRef
+         <crossRef>https://sourceware.org/git/?p=glibc.git;a=blob;f=csu/abi-note.c;h=c2ec208e94fbe91f63d3c375bd254b884695d190;hb=HEAD</crossRef>
       </crossRefs>
       <notes>Typically used with GPL-2.0-or-later.  Sometimes also referred to as "linking exception."</notes>
     <text>
       <p>In addition to the permissions in the GNU
-       <alt match="Library|Lesser" name"Library"> </alt> General Public License, the <alt match=".+" name="authors">authors</alt>
+       <alt match="Library|Lesser|()" name="Library"> </alt> General Public License, the <alt match=".+" name="authors">authors</alt>
         <alt match="give(s)?" name="gives">give</alt> you unlimited permission to link the compiled version of this
         <alt name="file" match="file|library">file</alt><optional> into combinations</optional> with other programs,
         and to distribute those <alt name="programs" match="combinations|programs">programs</alt> without any restriction


### PR DESCRIPTION
fixes #2055 

Signed-off-by: Jilayne Lovejoy

needs a bit more work for first set of markup:  `<alt match="Library|Lesser"</alt>` really needs to be Library or Lesser or nothing. @swinslow is there a way to do that?

which is also why it's not matching to the .txt file