### PR TITLE
Fix python-ldap license link

### DIFF
--- a/src/python-ldap.xml
+++ b/src/python-ldap.xml
@@ -3,8 +3,7 @@
    <license isOsiApproved="false" licenseId="python-ldap"
    name="Python ldap License" listVersionAdded="3.22">
       <crossRefs>
-         <crossRef>https://github.com/zdohnal/hplip/blob/master/base/ldif.py</crossRef>
-         <crossRef>https://sourceforge.net/projects/hplip/files/hplip/3.23.5/hplip-3.23.5.tar.gz/download</crossRef>
+         <crossRef>https://github.com/python-ldap/python-ldap/blob/main/LICENCE</crossRef>
       </crossRefs>
       <text>
          <p>


### PR DESCRIPTION
Fixes: https://github.com/spdx/license-list-XML/issues/2256