### PR TITLE
Update link for MIT license on OSI website

### DIFF
--- a/src/MIT.xml
+++ b/src/MIT.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="MIT" name="MIT License">
       <crossRefs>
-         <crossRef>https://opensource.org/licenses/MIT</crossRef>
+         <crossRef>https://opensource.org/license/mit/</crossRef>
       </crossRefs>
     <text>
       <titleText>


### PR DESCRIPTION
I noticed that the page for MIT lists a broken link - the information does seem to exist on OSI's site though, at a new URL: https://opensource.org/license/mit/

Updated the MIT file to reflect this.