### PR TITLE
Fix exception tag in stunnel-exception

### DIFF
--- a/src/exceptions/stunnel-exception.xml
+++ b/src/exceptions/stunnel-exception.xml
@@ -27,5 +27,5 @@
             release a modified version which carries forward this exception.
          </p>
       </text>
-   </license>
+   </exception>
 </SPDXLicenseCollection>

--- a/src/exceptions/stunnel-exception.xml
+++ b/src/exceptions/stunnel-exception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <exception isOsiApproved="false" licenseId="stunnel-exception"
+   <exception licenseId="stunnel-exception"
    name="stunnel Exception" listVersionAdded="3.22">
       <crossRefs>
          <crossRef>https://github.com/mtrojnar/stunnel/blob/master/COPYING.md</crossRef>

--- a/src/exceptions/stunnel-exception.xml
+++ b/src/exceptions/stunnel-exception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isOsiApproved="false" licenseId="stunnel-exception"
+   <exception isOsiApproved="false" licenseId="stunnel-exception"
    name="stunnel Exception" listVersionAdded="3.22">
       <crossRefs>
          <crossRef>https://github.com/mtrojnar/stunnel/blob/master/COPYING.md</crossRef>


### PR DESCRIPTION
stunnel-exception was inadvertently added with an intro tag of `license` rather than `exception`. This PR fixes that.

Signed-off-by: Steve Winslow <steve@swinslow.net>