### PR TITLE
Add fmt-exception

### DIFF
--- a/src/exceptions/fmt-exception.xml
+++ b/src/exceptions/fmt-exception.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <exception licenseId="fmt-exception" name="fmt exception">
+   <exception licenseId="fmt-exception" name="fmt exception" listVersionAdded="3.23">
    <crossRefs>
       <crossRef>https://github.com/fmtlib/fmt/blob/master/LICENSE</crossRef>
       <crossRef>https://github.com/fmtlib/fmt/blob/2eb363297b24cd71a68ccfb20ff755430f17e60f/LICENSE#L22C1-L27C62</crossRef>
    </crossRefs>
+   <notes>
+      Typically used with MIT.
+  </notes>
    <text>
       <optional><p>--- Optional exception to the license ---</p></optional>
       <p>

--- a/src/exceptions/fmt-exception.xml
+++ b/src/exceptions/fmt-exception.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SPDXLicenseCollection xmlns="http://www.spdx.org/license">
+   <exception licenseId="fmt-exception" name="fmt exception">
+   <crossRefs>
+      <crossRef>https://github.com/fmtlib/fmt/blob/master/LICENSE</crossRef>
+      <crossRef>https://github.com/fmtlib/fmt/blob/2eb363297b24cd71a68ccfb20ff755430f17e60f/LICENSE#L22C1-L27C62</crossRef>
+   </crossRefs>
+   <text>
+      <optional><p>--- Optional exception to the license ---</p></optional>
+      <p>
+	As an exception, if, as a result of your compiling your source code, portions
+	of this Software are embedded into a machine-executable object form of such
+	source code, you may redistribute such embedded portions in such object form
+	without including the above copyright and permission notices.
+      </p>
+   </text>
+   </exception>
+</SPDXLicenseCollection>

--- a/test/simpleTestForGenerator/fmt-exception.txt
+++ b/test/simpleTestForGenerator/fmt-exception.txt
@@ -1,0 +1,6 @@
+--- Optional exception to the license ---
+
+As an exception, if, as a result of your compiling your source code, portions
+of this Software are embedded into a machine-executable object form of such
+source code, you may redistribute such embedded portions in such object form
+without including the above copyright and permission notices.


### PR DESCRIPTION

This adds a new exception, found in the license of `fmtlib`, as per #2282.

Notes:

- I assume the `listVersionAdded` attribute will be (automatically?) added in the next release of the License List, so I didn't add it.
- I made the heading line `<optional>`, since the exception text might appear without it. If there is disagreement, I can make it mandatory.

Closes #2282
