### PR TITLE
Fixed a typo in Gmsh-exception.xml

### DIFF
--- a/src/exceptions/Gmsh-exception.xml
+++ b/src/exceptions/Gmsh-exception.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <exception licenseId="Gmsh-exception"
-   name="Gmsh exception>" listVersionAdded="3.23">
+   name="Gmsh exception" listVersionAdded="3.23">
    <crossRefs>
       <crossRef>https://gitlab.onelab.info/gmsh/gmsh/-/raw/master/LICENSE.txt</crossRef>
    </crossRefs>


### PR DESCRIPTION
The ">" at the end of "Gmsh exception>" appears to be a typo.