### PR TITLE
Update Mackerras-3-Clause-acknowledgment.xml

### DIFF
--- a/src/Mackerras-3-Clause-acknowledgment.xml
+++ b/src/Mackerras-3-Clause-acknowledgment.xml
@@ -34,7 +34,7 @@
                <bullet>3.</bullet>
                Redistributions of any form whatsoever must retain the
                following acknowledgment: "This product includes software
-               developed by Paul Mackerras &lt;paulus@ozlabs.org&gt;".
+               developed by Paul Mackerras <alt match="(&lt;paulus@ozlabs.org&gt;|&lt;paulus@samba.org&gt;)" name="emailAddress">&lt;paulus@ozlabs.org&gt;</alt>".
             </item>
          </list>
          <p>

--- a/src/Mackerras-3-Clause-acknowledgment.xml
+++ b/src/Mackerras-3-Clause-acknowledgment.xml
@@ -34,7 +34,7 @@
                <bullet>3.</bullet>
                Redistributions of any form whatsoever must retain the
                following acknowledgment: "This product includes software
-               developed by Paul Mackerras &lt;<alt match="(paulus@ozlabs.org|paulus@samba.org)" name="emailAddress">paulus@ozlabs.org</alt>&gt;".
+               developed by Paul Mackerras <alt match="(&lt;paulus@ozlabs.org&gt;|&lt;paulus@samba.org&gt;)" name="emailAddress">&lt;paulus@ozlabs.org&gt;</alt>".
             </item>
          </list>
          <p>

--- a/src/Mackerras-3-Clause-acknowledgment.xml
+++ b/src/Mackerras-3-Clause-acknowledgment.xml
@@ -34,7 +34,7 @@
                <bullet>3.</bullet>
                Redistributions of any form whatsoever must retain the
                following acknowledgment: "This product includes software
-               developed by Paul Mackerras &lt;paulus@<alt match="(ozlabs.org|samba.org)" name="emailDomain">ozlabs.org</alt>&gt;".
+               developed by Paul Mackerras &lt;<alt match="(paulus@ozlabs.org|paulus@samba.org)" name="emailAddress">paulus@ozlabs.org</alt>&gt;".
             </item>
          </list>
          <p>

--- a/src/Mackerras-3-Clause-acknowledgment.xml
+++ b/src/Mackerras-3-Clause-acknowledgment.xml
@@ -34,7 +34,7 @@
                <bullet>3.</bullet>
                Redistributions of any form whatsoever must retain the
                following acknowledgment: "This product includes software
-               developed by Paul Mackerras <alt match="(&lt;paulus@ozlabs.org&gt;|&lt;paulus@samba.org&gt;)" name="emailAddress">&lt;paulus@ozlabs.org&gt;</alt>".
+               developed by Paul Mackerras &lt;paulus@<alt match="(ozlabs.org|samba.org)" name="emailDomain">ozlabs.org</alt>&gt;".
             </item>
          </list>
          <p>


### PR DESCRIPTION
The current email address is listed from ppp-2.5.1 onwards, but the email address in the license is different up to ppp-2.5.0.

https://github.com/ppp-project/ppp/blob/ppp-2.5.1/pppd/auth.c#L20: paulus@ozlabs.org

https://github.com/ppp-project/ppp/blob/ppp-2.5.0/pppd/auth.c#L20: paulus@samba.org