### PR TITLE
BSD-3-Clause-No-Nuclear-License: Update the license URL

### DIFF
--- a/src/BSD-3-Clause-No-Nuclear-License.xml
+++ b/src/BSD-3-Clause-No-Nuclear-License.xml
@@ -3,7 +3,7 @@
    <license isOsiApproved="false" licenseId="BSD-3-Clause-No-Nuclear-License"
             name="BSD 3-Clause No Nuclear License">
       <crossRefs>
-         <crossRef>http://download.oracle.com/otn-pub/java/licenses/bsd.txt?AuthParam=1467140197_43d516ce1776bd08a58235a7785be1cc</crossRef>
+         <crossRef>http://download.oracle.com/otn-pub/java/licenses/bsd.txt</crossRef>
       </crossRefs>
       <notes>This license has an older Sun copyright notice and is the same
          license as BSD-3-Clause-No-Nuclear-Warranty, except it


### PR DESCRIPTION
Remove the "AuthParam". It seems unnecessary to add as it will be generated each time a new user goes to http://download.oracle.com/otn-pub/java/licenses/bsd.txt. Also, with that AuthParam, I can't see the license (the site throws an "unauthorized request" error).