### PR TITLE
Adding markup to hpnd-export2-us

### DIFF
--- a/src/HPND-export2-US.xml
+++ b/src/HPND-export2-US.xml
@@ -26,9 +26,9 @@
             without fee is hereby granted, provided that the above copyright
             notice appear in all copies and that both that copyright notice
             and this permission notice appear in supporting documentation,
-            and that the name of Apple Inc. not be used in advertising or
+            and that the name of <alt match=".*" name="copyrightHolder0">Apple Inc.</alt> not be used in advertising or
             publicity pertaining to distribution of the software without
-            specific, written prior permission. Apple Inc. makes no
+            specific, written prior permission. <alt match=".*" name="copyrightHolder1">Apple Inc.</alt>. makes no
             representations about the suitability of this software for any
             purpose. It is provided "as is" without express or implied warranty.
          </p>


### PR DESCRIPTION
Adding markup to have copyright holder be editable.

Fixes #2514 