### PR TITLE
Fix tags for new exceptions

### DIFF
--- a/src/exceptions/GNU-compiler-exception.xml
+++ b/src/exceptions/GNU-compiler-exception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isOsiApproved="false" licenseId="GNU-compiler-exception"
+   <exception licenseId="GNU-compiler-exception"
    name="GNU Compiler Exception" listVersionAdded="3.22">
       <crossRefs>
          <crossRef>https://sourceware.org/git?p=binutils-gdb.git;a=blob;f=libiberty/unlink-if-ordinary.c;h=e49f2f2f67bfdb10d6b2bd579b0e01cad0fd708e;hb=HEAD#l19</crossRef>
@@ -18,5 +18,5 @@
             file might be covered by the GNU General Public License.
          </p>
       </text>
-   </license>
+   </exception>
 </SPDXLicenseCollection>

--- a/src/exceptions/SANE-exception.xml
+++ b/src/exceptions/SANE-exception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isOsiApproved="false" licenseId="SANE-exception"
+   <exception licenseId="SANE-exception"
    name="SANE Exception" listVersionAdded="3.22">
       <crossRefs>
          <crossRef>https://github.com/alexpevzner/sane-airscan/blob/master/LICENSE</crossRef>
@@ -35,5 +35,5 @@
             If you do not wish that, delete this exception notice.
          </p>
       </text>
-   </license>
+   </exception>
 </SPDXLicenseCollection>

--- a/src/exceptions/Texinfo-exception.xml
+++ b/src/exceptions/Texinfo-exception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isOsiApproved="false" licenseId="Texinfo-exception"
+   <exception licenseId="Texinfo-exception"
    name="Texinfo exception" listVersionAdded="3.22">
       <crossRefs>
          <crossRef>https://git.savannah.gnu.org/cgit/automake.git/tree/lib/texinfo.tex?h=v1.16.5#n23</crossRef>
@@ -13,5 +13,5 @@
             section 7 of the GNU General Public License, version 3 ("GPLv3").
          </p>
       </text>
-   </license>
+   </exception>
 </SPDXLicenseCollection>


### PR DESCRIPTION
As with #2198, this fixes a few new exceptions that inadvertently had a `license` tag applied.

Signed-off-by: Steve Winslow <steve@swinslow.net>