### PR TITLE
Use HTTPS for URLs in MPL-1.1 and MPL-2.0

### DIFF
--- a/src/MPL-1.1.xml
+++ b/src/MPL-1.1.xml
@@ -518,7 +518,7 @@
          <standardLicenseHeader>
          <p><optional spacing="none">"</optional>The contents of this file are subject to the Mozilla Public License Version 1.1 (the
          "License"); you may not use this file except in compliance with the License. You may obtain
-         a copy of the License at http://www.mozilla.org/MPL/</p>
+         a copy of the License at https://www.mozilla.org/MPL/</p>
          <p>Software distributed under the License is distributed on an "AS IS" basis, WITHOUT WARRANTY OF
          ANY KIND, either express or implied. See the License for the specific language governing rights and
          limitations under the License.</p>

--- a/src/MPL-2.0-no-copyleft-exception.xml
+++ b/src/MPL-2.0-no-copyleft-exception.xml
@@ -460,7 +460,7 @@
          <optional><p>-------------------------------------------</p></optional>
 	 <standardLicenseHeader>
             <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL
-         was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.</p>
+         was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.</p>
          </standardLicenseHeader>
          <p>If it is not possible or desirable to put the notice in a particular file, then You may include the
          notice in a location (such as a LICENSE file in a relevant directory) where a recipient would be

--- a/src/MPL-2.0.xml
+++ b/src/MPL-2.0.xml
@@ -459,7 +459,7 @@
          <optional><p>-------------------------------------------</p></optional>
 	 <standardLicenseHeader>
             <p>This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL
-         was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.</p>
+         was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.</p>
          </standardLicenseHeader>
          <p>If it is not possible or desirable to put the notice in a particular file, then You may include the
          notice in a location (such as a LICENSE file in a relevant directory) where a recipient would be


### PR DESCRIPTION
As in the texts published at https://www.mozilla.org/en-US/MPL/1.1/ and https://www.mozilla.org/en-US/MPL/2.0/