### PR TITLE
License matching guidelines -> License list matching guidelines

### DIFF
--- a/DOCS/license-matching-guidelines-and-templates.md
+++ b/DOCS/license-matching-guidelines-and-templates.md
@@ -1,4 +1,4 @@
-# Annex B License matching guidelines and templates (Informative)
+# Annex B License list matching guidelines and templates (Informative)
 
 ## B.1 SPDX license list matching guidelines <a name="B.1"></a>
 


### PR DESCRIPTION
Make the title of the Annex match the name "SPDX License List Matching Guidelines" that use everywhere else.