### PR TITLE
chore: update to actions/setup-python@v5

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python 3.10
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
       - name: Install dependencies


### PR DESCRIPTION
v3 is using node16
Cauing a warning:

Validate schema
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/setup-python@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

v5 seems to be current according to https://github.com/actions/setup-python