### PR TITLE
add Ruby-pty license

### DIFF
--- a/src/Ruby-pty.xml
+++ b/src/Ruby-pty.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SPDXLicenseCollection xmlns="http://www.spdx.org/license">
+   <license isOsiApproved="false" licenseId="Ruby-pty"
+   name="Ruby pty extension license" listVersionAdded="3.25.0">
+      <crossRefs>
+         <crossRef>https://github.com/ruby/ruby/blob/9f6deaa6888a423720b4b127b5314f0ad26cc2e6/ext/pty/pty.c#L775-L786</crossRef>
+         <crossRef>https://github.com/ruby/ruby/commit/0a64817fb80016030c03518fb9459f63c11605ea#diff-ef5fa30838d6d0cecad9e675cc50b24628cfe2cb277c346053fafcc36c91c204</crossRef>
+         <crossRef>https://github.com/ruby/ruby/commit/0a64817fb80016030c03518fb9459f63c11605ea#diff-fedf217c1ce44bda01f0a678d3ff8b198bed478754d699c527a698ad933979a0</crossRef>
+      </crossRefs>
+      <text>
+        <copyrightText>
+                <p>
+                        (c) Copyright 1998 by Akinori Ito.
+                </p>
+        </copyrightText>
+        <p>
+                This software may be redistributed freely for this
+                purpose, in full or in part, provided that this entire
+                copyright notice is included on any copies of this
+                software and applications and derivations thereof.
+        </p>
+        <p>
+                This software is provided on an "as is" basis, without warranty
+                of any kind, either expressed or implied, as to any matter
+                including, but not limited to warranty of fitness of purpose, or
+                merchantability, or results obtained from use of this software.
+        </p>
+      </text>
+   </license>
+</SPDXLicenseCollection>

--- a/src/Ruby-pty.xml
+++ b/src/Ruby-pty.xml
@@ -7,6 +7,7 @@
          <crossRef>https://github.com/ruby/ruby/commit/0a64817fb80016030c03518fb9459f63c11605ea#diff-ef5fa30838d6d0cecad9e675cc50b24628cfe2cb277c346053fafcc36c91c204</crossRef>
          <crossRef>https://github.com/ruby/ruby/commit/0a64817fb80016030c03518fb9459f63c11605ea#diff-fedf217c1ce44bda01f0a678d3ff8b198bed478754d699c527a698ad933979a0</crossRef>
       </crossRefs>
+      <notes>There is a Japanese translation of this license included with some instances of use.</notes>
       <text>
         <copyrightText>
                 <p>

--- a/test/simpleTestForGenerator/Ruby-pty.txt
+++ b/test/simpleTestForGenerator/Ruby-pty.txt
@@ -1,0 +1,10 @@
+(c) Copyright 1998 by Akinori Ito.
+
+This software may be redistributed freely for this purpose, in full
+or in part, provided that this entire copyright notice is included
+on any copies of this software and applications and derivations thereof.
+
+This software is provided on an "as is" basis, without warranty of any
+kind, either expressed or implied, as to any matter including, but not
+limited to warranty of fitness of purpose, or merchantability, or
+results obtained from use of this software.


### PR DESCRIPTION
Fixes: #2446

Note that I omitted that Japan text, which was included in the original submission but was not present in most linked examples. 
If I got it correctly, it is a translation of the English text.