### PR TITLE
migrate to checkout@v4

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -13,7 +13,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '11'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Fetch changes for git diff
         id: fetchdiff
         run: |

--- a/.github/workflows/finalised-license-comment.yaml
+++ b/.github/workflows/finalised-license-comment.yaml
@@ -14,7 +14,7 @@ jobs:
     name: Comment automatically on accepted license requests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install git3po
         run: npm install -g git3po
       - name: Run `git3po` to leave comment

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -8,7 +8,7 @@ jobs:
     name: Validate schema
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python 3.10
         uses: actions/setup-python@v3
         with:
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: '11'
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Fetch changes for git diff
         id: fetchdiff
         run: |


### PR DESCRIPTION
https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
https://github.com/actions/checkout/releases

git3po is no longer possible to install with checkout@v2

Note that I did not test this PR as I have no idea how to test it.