### PR TITLE
Update license-matching-guidelines-and-templates.md

### DIFF
--- a/DOCS/license-matching-guidelines-and-templates.md
+++ b/DOCS/license-matching-guidelines-and-templates.md
@@ -89,11 +89,11 @@ XML files do not require specific markup to implement this guideline.
 
 Because punctuation can change the meaning of a sentence, punctuation needs to be included in the matching process. 
 
-XML files do not require specific markup to implement this guideline. 
+XML files do not require specific markup to implement this guideline, unless to indicate an exception to the guideline. 
 
 ### B.6.2  Guideline: punctuation <a name="B.6.2"></a>
 
-Punctuation should be matched, unless otherwise stated in these guidelines.
+Punctuation should be matched, unless otherwise stated in these guidelines or unless specific markup is added.
 
 ### B.6.3  Guideline: hyphens, dashes <a name="B.6.3"></a>
 
@@ -103,15 +103,21 @@ Any hyphen, dash, en dash, em dash, or other variation should be considered equi
 
 Any variation of quotations (single, double, curly, etc.) should be considered equivalent.
 
-## B.7 Code Comment Indicators <a name="B.7"></a>
+## B.7 Code Comment Indicators or Separators <a name="B.7"></a>
 
 ### B.7.1  Purpose <a name="B.7.1"></a>
 
-To avoid the possibility of a non-match due to the existence or absence of code comment indicators placed within the license text, e.g. at the start of each line of text.
+To avoid the possibility of a non-match due to  the existence or absence of code comment indicators placed within the license text, e.g. at the start of each line of text, or repetitive characters to establish a separation of text.
 
 ### B.7.2  Guideline <a name="B.7.2"></a>
 
 Any kind of code comment indicator or prefix which occurs at the beginning of each line in a matchable section should be ignored for matching purposes. 
+
+XML files do not require specific markup to implement this guideline. 
+
+### B.7.3  Guideline <a name="B.7.3"></a>
+
+A non-letter character repeated 3 or more times to establish a visual separation should be ignored for matching purposes. 
 
 XML files do not require specific markup to implement this guideline. 
 

--- a/DOCS/license-matching-guidelines-and-templates.md
+++ b/DOCS/license-matching-guidelines-and-templates.md
@@ -107,7 +107,7 @@ Any variation of quotations (single, double, curly, etc.) should be considered e
 
 ### B.7.1  Purpose <a name="B.7.1"></a>
 
-To avoid the possibility of a non-match due to  the existence or absence of code comment indicators placed within the license text, e.g., at the start of each line of text, or repetitive characters to establish a separation of text, e.g., ---, ===, ___, or ***.
+To avoid the possibility of a non-match due to the existence or absence of code comment indicators placed within the license text, e.g., at the start of each line of text, or repetitive characters to establish a separation of text, e.g., ---, ===, ___, or ***.
 
 ### B.7.2  Guideline <a name="B.7.2"></a>
 

--- a/DOCS/license-matching-guidelines-and-templates.md
+++ b/DOCS/license-matching-guidelines-and-templates.md
@@ -107,7 +107,7 @@ Any variation of quotations (single, double, curly, etc.) should be considered e
 
 ### B.7.1  Purpose <a name="B.7.1"></a>
 
-To avoid the possibility of a non-match due to  the existence or absence of code comment indicators placed within the license text, e.g. at the start of each line of text, or repetitive characters to establish a separation of text.
+To avoid the possibility of a non-match due to  the existence or absence of code comment indicators placed within the license text, e.g., at the start of each line of text, or repetitive characters to establish a separation of text, e.g., ---, ===, ___, or ***.
 
 ### B.7.2  Guideline <a name="B.7.2"></a>
 


### PR DESCRIPTION
fixes #1617 

Adds guideline for ---, ***, etc.

Also updated punctuation guideline to note that exceptions (e.g., Oxford comma or not) may have markup.