### PR TITLE
add HPND-export-US-acknowledgement

### DIFF
--- a/src/HPND-export-US-acknowledgement.xml
+++ b/src/HPND-export-US-acknowledgement.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="false" licenseId="HPND-export-US-acknowledgement"
-   name="HPND with US Government export control warning and acknowledgment rqmt" listVersionAdded="3.24">
+   name="HPND with US Government export control warning and acknowledgment" listVersionAdded="3.24">
       <crossRefs>
          <crossRef>https://github.com/krb5/krb5/blob/krb5-1.21.2-final/NOTICE#L831-L852</crossRef>
          <crossRef>https://web.mit.edu/kerberos/krb5-1.21/doc/mitK5license.html</crossRef>

--- a/src/HPND-export-US-acknowledgement.xml
+++ b/src/HPND-export-US-acknowledgement.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SPDXLicenseCollection xmlns="http://www.spdx.org/license">
+   <license isOsiApproved="false" licenseId="HPND-export-US-acknowledgement"
+   name="HPND with US Government export control warning and acknowledgment rqmt" listVersionAdded="3.24">
+      <crossRefs>
+         <crossRef>https://github.com/krb5/krb5/blob/krb5-1.21.2-final/NOTICE#L831-L852</crossRef>
+         <crossRef>https://web.mit.edu/kerberos/krb5-1.21/doc/mitK5license.html</crossRef>
+      </crossRefs>
+      <notes>
+        This license is similar to HPND-export-US, but has a different obligation relating to notice and different disclaimer.
+      </notes>
+      <text>
+         <p>
+            Copyright (C) 1994 by the University of Southern California
+         </p>
+         <p>
+            EXPORT OF THIS SOFTWARE from the United States of America may
+            require a specific license from the United States Government.
+            It is the responsibility of any person or organization
+            contemplating export to obtain such a license before exporting.
+         </p>
+         <p>
+            WITHIN THAT CONSTRAINT, permission to copy, modify, and distribute
+            this software and its documentation in source and binary forms
+            is hereby granted, provided that any documentation or other
+            materials related to such distribution or use acknowledge that the
+            software was developed by the University of Southern California.
+         </p>
+         <p>
+            DISCLAIMER OF WARRANTY. THIS SOFTWARE IS PROVIDED "AS IS".
+            The University of Southern California MAKES NO REPRESENTATIONS
+            OR WARRANTIES, EXPRESS OR IMPLIED. By way of example, but not
+            limitation, the University of Southern California MAKES NO
+            REPRESENTATIONS OR WARRANTIES OF MERCHANTABILITY OR FITNESS
+            FOR ANY PARTICULAR PURPOSE. The University of Southern
+            California shall not be held liable for any liability nor for
+            any direct, indirect, or consequential damages with respect
+            to any claim by the user or distributor of the ksu software.
+         </p>
+      </text>
+   </license>
+</SPDXLicenseCollection>

--- a/test/simpleTestForGenerator/HPND-export-US-acknowledgement.txt
+++ b/test/simpleTestForGenerator/HPND-export-US-acknowledgement.txt
@@ -1,0 +1,22 @@
+Copyright (C) 1994 by the University of Southern California
+
+   EXPORT OF THIS SOFTWARE from the United States of America may
+   require a specific license from the United States Government. It
+   is the responsibility of any person or organization
+   contemplating export to obtain such a license before exporting.
+
+WITHIN THAT CONSTRAINT, permission to copy, modify, and distribute
+this software and its documentation in source and binary forms is
+hereby granted, provided that any documentation or other materials
+related to such distribution or use acknowledge that the software
+was developed by the University of Southern California.
+
+DISCLAIMER OF WARRANTY.  THIS SOFTWARE IS PROVIDED "AS IS".  The
+University of Southern California MAKES NO REPRESENTATIONS OR
+WARRANTIES, EXPRESS OR IMPLIED.  By way of example, but not
+limitation, the University of Southern California MAKES NO
+REPRESENTATIONS OR WARRANTIES OF MERCHANTABILITY OR FITNESS FOR ANY
+PARTICULAR PURPOSE. The University of Southern California shall not
+be held liable for any liability nor for any direct, indirect, or
+consequential damages with respect to any claim by the user or
+distributor of the ksu software.


### PR DESCRIPTION
Fixes: #2349

I am not sure if the "rqmt" in the license name was intentional or a typo.