### PR TITLE
new license: W3C-20230101

### DIFF
--- a/src/W3C-20230101.xml
+++ b/src/W3C-20230101.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SPDXLicenseCollection xmlns="http://www.spdx.org/license">
+   <license isOsiApproved="false" licenseId="W3C-20230101" listVersionAdded="3.23"
+            name="W3C Software Notice and Document License (2023-01-01)">
+   <crossRefs>
+      <crossRef>https://www.w3.org/copyright/software-license-2023/</crossRef>
+   </crossRefs>
+   <standardLicenseHeader>
+This software or document includes material copied from or derived from <alt
+match=".+" name="softwareOrDocumentNameURI">[$name: $URI]</alt>. Copyright (c)
+<alt match=".+" name="year">[$date-of-software]</alt> World Wide Web
+Consortium. https://www.w3.org/copyright/software-license-2023/
+   </standardLicenseHeader>
+   <notes>This license takes effect 1st January, 2023. This version updates
+   identification of the copyright holder.</notes>
+    <text>
+      <p>This work is being provided by the copyright holders under the
+      following license.</p>
+      <p>License
+         <br/>By obtaining and/or copying this work, you (the licensee) agree
+         that you have read, understood, and will comply with the following
+         terms and conditions.
+      </p>
+      <p>Permission to copy, modify, and distribute this work, with or without
+      modification, for any purpose and without fee or royalty is hereby
+      granted, provided that you include the following on ALL copies of the
+      work or portions thereof, including modifications:</p>
+      <list>
+         <item>
+            <bullet>•</bullet>
+            The full text of this NOTICE in a location viewable to users of
+            the redistributed or derivative work.
+         </item>
+         <item>
+            <bullet>•</bullet>
+            Any pre-existing intellectual property disclaimers, notices, or
+            terms and conditions. If none exist, the W3C software and document
+            short notice should be included.
+         </item>
+         <item>
+            <bullet>•</bullet>
+            Notice of any changes or modifications, through a copyright
+            statement on the new code or document such as "This software or
+            document includes material copied from or derived from [title and
+            URI of the W3C document]. Copyright © [$year-of-document] World
+            Wide Web Consortium.
+            https://www.w3.org/copyright/software-license-2023/"
+         </item>
+      </list>
+      <p>disclaimers
+         <br/>THIS WORK IS PROVIDED "AS IS," AND COPYRIGHT HOLDERS MAKE NO
+         REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT
+         NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY OR FITNESS FOR ANY
+         PARTICULAR PURPOSE OR THAT THE USE OF THE SOFTWARE OR DOCUMENT
+         WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS
+         OR OTHER RIGHTS.
+         <br/>
+         <br/>COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT,
+         SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE
+         SOFTWARE OR DOCUMENT.
+      </p>
+      <p>The name and trademarks of copyright holders may NOT be used in
+      advertising or publicity pertaining to the work without specific,
+      written prior permission. Title to copyright in this work will at all
+      times remain with copyright holders.</p>
+    </text>
+  </license>
+</SPDXLicenseCollection>

--- a/test/simpleTestForGenerator/W3C-20230101.txt
+++ b/test/simpleTestForGenerator/W3C-20230101.txt
@@ -1,0 +1,17 @@
+This work is being provided by the copyright holders under the following license.
+
+License
+By obtaining and/or copying this work, you (the licensee) agree that you have read, understood, and will comply with the following terms and conditions.
+
+Permission to copy, modify, and distribute this work, with or without modification, for any purpose and without fee or royalty is hereby granted, provided that you include the following on ALL copies of the work or portions thereof, including modifications:
+
+     • The full text of this NOTICE in a location viewable to users of the redistributed or derivative work.
+     • Any pre-existing intellectual property disclaimers, notices, or terms and conditions. If none exist, the W3C software and document short notice should be included.
+     • Notice of any changes or modifications, through a copyright statement on the new code or document such as "This software or document includes material copied from or derived from [title and URI of the W3C document]. Copyright © [$year-of-document] World Wide Web Consortium. https://www.w3.org/copyright/software-license-2023/"
+
+Disclaimers
+THIS WORK IS PROVIDED "AS IS," AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF THE SOFTWARE OR DOCUMENT WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
+
+COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE SOFTWARE OR DOCUMENT.
+
+The name and trademarks of copyright holders may NOT be used in advertising or publicity pertaining to the work without specific, written prior permission. Title to copyright in this work will at all times remain with copyright holders.


### PR DESCRIPTION
Add updated W3C license, the previous versions date from 2015, 2002, and 1998.

I'd also perhaps suggest renaming W3C.xml to W3C-20021231.xml for clarity, though do understand this would be a breaking change. I think I've followed the steps necessary to add a license, so please do let me know if I've missed something, first time contributor.