### PR TITLE
Fix license versions for semver and typo

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -44,7 +44,7 @@ Fixed typo in license list schema XSD file.
 
 See all PRs for 3.24.0 here: https://github.com/spdx/license-list-XML/pulls?page=1&q=is%3Apr+milestone%3A%223.24.0%22+is%3Aclosed
 
-See comparision of changes from 3.23 to 3.24.0: https://github.com/spdx/license-list-XML/compare/v3.23...v3.24.0
+See comparison of changes from 3.23 to 3.24.0: https://github.com/spdx/license-list-XML/compare/v3.23...v3.24.0
 
 ## version 3.23 - 2024-02-08
 
@@ -100,7 +100,7 @@ Added and improved markup for many licenses and many minor improvements to other
 
 See all PRs for 3.23 here: https://github.com/spdx/license-list-XML/pulls?page=1&q=is%3Apr+milestone%3A%223.23%22+is%3Aclosed
 
-See comparision of changes from 3.22 to 3.23: https://github.com/spdx/license-list-XML/compare/v3.22...v3.23
+See comparison of changes from 3.22 to 3.23: https://github.com/spdx/license-list-XML/compare/v3.22...v3.23
 
 ## version 3.22 - 2023-10-05
 
@@ -159,7 +159,7 @@ Added and improved markup for many licenses and many minor improvements to other
 
 See all PRs for 3.22 here: https://github.com/spdx/license-list-XML/pulls?page=1&q=is%3Apr+milestone%3A%223.22%22+is%3Aclosed
 
-See comparision of changes from 3.21 to 3.22: https://github.com/spdx/license-list-XML/compare/v3.21...v3.22
+See comparison of changes from 3.21 to 3.22: https://github.com/spdx/license-list-XML/compare/v3.21...v3.22
 
 ## version 3.21 - 2023-06-18
 
@@ -206,7 +206,7 @@ Designated current license list XML schema as version 1.0.0.
 
 See all PRs for 3.21 here: https://github.com/spdx/license-list-XML/pulls?page=1&q=is%3Apr+milestone%3A%223.21%22+is%3Aclosed
 
-See comparision of changes from 3.20 to 3.21: https://github.com/spdx/license-list-XML/compare/v3.20...v3.21
+See comparison of changes from 3.20 to 3.21: https://github.com/spdx/license-list-XML/compare/v3.20...v3.21
 
 ## version 3.20 - 2023-02-17
 
@@ -267,7 +267,7 @@ Updated to latest version of the License List Publisher.
 
 See all PRs for 3.20 here: https://github.com/spdx/license-list-XML/pulls?page=1&q=is%3Apr+milestone%3A%223.20%22+is%3Aclosed
 
-See comparision of changes from 3.19 to 3.20: https://github.com/spdx/license-list-XML/compare/v3.19...v3.20
+See comparison of changes from 3.19 to 3.20: https://github.com/spdx/license-list-XML/compare/v3.19...v3.20
 
 ## version 3.19 - 2022-11-30
 
@@ -289,7 +289,7 @@ Cleanup of markup for many licenses and other minor changes.
 
 See all PRs for 3.19 here: https://github.com/spdx/license-list-XML/pulls?page=1&q=is%3Apr+milestone%3A%223.19%22+is%3Aclosed
 
-See comparision of changes from 3.18 to 3.19: https://github.com/spdx/license-list-XML/compare/v3.18...v3.19
+See comparison of changes from 3.18 to 3.19: https://github.com/spdx/license-list-XML/compare/v3.18...v3.19
 
 ## version 3.18 - 2022-08-11
 
@@ -314,7 +314,7 @@ Updates to various documentation, adjustments to markup for various licenses and
 
 See all PRs for 3.18 here: https://github.com/spdx/license-list-XML/pulls?page=1&q=is%3Apr+milestone%3A%223.18%22+is%3Aclosed
 
-See comparision of changes from 3.17 to 3.18: https://github.com/spdx/license-list-XML/compare/v3.17...v3.18
+See comparison of changes from 3.17 to 3.18: https://github.com/spdx/license-list-XML/compare/v3.17...v3.18
 
 ## version 3.17 - 2022-05-08
 
@@ -336,7 +336,7 @@ Updated to latest version of the License List Publisher.
 
 See all PRs for 3.17 here: https://github.com/spdx/license-list-XML/pulls?page=1&q=is%3Apr+milestone%3A%223.17%22+is%3Aclosed
 
-See comparision of changes from 3.16 to 3.17: https://github.com/spdx/license-list-XML/compare/v3.16...v3.17
+See comparison of changes from 3.16 to 3.17: https://github.com/spdx/license-list-XML/compare/v3.16...v3.17
 
 ## version 3.16 - 2022-02-06
 
@@ -361,7 +361,7 @@ Updated to latest version of the License List Publisher.
 
 See all PRs for 3.16 here: https://github.com/spdx/license-list-XML/pulls?page=1&q=is%3Apr+milestone%3A%223.16%22+is%3Aclosed
 
-See comparision of changes from 3.15 to 3.16: https://github.com/spdx/license-list-XML/compare/v3.15...v3.16
+See comparison of changes from 3.15 to 3.16: https://github.com/spdx/license-list-XML/compare/v3.15...v3.16
 
 ## version 3.15 - 2021-11-14
 
@@ -382,7 +382,7 @@ Updated to latest version of the License List Publisher.
 
 See all PRs for 3.15 here: https://github.com/spdx/license-list-XML/pulls?page=1&q=is%3Apr+milestone%3A%223.15%22+is%3Aclosed
 
-See comparision of changes from 3.14 to 3.15: https://github.com/spdx/license-list-XML/compare/v3.14...v3.15
+See comparison of changes from 3.14 to 3.15: https://github.com/spdx/license-list-XML/compare/v3.14...v3.15
 
 ## version 3.14 - 2021-08-08
 
@@ -406,7 +406,7 @@ Updates to various documentation, adjustments to markup for various licenses and
 
 See all PRs for 3.14 here: https://github.com/spdx/license-list-XML/pulls?page=1&q=is%3Apr+milestone%3A%223.14%22+is%3Aclosed
 
-See comparision of changes from 3.13 to 3.14: https://github.com/spdx/license-list-XML/compare/v3.13...v3.14
+See comparison of changes from 3.13 to 3.14: https://github.com/spdx/license-list-XML/compare/v3.13...v3.14
 
 ## version 3.13 - 2021-05-15
 
@@ -419,7 +419,7 @@ Updates to various documentation, adjustments to markup for various licenses and
 
 See all PRs for 3.13 here: https://github.com/spdx/license-list-XML/pulls?page=1&q=is%3Apr+milestone%3A%223.13%22+is%3Aclosed
 
-See comparision of changes from 3.12 to 3.13: https://github.com/spdx/license-list-XML/compare/v3.12...v3.13
+See comparison of changes from 3.12 to 3.13: https://github.com/spdx/license-list-XML/compare/v3.12...v3.13
 
 ## version 3.12 - 2021-03-07
 
@@ -442,7 +442,7 @@ Updates to various documentation, cleanup of markup for various licenses and oth
 
 See all PRs for 3.12 here: https://github.com/spdx/license-list-XML/pulls?page=1&q=is%3Apr+milestone%3A%223.12+release%22+is%3Aclosed
 
-See comparision of changes from 3.11 to 3.12: https://github.com/spdx/license-list-XML/compare/v3.11...v3.12
+See comparison of changes from 3.11 to 3.12: https://github.com/spdx/license-list-XML/compare/v3.11...v3.12
 
 ## version 3.11 - 2020-11-25
 
@@ -461,7 +461,7 @@ Updates and cleanup of markup for various licenses and other minor changes.
 
 See all PRs for 3.11 here: https://github.com/spdx/license-list-XML/pulls?page=1&q=is%3Apr+milestone%3A%223.11+release%22+is%3Aclosed
 
-See comparision of changes from 3.10 to 3.11: https://github.com/spdx/license-list-XML/compare/v3.10...v3.11
+See comparison of changes from 3.10 to 3.11: https://github.com/spdx/license-list-XML/compare/v3.10...v3.11
 
 ## version 3.10 - 2020-08-03
 
@@ -496,7 +496,7 @@ Updates and cleanup of markup for various licenses and other minor changes.
 
 See all PRs for 3.10 here: https://github.com/spdx/license-list-XML/pulls?page=1&q=is%3Apr+milestone%3A%223.10+release%22+is%3Aclosed
 
-See comparision of changes from 3.9 to 3.10: https://github.com/spdx/license-list-XML/compare/v3.9...v3.10
+See comparison of changes from 3.9 to 3.10: https://github.com/spdx/license-list-XML/compare/v3.9...v3.10
 
 ## version 3.9 - 2020-05-15
 
@@ -534,7 +534,7 @@ Updates and cleanup of markup for various licenses and other minor changes.
 
 See all PRs for 3.9 here: https://github.com/spdx/license-list-XML/pulls?page=1&q=is%3Apr+milestone%3A%223.9+release%22+is%3Aclosed
 
-See comparision of changes from 3.8 to 3.9: https://github.com/spdx/license-list-XML/compare/v3.8...v3.9
+See comparison of changes from 3.8 to 3.9: https://github.com/spdx/license-list-XML/compare/v3.8...v3.9
 
 ## version 3.8 - 2020-02-09
 
@@ -556,7 +556,7 @@ Add machine-readable copy of "equivalent words" from matching guidelines.
 
 See all PRs for 3.8 here: https://github.com/spdx/license-list-XML/pulls?page=1&q=is%3Apr+milestone%3A%223.8+release%22+is%3Aclosed
 
-See comparision of changes from 3.7 to 3.8: https://github.com/spdx/license-list-XML/compare/v3.7...v3.8
+See comparison of changes from 3.7 to 3.8: https://github.com/spdx/license-list-XML/compare/v3.7...v3.8
 
 ## version 3.7 - 2019-10-22
 
@@ -582,7 +582,7 @@ requiring re-test of entire repo.
 
 See all PRs for 3.7 here: https://github.com/spdx/license-list-XML/pulls?page=1&q=is%3Apr+milestone%3A%223.7+release%22+is%3Aclosed
 
-See comparision of changes from 3.6 to 3.7: https://github.com/spdx/license-list-XML/compare/v3.6...v3.7
+See comparison of changes from 3.6 to 3.7: https://github.com/spdx/license-list-XML/compare/v3.6...v3.7
 
 ## version 3.6 - 2019-07-10
 
@@ -612,7 +612,7 @@ Cleanup of stray whitespace across the repository.
 
 See all PRs for 3.6 here: https://github.com/spdx/license-list-XML/pulls?page=1&q=is%3Apr+milestone%3A%223.6+release%22+is%3Aclosed
 
-See comparision of changes from 3.5 to 3.6: https://github.com/spdx/license-list-XML/compare/v3.5...v3.6
+See comparison of changes from 3.5 to 3.6: https://github.com/spdx/license-list-XML/compare/v3.5...v3.6
 
 ## version 3.5 - 2019-04-02
 
@@ -646,7 +646,7 @@ Updated CONTRIBUTING page and links for "Request New License" (previously a webp
 
 See all PRs for 3.4 here: https://github.com/spdx/license-list-XML/pulls?utf8=%E2%9C%93&q=milestone%3A%223.4+release%22+
 
-See comparision of changes from 3.3 and 3.4: https://github.com/spdx/license-list-XML/compare/v3.3...v3.4
+See comparison of changes from 3.3 and 3.4: https://github.com/spdx/license-list-XML/compare/v3.3...v3.4
 
 ## version 3.3 - 2018-10-24
 
@@ -662,4 +662,4 @@ Updated or added license info for source files associated with SPDX License List
 
 See all PRs for 3.3 here: https://github.com/spdx/license-list-XML/pulls?q=is%3Apr+is%3Aclosed+milestone%3A%223.3+release%22
 
-See comparision of changes from 3.2 and 3.3: https://github.com/spdx/license-list-XML/compare/v3.2...v3.3
+See comparison of changes from 3.2 and 3.3: https://github.com/spdx/license-list-XML/compare/v3.2...v3.3

--- a/src/3D-Slicer-1.0.xml
+++ b/src/3D-Slicer-1.0.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
 <license isOsiApproved="false" licenseId="3D-Slicer-1.0"
-         name="3D Slicer License v1.0" listVersionAdded="3.24">
+         name="3D Slicer License v1.0" listVersionAdded="3.24.0">
 	<crossRefs>
 		<crossRef>https://slicer.org/LICENSE</crossRef>
 		<crossRef>https://github.com/Slicer/Slicer/blob/main/License.txt</crossRef>

--- a/src/AMD-newlib.xml
+++ b/src/AMD-newlib.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="false" licenseId="AMD-newlib"
-   name="AMD newlib License" listVersionAdded="3.24">
+   name="AMD newlib License" listVersionAdded="3.24.0">
       <crossRefs>
          <crossRef>https://sourceware.org/git/?p=newlib-cygwin.git;a=blob;f=newlib/libc/sys/a29khif/_close.S;h=04f52ae00de1dafbd9055ad8d73c5c697a3aae7f;hb=HEAD</crossRef>
       </crossRefs>

--- a/src/BSD-2-Clause-first-lines.xml
+++ b/src/BSD-2-Clause-first-lines.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="false" licenseId="BSD-2-Clause-first-lines"
             name="BSD 2-Clause - first lines requirement"
-            listVersionAdded="3.24">
+            listVersionAdded="3.24.0">
       <crossRefs>
         <crossRef>https://github.com/krb5/krb5/blob/krb5-1.21.2-final/NOTICE#L664-L690</crossRef>
         <crossRef>https://web.mit.edu/kerberos/krb5-1.21/doc/mitK5license.html</crossRef>

--- a/src/Catharon.xml
+++ b/src/Catharon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="false" licenseId="Catharon"
-   name="Catharon License" listVersionAdded="3.24">
+   name="Catharon License" listVersionAdded="3.24.0">
       <crossRefs>
          <crossRef>https://github.com/scummvm/scummvm/blob/v2.8.0/LICENSES/CatharonLicense.txt</crossRef>
       </crossRefs>

--- a/src/Gutmann.xml
+++ b/src/Gutmann.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="false" licenseId="Gutmann"
-   name="Gutmann License" listVersionAdded="3.24">
+   name="Gutmann License" listVersionAdded="3.24.0">
       <crossRefs>
          <crossRef>https://www.cs.auckland.ac.nz/~pgut001/dumpasn1.c</crossRef>
       </crossRefs>

--- a/src/HPND-Intel.xml
+++ b/src/HPND-Intel.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
 <license isOsiApproved="false" licenseId="HPND-Intel" 
 	name="Historical Permission Notice and Disclaimer - Intel variant"
-	listVersionAdded="3.24">
+	listVersionAdded="3.24.0">
 	<crossRefs>
 		<crossRef>https://sourceware.org/git/?p=newlib-cygwin.git;a=blob;f=newlib/libc/machine/i960/memcpy.S;hb=HEAD</crossRef>
 	</crossRefs>

--- a/src/HPND-UC-export-US.xml
+++ b/src/HPND-UC-export-US.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="false" licenseId="HPND-UC-export-US"
       name="Historical Permission Notice and Disclaimer - University of California, US export warning"
-      listVersionAdded="3.24">
+      listVersionAdded="3.24.0">
       <crossRefs>
          <crossRef>https://github.com/RTimothyEdwards/magic/blob/master/LICENSE</crossRef>
       </crossRefs>

--- a/src/HPND-export-US-acknowledgement.xml
+++ b/src/HPND-export-US-acknowledgement.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="false" licenseId="HPND-export-US-acknowledgement"
-   name="HPND with US Government export control warning and acknowledgment" listVersionAdded="3.24">
+   name="HPND with US Government export control warning and acknowledgment" listVersionAdded="3.24.0">
       <crossRefs>
          <crossRef>https://github.com/krb5/krb5/blob/krb5-1.21.2-final/NOTICE#L831-L852</crossRef>
          <crossRef>https://web.mit.edu/kerberos/krb5-1.21/doc/mitK5license.html</crossRef>

--- a/src/HPND-export2-US.xml
+++ b/src/HPND-export2-US.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="false" licenseId="HPND-export2-US"
-      name="HPND with US Government export control and 2 disclaimers" listVersionAdded="3.24">
+      name="HPND with US Government export control and 2 disclaimers" listVersionAdded="3.24.0">
       <crossRefs>
          <crossRef>https://github.com/krb5/krb5/blob/krb5-1.21.2-final/NOTICE#L111-L133</crossRef>
          <crossRef>https://web.mit.edu/kerberos/krb5-1.21/doc/mitK5license.html</crossRef>

--- a/src/HPND-merchantability-variant.xml
+++ b/src/HPND-merchantability-variant.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="false" licenseId="HPND-merchantability-variant"
-   name="Historical Permission Notice and Disclaimer - merchantability variant" listVersionAdded="3.24">
+   name="Historical Permission Notice and Disclaimer - merchantability variant" listVersionAdded="3.24.0">
       <crossRefs>
          <crossRef>https://sourceware.org/git/?p=newlib-cygwin.git;a=blob;f=newlib/libc/misc/fini.c;hb=HEAD</crossRef>
       </crossRefs>

--- a/src/HPND-sell-variant-MIT-disclaimer-rev.xml
+++ b/src/HPND-sell-variant-MIT-disclaimer-rev.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="false"
-   licenseId="HPND-sell-variant-MIT-disclaimer-rev" name="HPND sell variant with MIT disclaimer - reverse" listVersionAdded="3.24">
+   licenseId="HPND-sell-variant-MIT-disclaimer-rev" name="HPND sell variant with MIT disclaimer - reverse" listVersionAdded="3.24.0">
       <crossRefs>
          <crossRef>https://github.com/sigmavirus24/x11-ssh-askpass/blob/master/dynlist.c</crossRef>
       </crossRefs>

--- a/src/MIT-Khronos-old.xml
+++ b/src/MIT-Khronos-old.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="false" licenseId="MIT-Khronos-old"
-   name="MIT Khronos - old variant" listVersionAdded="3.24">
+   name="MIT Khronos - old variant" listVersionAdded="3.24.0">
       <crossRefs>
          <crossRef>https://github.com/KhronosGroup/SPIRV-Cross/blob/main/LICENSES/LicenseRef-KhronosFreeUse.txt</crossRef>
       </crossRefs>

--- a/src/NCBI-PD.xml
+++ b/src/NCBI-PD.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isOsiApproved="false" licenseId="NCBI-PD" name="NCBI Public Domain Notice" listVersionAdded="3.24">
+   <license isOsiApproved="false" licenseId="NCBI-PD" name="NCBI Public Domain Notice" listVersionAdded="3.24.0">
       <crossRefs>
          <crossRef>https://github.com/ncbi/sra-tools/blob/e8e5b6af4edc460156ad9ce5902d0779cffbf685/LICENSE</crossRef>
          <crossRef>https://github.com/ncbi/datasets/blob/0ea4cd16b61e5b799d9cc55aecfa016d6c9bd2bf/LICENSE.md</crossRef>

--- a/src/NCL.xml
+++ b/src/NCL.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="false" licenseId="NCL"
-   name="NCL Source Code License" listVersionAdded="3.24">
+   name="NCL Source Code License" listVersionAdded="3.24.0">
       <crossRefs>
          <crossRef>https://gitlab.freedesktop.org/pipewire/pipewire/-/blob/master/src/modules/module-filter-chain/pffft.c?ref_type=heads#L1-52</crossRef>
       </crossRefs>

--- a/src/OAR.xml
+++ b/src/OAR.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="false" licenseId="OAR"
-   name="OAR License" listVersionAdded="3.24">
+   name="OAR License" listVersionAdded="3.24.0">
       <crossRefs>
          <crossRef>https://sourceware.org/git/?p=newlib-cygwin.git;a=blob;f=newlib/libc/string/strsignal.c;hb=HEAD#l35</crossRef>
       </crossRefs>

--- a/src/PPL.xml
+++ b/src/PPL.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
     <license isOsiApproved="false" licenseId="PPL"
-             name="Peer Production License" listVersionAdded="3.24">
+             name="Peer Production License" listVersionAdded="3.24.0">
     <crossRefs>
         <crossRef>https://wiki.p2pfoundation.net/Peer_Production_License</crossRef>
         <crossRef>http://www.networkcultures.org/_uploads/%233notebook_telekommunist.pdf</crossRef>

--- a/src/Sun-PPP-2000.xml
+++ b/src/Sun-PPP-2000.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
     <license isOsiApproved="false" licenseId="Sun-PPP-2000"
-	name="Sun PPP License (2000)" listVersionAdded="3.24">
+	name="Sun PPP License (2000)" listVersionAdded="3.24.0">
       <crossRefs>
          <crossRef>https://github.com/ppp-project/ppp/blob/master/modules/ppp_ahdlc.c#L7-L19</crossRef>
       </crossRefs>

--- a/src/X11-swapped.xml
+++ b/src/X11-swapped.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isOsiApproved="false" licenseId="X11-swapped" name="X11 swapped final paragraphs" listVersionAdded="3.25">
+   <license isOsiApproved="false" licenseId="X11-swapped" name="X11 swapped final paragraphs" listVersionAdded="3.25.0">
       <crossRefs>
          <crossRef>https://github.com/fedeinthemix/chez-srfi/blob/master/srfi/LICENSE</crossRef>
       </crossRefs>

--- a/src/any-OSI.xml
+++ b/src/any-OSI.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="false" licenseId="any-OSI"
-   name="Any OSI License" listVersionAdded="3.24">
+   name="Any OSI License" listVersionAdded="3.24.0">
       <crossRefs>
          <crossRef>https://metacpan.org/pod/Exporter::Tidy#LICENSE</crossRef>
       </crossRefs>

--- a/src/cve-tou.xml
+++ b/src/cve-tou.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="false" licenseId="cve-tou"
-   name="Common Vulnerability Enumeration ToU License" listVersionAdded="3.24">
+   name="Common Vulnerability Enumeration ToU License" listVersionAdded="3.24.0">
       <crossRefs>
          <crossRef>https://www.cve.org/Legal/TermsOfUse</crossRef>
       </crossRefs>

--- a/src/exceptions/Asterisk-linking-protocols-exception.xml
+++ b/src/exceptions/Asterisk-linking-protocols-exception.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <exception licenseId="Asterisk-linking-protocols-exception"
-   name="Asterisk linking protocols exception" listVersionAdded="3.24">
+   name="Asterisk linking protocols exception" listVersionAdded="3.24.0">
    <crossRefs>
       <crossRef>https://github.com/asterisk/asterisk/blob/115d7c01e32ccf4566a99e9d74e2b88830985a0b/LICENSE#L27</crossRef>
    </crossRefs>

--- a/src/exceptions/PCRE2-exception.xml
+++ b/src/exceptions/PCRE2-exception.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
 <exception licenseId="PCRE2-exception"
-   name="PCRE2 exception" listVersionAdded="3.24">
+   name="PCRE2 exception" listVersionAdded="3.24.0">
 	<crossRefs>
 		<crossRef>https://www.pcre.org/licence.txt</crossRef>
 	</crossRefs>

--- a/src/exceptions/RRDtool-FLOSS-exception-2.0.xml
+++ b/src/exceptions/RRDtool-FLOSS-exception-2.0.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <exception licenseId="RRDtool-FLOSS-exception-2.0"
-   name="RRDtool FLOSS exception 2.0" listVersionAdded="3.24">
+   name="RRDtool FLOSS exception 2.0" listVersionAdded="3.24.0">
       <crossRefs>
          <crossRef>https://github.com/oetiker/rrdtool-1.x/blob/master/COPYRIGHT#L25-L90</crossRef>
          <crossRef>https://oss.oetiker.ch/rrdtool/license.en.html</crossRef>

--- a/src/exceptions/romic-exception.xml
+++ b/src/exceptions/romic-exception.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <exception licenseId="romic-exception"
-   name="Romic Exception" listVersionAdded="3.25">
+   name="Romic Exception" listVersionAdded="3.25.0">
    <crossRefs>
       <crossRef>https://web.archive.org/web/20210124015834/http://mo.morsi.org/blog/2009/08/13/lesser_affero_gplv3/</crossRef>
       <crossRef>https://sourceforge.net/p/romic/code/ci/3ab2856180cf0d8b007609af53154cf092efc58f/tree/COPYING</crossRef>

--- a/src/pkgconf.xml
+++ b/src/pkgconf.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="false" licenseId="pkgconf"
-   name="pkgconf License" listVersionAdded="3.24">
+   name="pkgconf License" listVersionAdded="3.24.0">
       <crossRefs>
          <crossRef>https://github.com/pkgconf/pkgconf/blob/master/cli/main.c#L8</crossRef>
       </crossRefs>

--- a/src/threeparttable.xml
+++ b/src/threeparttable.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="false" licenseId="threeparttable"
-   name="threeparttable License" listVersionAdded="3.24">
+   name="threeparttable License" listVersionAdded="3.24.0">
       <crossRefs>
          <crossRef>https://fedoraproject.org/wiki/Licensing/Threeparttable</crossRef>
       </crossRefs>

--- a/src/xzoom.xml
+++ b/src/xzoom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="false" licenseId="xzoom"
-   name="xzoom License" listVersionAdded="3.24">
+   name="xzoom License" listVersionAdded="3.24.0">
       <crossRefs>
          <crossRef>https://metadata.ftp-master.debian.org/changelogs//main/x/xzoom/xzoom_0.3-27_copyright</crossRef>
       </crossRefs>


### PR DESCRIPTION
Fixes #2488

This commit adds ".0" for many licenses with listVersionAdded 3.24 (and a couple with 3.25) following the move to semver for the 3.24.0 release.

It also fixes a long-standing and much-copied typo in the release notes that was bothering me.

This handles items 1, 2 and 5 from #2488 (@xsuchy already took care of 3 and 4 -- thank you!)

Signed-off-by: Steve Winslow <steve@swinslow.net>