### PR TITLE
markup change to MIT-Khronos-old

### DIFF
--- a/src/MIT-Khronos-old.xml
+++ b/src/MIT-Khronos-old.xml
@@ -26,12 +26,14 @@
             The above copyright notice and this permission notice shall be
             included in all copies or substantial portions of the Materials.
          </p>
+         <optional>
          <p>
             MODIFICATIONS TO THIS FILE MAY MEAN IT NO LONGER ACCURATELY
             REFLECTS KHRONOS STANDARDS. THE UNMODIFIED, NORMATIVE
             VERSIONS OF KHRONOS SPECIFICATIONS AND HEADER INFORMATION
             ARE LOCATED AT https://www.khronos.org/registry/
          </p>
+         </optional>
          <p>
             THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF
             ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO


### PR DESCRIPTION
In the review in #2017 it was said that this paragraph: This text may be omittable (B.3.5 Guideline: omittable text), as it is merely informative or explanatory, not any right grant or restriction.

but the optional tags were not added in the initial commit. Adding now.