### PR TITLE
Add cross-ref for ISC-Veillard variant

### DIFF
--- a/src/ISC-Veillard.xml
+++ b/src/ISC-Veillard.xml
@@ -5,9 +5,11 @@
       <crossRefs>
          <crossRef>https://raw.githubusercontent.com/GNOME/libxml2/4c2e7c651f6c2f0d1a74f350cbda95f7df3e7017/hash.c</crossRef>
          <crossRef>https://github.com/GNOME/libxml2/blob/master/dict.c</crossRef>
+         <crossRef>https://sourceforge.net/p/ctrio/git/ci/master/tree/README</crossRef>
       </crossRefs>
       <notes>
         This license uses the same grant as ISC, but a different disclaimer paragraph.
+        It originates from the Trio printf library.
       </notes>
       <text>
          <copyrightText>

--- a/src/ISC-Veillard.xml
+++ b/src/ISC-Veillard.xml
@@ -9,7 +9,7 @@
       </crossRefs>
       <notes>
         This license uses the same grant as ISC, but a different disclaimer paragraph.
-        It originates from the Trio printf library.
+        It appears to originate from the Trio printf library.
       </notes>
       <text>
          <copyrightText>


### PR DESCRIPTION
This license originates from the Trio printf library.