### PR TITLE
Add new erlang-otp-linking-exception.xml

### DIFF
--- a/src/exceptions/erlang-otp-linking-exception.xml
+++ b/src/exceptions/erlang-otp-linking-exception.xml
@@ -10,13 +10,11 @@
       This exception is based on the suggested template from the Free Software Foundation's FAQ about the GPL.
     </notes>
     <text>
-      <titleText>
 	<optional>
 	<p>
 	  Additional permission under GNU AGPL version 3 section 7
 	</p>
 	</optional>
-      </titleText>
       <p>
 	If you modify this Program, or any covered work, by linking or
 	combining it with runtime libraries of Erlang/OTP as released by

--- a/src/exceptions/erlang-otp-linking-exception.xml
+++ b/src/exceptions/erlang-otp-linking-exception.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SPDXLicenseCollection xmlns="http://www.spdx.org/license">
+  <exception licenseId="erlang-otp-linking-exception" name="Erlang/OTP Linking Exception" listVersionAdded="3.25.0">
+    <crossRefs>
+      <crossRef>https://www.gnu.org/licenses/gpl-faq.en.html#GPLIncompatibleLibs</crossRef>
+      <crossRef>https://erlang.org/pipermail/erlang-questions/2012-May/066355.html</crossRef>
+      <crossRef>https://gitea.osmocom.org/erlang/osmo_ss7/src/commit/2286c1b8738d715950026650bf53f19a69d6ed0e/src/ss7_links.erl#L20</crossRef>
+    </crossRefs>
+    <notes>
+      This exception is based on the suggested template from the Free Software Foundation's FAQ about the GPL.
+    </notes>
+    <text>
+      <titleText>
+	<optional>
+	<p>
+	  Additional permission under GNU AGPL version 3 section 7
+	</p>
+	</optional>
+      </titleText>
+      <p>
+	If you modify this Program, or any covered work, by linking or
+	combining it with runtime libraries of Erlang/OTP as released by
+	Ericsson on https://www.erlang.org (or a modified version of these
+	libraries), containing parts covered by the terms of the Erlang Public
+	License (https://www.erlang.org/EPLICENSE),
+	<alt match=".+" name="licensors">the licensors of this Program</alt>
+	grant you additional permission to convey the resulting work
+	without the need to license the runtime libraries of Erlang/OTP under
+	the <alt match=".+" name="libraryLicense2">[name of library's license]</alt>.
+	Corresponding Source for a non-source form of such a combination shall include
+	the source code for the parts of the runtime libraries of Erlang/OTP used as
+	well as that of the covered work.
+      </p>
+    </text>
+  </exception>
+</SPDXLicenseCollection>

--- a/test/simpleTestForGenerator/erlang-otp-linking-exception.txt
+++ b/test/simpleTestForGenerator/erlang-otp-linking-exception.txt
@@ -1,0 +1,11 @@
+If you modify this Program, or any covered work, by linking or
+combining it with runtime libraries of Erlang/OTP as released by
+Ericsson on https://www.erlang.org (or a modified version of these
+libraries), containing parts covered by the terms of the Erlang Public
+License (https://www.erlang.org/EPLICENSE), the licensors of this
+Program grant you additional permission to convey the resulting work
+without the need to license the runtime libraries of Erlang/OTP under
+the GNU Affero General Public License. Corresponding Source for a
+non-source form of such a combination shall include the source code
+for the parts of the runtime libraries of Erlang/OTP used as well as
+that of the covered work.


### PR DESCRIPTION
I've tried to use an <alt> tag to make the exception work with other licenses.  The orignal wording was focused on AGPLv3, but it would just as well work with GPLv3, for example.

Fixes: #2495