### PR TITLE
Adding markup to openvpn-openssl exception

### DIFF
--- a/src/exceptions/openvpn-openssl-exception.xml
+++ b/src/exceptions/openvpn-openssl-exception.xml
@@ -19,9 +19,9 @@
          the same license as OpenSSL), and distribute linked
          combinations including the two. You must obey the GNU <optional>Lesser</optional> General
          Public License in all respects for all of the code used other
-         than OpenSSL. If you modify <alt name="file" match="(this file)|file(\(s\))?">this file</alt><alt name="this exception" match="()|( with this exception)"></alt>,
+         than OpenSSL. If you modify <alt name="file" match="(this file)|file(\(s\))?">this file</alt><alt name="this exception" match="()|( with this exception)" spacing="none"></alt>,
          you may extend this
-         exception to your version of the file, but you are not
+         exception to your version of the <alt name="file2" match="file(\(s\))?">file</alt>, but you are not
          obligated to do so. If you do not wish to do so, delete this
          exception statement from your version.</p>
          <optional>


### PR DESCRIPTION
Fixes #2401 

- Adds matching to be "version of the file" or "version of the file(s)".
- Removes a space before the comma
<img width="75" alt="image" src="https://github.com/spdx/license-list-XML/assets/5489711/e6a78061-3d83-4fff-9922-e98b8f9c27f9">
