### PR TITLE
change spelling of "University" in xpp license

### DIFF
--- a/src/xpp.xml
+++ b/src/xpp.xml
@@ -43,7 +43,7 @@
         </item>
         <item>
             <bullet>5)</bullet>
-          Products derived from this software may not use &quot;Indiana <alt match="Univeristy|University" name="uni3">Univeristy</alt>&quot; 
+          Products derived from this software may not use &quot;Indiana <alt match="Univeristy|University" name="uni3">University</alt>&quot; 
           name nor may &quot;Indiana
           <alt match="Univeristy|University" name="uni4">Univeristy</alt>&quot; appear in their name, 
           without prior written permission of the Indiana University.


### PR DESCRIPTION
Fixes: #2587
Both spelling are possible using the alt tag. So it is safe to swap it, because this does not change any matching. It just change the text of example in our documentation.