### PR TITLE
SWI-exception: Revise notes

### DIFF
--- a/src/exceptions/SWI-exception.xml
+++ b/src/exceptions/SWI-exception.xml
@@ -4,8 +4,8 @@
    <crossRefs>
       <crossRef>https://github.com/SWI-Prolog/packages-clpqr/blob/bfa80b9270274f0800120d5b8e6fef42ac2dc6a5/clpqr/class.pl</crossRef>
    </crossRefs>
-      <notes>This exception is the same as GNU-compiler-exception but 
-         delineates that the library is compiled with a Free Softare compiler, 
+      <notes>This exception is closely similar to GNU-compiler-exception but 
+         delineates that the library is compiled with a Free Software compiler, 
          which is slightly broader than a GNU compiler.</notes>
    <text>
       <p>


### PR DESCRIPTION
As a follow-on from #2297, a couple of things here:

* typo fix: "softare" => "software"
* wording is slightly different between the two (beyond just the "free software" reference), so I opted for "closely similar" rather than "the same as"

Signed-off-by: Steve Winslow <steve@swinslow.net>