### PR TITLE
Fix URLs to OSI website

### DIFF
--- a/DOCS/history-OSI-SPDX.md
+++ b/DOCS/history-OSI-SPDX.md
@@ -34,9 +34,9 @@ See SPDX-legal email list from April 2012 [here](https://lists.spdx.org/g/Spdx-l
 Suggestion for OSI: Consider listing all licenses ever approved on OSI website to retain a full historical record (even if noted as superceded).
 
 ## Artistic License variations
-The OSI explicitly approved two variants of [Artistic License 1.0](https://opensource.org/licenses/Artistic-1.0) as stated at the top of the page: with clause 8 and without. Because the presence or absence of clause 8 presents a substantive difference, SPDX added them as two separate licenses. 
+The OSI explicitly approved two variants of [Artistic License 1.0](https://opensource.org/license/Artistic-1.0) as stated at the top of the page: with clause 8 and without. Because the presence or absence of clause 8 presents a substantive difference, SPDX added them as two separate licenses. 
 
-In the course of this research, it was discovered that the text for the Artistic License 1.0 that was listed on the OSI website did not match the text of the Artistic License [used by Perl](https://dev.perl.org/licenses/artistic.html), which has 10 clauses, clause 5, 6, 7, and 8 being different from those on the OSI site. It is still unclear to this day what was originally submitted to OSI or where the text at https://opensource.org/licenses/Artistic-1.0 (either with or without clause 8) has been used in actual code.
+In the course of this research, it was discovered that the text for the Artistic License 1.0 that was listed on the OSI website did not match the text of the Artistic License [used by Perl](https://dev.perl.org/licenses/artistic.html), which has 10 clauses, clause 5, 6, 7, and 8 being different from those on the OSI site. It is still unclear to this day what was originally submitted to OSI or where the text at https://opensource.org/license/Artistic-1.0 (either with or without clause 8) has been used in actual code.
 
 As a result SPDX added 3 licenses to accommodate these variations:
 * `Artistic-1.0`
@@ -45,14 +45,14 @@ As a result SPDX added 3 licenses to accommodate these variations:
 
 OSI added a separate page for `Artistic-1.0-Perl` but the notation describing the variant is still confusing. 
 
-Suggestion for OSI: OSI add the SPDX ids, `Artistic-1.0` and `Artistic-1.0-cl8` to [this page](https://opensource.org/licenses/Artistic-1.0) and update the notation to something like,  “OSI approved this variant of Artistic License 1.0, (Artistic-1.0) with 9 clauses, as well as a variant that contains an additional clause 8 (Artistic-1.0-cl8). There is also the variant used by Perl (Artistic-1.0-Perl), which has differences from the text here in clauses 5, 6, 7 and 8.”
-And add the SPDX id, `Artistic-1.0-Perl` on [this page](https://opensource.org/licenses/Artistic-Perl-1.0) and update that note accordingly as well. 
+Suggestion for OSI: OSI add the SPDX ids, `Artistic-1.0` and `Artistic-1.0-cl8` to [this page](https://opensource.org/license/Artistic-1.0) and update the notation to something like,  “OSI approved this variant of Artistic License 1.0, (Artistic-1.0) with 9 clauses, as well as a variant that contains an additional clause 8 (Artistic-1.0-cl8). There is also the variant used by Perl (Artistic-1.0-Perl), which has differences from the text here in clauses 5, 6, 7 and 8.”
+And add the SPDX id, `Artistic-1.0-Perl` on [this page](https://opensource.org/license/Artistic-Perl-1.0) and update that note accordingly as well. 
 
 These SPDX licenses have an explanation, as appropriate, in the Note field. 
 
 ## License exceptions
 In at least two cases, the OSI approved a license exception with an SPDX id that is not current: 
-* [eCos License version 2.0](https://opensource.org/licenses/eCos-2.0) and lists the SPDX identifiers as `eCos-2.0`
+* [eCos License version 2.0](https://opensource.org/license/eCos-2.0) and lists the SPDX identifiers as `eCos-2.0`
 * [wxWindows Library License](https://spdx.org/licenses/wxWindows.html) and lists the SPDX identifier as `wxWindows`
 This is probably because these licenses were originally on the SPDX License List as a stand alone licenses. However, when SPDX 2.0 came out in May 2015, exceptions were moved to their own part of the SPDX License List to be used with the `WITH` operator to allow more extensible and varied license expressions, see https://spdx.org/licenses/eCos-2.0.html and now see https://spdx.org/licenses/eCos-exception-2.0.html
 and https://spdx.org/licenses/wxWindows.html and now see https://spdx.org/licenses/WxWindows-exception-3.1.html
@@ -74,7 +74,7 @@ Suggestion for OSI: OSI could add the variant SPDX ids to the license pages, and
 
 ## Not in SPDX list, but in OSI's list
 
-* [Jabber Open Source License](https://opensource.org/licenses/jabberpl) - This is a case where the text on the OSI site is not the same as the archived text at http://archive.jabber.org/core/JOSL.pdf SPDX would consider these two texts as different licenses, and was trying to clarify with the OSI which text was submitted and approved by OSI. Martin Michlmayr and Jilayne discussed this back in 2013 (https://lists.spdx.org/g/Spdx-legal/topic/22080295#475), but never reached a resolution. Jilayne emailed the OSI Board about this issue in July 2019. 
+* [Jabber Open Source License](https://opensource.org/license/jabberpl) - This is a case where the text on the OSI site is not the same as the archived text at http://archive.jabber.org/core/JOSL.pdf SPDX would consider these two texts as different licenses, and was trying to clarify with the OSI which text was submitted and approved by OSI. Martin Michlmayr and Jilayne discussed this back in 2013 (https://lists.spdx.org/g/Spdx-legal/topic/22080295#475), but never reached a resolution. Jilayne emailed the OSI Board about this issue in July 2019. 
 
 Suggestion: SPDX could recognize both variants on the SPDX License List and note the one that is specifically OSI-approved. This would require clarification from OSI as to which one was approved and make any updates to its site accordingly. If both variants were OSI-approved, then a new entry would be warranted on the OSI site and on the SPDX License List. 
 

--- a/DOCS/xml-fields.md
+++ b/DOCS/xml-fields.md
@@ -48,7 +48,7 @@ There are two mandatory attributes for every `<license>` and `<exception>` tag:
 There are two additional highly encouraged attributes which are technically optional:
 * `listVersionAdded`: in which release version of the SPDX License List was the license first added, e.g., "3.24.0".
   * Typically you'll check the currently-released version at https://github.com/spdx/license-list-XML/releases and increment the minor version by 1 for a new license. E.g., when last release is "3.24.0" you add there "3.25.0".
-* `isOsiApproved` (for licenses, not exceptions): either "true" or "false" based on whether this license has been approved by the [Open Source Initiative](https://opensource.org/licenses/alphabetical)
+* `isOsiApproved` (for licenses, not exceptions): either "true" or "false" based on whether this license has been approved by the [Open Source Initiative](https://opensource.org/licenses)
 
 Finally, if the license ID has been deprecated, one additional attribute should be included:
 * `deprecatedVersion`: in which release version of the SPDX License List was the license first marked as deprecated, e.g. "3.24.0"

--- a/src/0BSD.xml
+++ b/src/0BSD.xml
@@ -4,6 +4,7 @@
 	name="BSD Zero Clause License" listVersionAdded="2.2">
       <crossRefs>
          <crossRef>http://landley.net/toybox/license.html</crossRef>
+         <crossRef>https://opensource.org/license/0BSD</crossRef>
          <crossRef>https://opensource.org/licenses/0BSD</crossRef>
       </crossRefs>
     <text>

--- a/src/AAL.xml
+++ b/src/AAL.xml
@@ -2,6 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="AAL" name="Attribution Assurance License">
       <crossRefs>
+         <crossRef>https://opensource.org/license/attribution</crossRef>
          <crossRef>https://opensource.org/licenses/attribution</crossRef>
       </crossRefs>
       <notes>

--- a/src/AFL-3.0.xml
+++ b/src/AFL-3.0.xml
@@ -3,6 +3,7 @@
    <license isOsiApproved="true" licenseId="AFL-3.0" name="Academic Free License v3.0">
       <crossRefs>
          <crossRef>http://www.rosenlaw.com/AFL3.0.htm</crossRef>
+         <crossRef>https://opensource.org/license/afl-3.0</crossRef>
          <crossRef>https://opensource.org/licenses/afl-3.0</crossRef>
       </crossRefs>
     <text>

--- a/src/AGPL-3.0-only.xml
+++ b/src/AGPL-3.0-only.xml
@@ -4,6 +4,7 @@
   name="GNU Affero General Public License v3.0 only">
     <crossRefs>
       <crossRef>https://www.gnu.org/licenses/agpl.txt</crossRef>
+      <crossRef>https://opensource.org/license/AGPL-3.0</crossRef>
       <crossRef>https://opensource.org/licenses/AGPL-3.0</crossRef>
     </crossRefs>
     <standardLicenseHeader>

--- a/src/AGPL-3.0-or-later.xml
+++ b/src/AGPL-3.0-or-later.xml
@@ -4,6 +4,7 @@
   name="GNU Affero General Public License v3.0 or later">
     <crossRefs>
       <crossRef>https://www.gnu.org/licenses/agpl.txt</crossRef>
+      <crossRef>https://opensource.org/license/AGPL-3.0</crossRef>
       <crossRef>https://opensource.org/licenses/AGPL-3.0</crossRef>
     </crossRefs>
     <notes>

--- a/src/AGPL-3.0.xml
+++ b/src/AGPL-3.0.xml
@@ -9,6 +9,7 @@
     </obsoletedBys>
     <crossRefs>
       <crossRef>https://www.gnu.org/licenses/agpl.txt</crossRef>
+      <crossRef>https://opensource.org/license/AGPL-3.0</crossRef>
       <crossRef>https://opensource.org/licenses/AGPL-3.0</crossRef>
     </crossRefs>
     <standardLicenseHeader>

--- a/src/APL-1.0.xml
+++ b/src/APL-1.0.xml
@@ -2,6 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="APL-1.0" name="Adaptive Public License 1.0">
       <crossRefs>
+         <crossRef>https://opensource.org/license/APL-1.0</crossRef>
          <crossRef>https://opensource.org/licenses/APL-1.0</crossRef>
       </crossRefs>
     <text>

--- a/src/Apache-1.1.xml
+++ b/src/Apache-1.1.xml
@@ -3,6 +3,7 @@
    <license isOsiApproved="true" licenseId="Apache-1.1" name="Apache License 1.1">
       <crossRefs>
          <crossRef>http://apache.org/licenses/LICENSE-1.1</crossRef>
+         <crossRef>https://opensource.org/license/Apache-1.1</crossRef>
          <crossRef>https://opensource.org/licenses/Apache-1.1</crossRef>
       </crossRefs>
       <notes>This license has been superseded by Apache License 2.0</notes>

--- a/src/Apache-2.0.xml
+++ b/src/Apache-2.0.xml
@@ -3,6 +3,7 @@
    <license isOsiApproved="true" licenseId="Apache-2.0" name="Apache License 2.0">
       <crossRefs>
          <crossRef>https://www.apache.org/licenses/LICENSE-2.0</crossRef>
+         <crossRef>https://opensource.org/license/Apache-2.0</crossRef>
          <crossRef>https://opensource.org/licenses/Apache-2.0</crossRef>
       </crossRefs>
       <notes>This license was released January 2004</notes>

--- a/src/Artistic-1.0-cl8.xml
+++ b/src/Artistic-1.0-cl8.xml
@@ -3,6 +3,7 @@
    <license isOsiApproved="true" licenseId="Artistic-1.0-cl8"
             name="Artistic License 1.0 w/clause 8" listVersionAdded="1.19">
       <crossRefs>
+         <crossRef>https://opensource.org/license/Artistic-1.0</crossRef>
          <crossRef>https://opensource.org/licenses/Artistic-1.0</crossRef>
       </crossRefs>
       <notes>This license was superseded by v2.0. This is Artistic License 1.0 as found on OSI site, including clause

--- a/src/Artistic-1.0.xml
+++ b/src/Artistic-1.0.xml
@@ -2,6 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="Artistic-1.0" name="Artistic License 1.0">
       <crossRefs>
+         <crossRef>https://opensource.org/license/Artistic-1.0</crossRef>
          <crossRef>https://opensource.org/licenses/Artistic-1.0</crossRef>
       </crossRefs>
       <notes>This license was superseded by v2.0. This is Artistic License 1.0 as found on OSI site, excluding clause

--- a/src/Artistic-2.0.xml
+++ b/src/Artistic-2.0.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>http://www.perlfoundation.org/artistic_license_2_0</crossRef>
          <crossRef>https://www.perlfoundation.org/artistic-license-20.html</crossRef>
+         <crossRef>https://opensource.org/license/artistic-license-2.0</crossRef>
          <crossRef>https://opensource.org/licenses/artistic-license-2.0</crossRef>
       </crossRefs>
       <notes>This license was released: 2006</notes>

--- a/src/BSD-2-Clause-Patent.xml
+++ b/src/BSD-2-Clause-Patent.xml
@@ -4,6 +4,7 @@
     name="BSD-2-Clause Plus Patent License" listVersionAdded="2.7"
     isOsiApproved="true">
     <crossRefs>
+      <crossRef>https://opensource.org/license/BSDplusPatent</crossRef>
       <crossRef>https://opensource.org/licenses/BSDplusPatent</crossRef>
     </crossRefs>
     <notes>

--- a/src/BSD-2-Clause.xml
+++ b/src/BSD-2-Clause.xml
@@ -3,6 +3,7 @@
    <license isOsiApproved="true" licenseId="BSD-2-Clause"
             name="BSD 2-Clause &#34;Simplified&#34; License">
       <crossRefs>
+         <crossRef>https://opensource.org/license/BSD-2-Clause</crossRef>
          <crossRef>https://opensource.org/licenses/BSD-2-Clause</crossRef>
       </crossRefs>
     <text>

--- a/src/BSD-3-Clause.xml
+++ b/src/BSD-3-Clause.xml
@@ -3,6 +3,7 @@
    <license isOsiApproved="true" licenseId="BSD-3-Clause"
             name="BSD 3-Clause &#34;New&#34; or &#34;Revised&#34; License">
       <crossRefs>
+         <crossRef>https://opensource.org/license/BSD-3-Clause</crossRef>
          <crossRef>https://opensource.org/licenses/BSD-3-Clause</crossRef>
          <crossRef>https://www.eclipse.org/org/documents/edl-v10.php</crossRef>
       </crossRefs>

--- a/src/BSL-1.0.xml
+++ b/src/BSL-1.0.xml
@@ -3,6 +3,7 @@
    <license isOsiApproved="true" licenseId="BSL-1.0" name="Boost Software License 1.0">
       <crossRefs>
          <crossRef>http://www.boost.org/LICENSE_1_0.txt</crossRef>
+         <crossRef>https://opensource.org/license/BSL-1.0</crossRef>
          <crossRef>https://opensource.org/licenses/BSL-1.0</crossRef>
       </crossRefs>
       <notes>This license was released: 17 August 2003</notes>

--- a/src/CAL-1.0-Combined-Work-Exception.xml
+++ b/src/CAL-1.0-Combined-Work-Exception.xml
@@ -3,6 +3,7 @@
   <license isOsiApproved="true" licenseId="CAL-1.0-Combined-Work-Exception" name="Cryptographic Autonomy License 1.0 (Combined Work Exception)" listVersionAdded="3.9">
     <crossRefs>
       <crossRef>http://cryptographicautonomylicense.com/license-text.html</crossRef>
+      <crossRef>https://opensource.org/license/CAL-1.0</crossRef>
       <crossRef>https://opensource.org/licenses/CAL-1.0</crossRef>
     </crossRefs>
     <notes>The first draft of this license was released February 2019, and the fourth revision was approved by the OSI February 2020. This license list entry is for use when the work is subject to the "Combined Work Exception" as described in section 4.5.</notes>

--- a/src/CAL-1.0.xml
+++ b/src/CAL-1.0.xml
@@ -3,6 +3,7 @@
   <license isOsiApproved="true" licenseId="CAL-1.0" name="Cryptographic Autonomy License 1.0" listVersionAdded="3.9">
     <crossRefs>
       <crossRef>http://cryptographicautonomylicense.com/license-text.html</crossRef>
+      <crossRef>https://opensource.org/license/CAL-1.0</crossRef>
       <crossRef>https://opensource.org/licenses/CAL-1.0</crossRef>
     </crossRefs>
     <notes>The first draft of this license was released February 2019, and the fourth revision was approved by the OSI February 2020.</notes>

--- a/src/CATOSL-1.1.xml
+++ b/src/CATOSL-1.1.xml
@@ -3,6 +3,7 @@
    <license isOsiApproved="true" licenseId="CATOSL-1.1"
             name="Computer Associates Trusted Open Source License 1.1">
       <crossRefs>
+         <crossRef>https://opensource.org/license/CATOSL-1.1</crossRef>
          <crossRef>https://opensource.org/licenses/CATOSL-1.1</crossRef>
       </crossRefs>
     <text>

--- a/src/CDDL-1.0.xml
+++ b/src/CDDL-1.0.xml
@@ -3,6 +3,7 @@
    <license isOsiApproved="true" licenseId="CDDL-1.0"
             name="Common Development and Distribution License 1.0">
       <crossRefs>
+         <crossRef>https://opensource.org/license/cddl1</crossRef>
          <crossRef>https://opensource.org/licenses/cddl1</crossRef>
       </crossRefs>
       <notes>This license was released: 24 January 2004.</notes>

--- a/src/CNRI-Python.xml
+++ b/src/CNRI-Python.xml
@@ -2,6 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="CNRI-Python" name="CNRI Python License">
       <crossRefs>
+         <crossRef>https://opensource.org/license/CNRI-Python</crossRef>
          <crossRef>https://opensource.org/licenses/CNRI-Python</crossRef>
       </crossRefs>
       <notes>CNRI portion of the multi-part Python License (Python-2.0)</notes>

--- a/src/CPAL-1.0.xml
+++ b/src/CPAL-1.0.xml
@@ -3,6 +3,7 @@
    <license isOsiApproved="true" licenseId="CPAL-1.0"
             name="Common Public Attribution License 1.0">
       <crossRefs>
+         <crossRef>https://opensource.org/license/CPAL-1.0</crossRef>
          <crossRef>https://opensource.org/licenses/CPAL-1.0</crossRef>
       </crossRefs>
       <notes>

--- a/src/CPL-1.0.xml
+++ b/src/CPL-1.0.xml
@@ -2,6 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="CPL-1.0" name="Common Public License 1.0">
       <crossRefs>
+         <crossRef>https://opensource.org/license/CPL-1.0</crossRef>
          <crossRef>https://opensource.org/licenses/CPL-1.0</crossRef>
       </crossRefs>
       <notes>This license was superseded by Eclipse Public License</notes>

--- a/src/CUA-OPL-1.0.xml
+++ b/src/CUA-OPL-1.0.xml
@@ -3,6 +3,7 @@
    <license isOsiApproved="true" licenseId="CUA-OPL-1.0"
             name="CUA Office Public License v1.0">
       <crossRefs>
+         <crossRef>https://opensource.org/license/CUA-OPL-1.0</crossRef>
          <crossRef>https://opensource.org/licenses/CUA-OPL-1.0</crossRef>
       </crossRefs>
       <notes>The CUA Office Project has ceased to use or recommend this license. This license is essentially a rebranded version of MPL-1.1, but was included on the SPDX License List due to its OSI-approved status. </notes>

--- a/src/ECL-1.0.xml
+++ b/src/ECL-1.0.xml
@@ -3,6 +3,7 @@
    <license isOsiApproved="true" licenseId="ECL-1.0"
             name="Educational Community License v1.0">
       <crossRefs>
+         <crossRef>https://opensource.org/license/ECL-1.0</crossRef>
          <crossRef>https://opensource.org/licenses/ECL-1.0</crossRef>
       </crossRefs>
     <text>

--- a/src/ECL-2.0.xml
+++ b/src/ECL-2.0.xml
@@ -3,6 +3,7 @@
    <license isOsiApproved="true" licenseId="ECL-2.0"
             name="Educational Community License v2.0">
       <crossRefs>
+         <crossRef>https://opensource.org/license/ECL-2.0</crossRef>
          <crossRef>https://opensource.org/licenses/ECL-2.0</crossRef>
       </crossRefs>
       <notes>The Educational Community License version 2.0 ("ECL") consists of the Apache 2.0 license, modified

--- a/src/EFL-1.0.xml
+++ b/src/EFL-1.0.xml
@@ -3,6 +3,7 @@
    <license isOsiApproved="true" licenseId="EFL-1.0" name="Eiffel Forum License v1.0">
       <crossRefs>
          <crossRef>http://www.eiffel-nice.org/license/forum.txt</crossRef>
+         <crossRef>https://opensource.org/license/EFL-1.0</crossRef>
          <crossRef>https://opensource.org/licenses/EFL-1.0</crossRef>
       </crossRefs>
       <notes>This license has been superseded by v2.0</notes>

--- a/src/EFL-2.0.xml
+++ b/src/EFL-2.0.xml
@@ -3,6 +3,7 @@
    <license isOsiApproved="true" licenseId="EFL-2.0" name="Eiffel Forum License v2.0">
       <crossRefs>
          <crossRef>http://www.eiffel-nice.org/license/eiffel-forum-license-2.html</crossRef>
+         <crossRef>https://opensource.org/license/EFL-2.0</crossRef>
          <crossRef>https://opensource.org/licenses/EFL-2.0</crossRef>
       </crossRefs>
     <text>

--- a/src/EPL-1.0.xml
+++ b/src/EPL-1.0.xml
@@ -3,6 +3,7 @@
    <license isOsiApproved="true" licenseId="EPL-1.0" name="Eclipse Public License 1.0">
       <crossRefs>
          <crossRef>http://www.eclipse.org/legal/epl-v10.html</crossRef>
+         <crossRef>https://opensource.org/license/EPL-1.0</crossRef>
          <crossRef>https://opensource.org/licenses/EPL-1.0</crossRef>
       </crossRefs>
       <notes>EPL replaced the CPL on 28 June 2005.</notes>

--- a/src/EUDatagrid.xml
+++ b/src/EUDatagrid.xml
@@ -3,6 +3,7 @@
    <license isOsiApproved="true" licenseId="EUDatagrid" name="EU DataGrid Software License">
       <crossRefs>
          <crossRef>http://eu-datagrid.web.cern.ch/eu-datagrid/license.html</crossRef>
+         <crossRef>https://opensource.org/license/EUDatagrid</crossRef>
          <crossRef>https://opensource.org/licenses/EUDatagrid</crossRef>
       </crossRefs>
     <text>

--- a/src/EUPL-1.1.xml
+++ b/src/EUPL-1.1.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>https://joinup.ec.europa.eu/software/page/eupl/licence-eupl</crossRef>
          <crossRef>https://joinup.ec.europa.eu/sites/default/files/custom-page/attachment/eupl1.1.-licence-en_0.pdf</crossRef>
+         <crossRef>https://opensource.org/license/EUPL-1.1</crossRef>
          <crossRef>https://opensource.org/licenses/EUPL-1.1</crossRef>
       </crossRefs>
       <notes>This license was released: 16 May 2008 This license is available in the 22 official languages of the EU. The

--- a/src/EUPL-1.2.xml
+++ b/src/EUPL-1.2.xml
@@ -8,6 +8,7 @@
       <crossRef>https://joinup.ec.europa.eu/sites/default/files/custom-page/attachment/2020-03/EUPL-1.2%20EN.txt</crossRef>
       <crossRef>https://joinup.ec.europa.eu/sites/default/files/inline-files/EUPL%20v1_2%20EN(1).txt</crossRef>
       <crossRef>http://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32017D0863</crossRef>
+      <crossRef>https://opensource.org/license/EUPL-1.2</crossRef>
       <crossRef>https://opensource.org/licenses/EUPL-1.2</crossRef>
     </crossRefs>
     <notes>

--- a/src/Entessa.xml
+++ b/src/Entessa.xml
@@ -2,6 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="Entessa" name="Entessa Public License v1.0">
       <crossRefs>
+         <crossRef>https://opensource.org/license/Entessa</crossRef>
          <crossRef>https://opensource.org/licenses/Entessa</crossRef>
       </crossRefs>
       <notes>This license is mostly a match to Apache-1.1 (except for the addition of "open source" before 

--- a/src/Fair.xml
+++ b/src/Fair.xml
@@ -3,6 +3,7 @@
    <license isOsiApproved="true" licenseId="Fair" name="Fair License">
       <crossRefs>
          <crossRef>https://web.archive.org/web/20150926120323/http://fairlicense.org/</crossRef>
+         <crossRef>https://opensource.org/license/Fair</crossRef>
          <crossRef>https://opensource.org/licenses/Fair</crossRef>
       </crossRefs>
     <text>

--- a/src/Frameworx-1.0.xml
+++ b/src/Frameworx-1.0.xml
@@ -3,6 +3,7 @@
    <license isOsiApproved="true" licenseId="Frameworx-1.0"
             name="Frameworx Open License 1.0">
       <crossRefs>
+         <crossRef>https://opensource.org/license/Frameworx-1.0</crossRef>
          <crossRef>https://opensource.org/licenses/Frameworx-1.0</crossRef>
       </crossRefs>
       <notes>The url included in the license does not work. (15/10/10)</notes>

--- a/src/GPL-2.0+.xml
+++ b/src/GPL-2.0+.xml
@@ -7,6 +7,7 @@
       </obsoletedBys>
       <crossRefs>
          <crossRef>https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html</crossRef>
+         <crossRef>https://opensource.org/license/GPL-2.0</crossRef>
          <crossRef>https://opensource.org/licenses/GPL-2.0</crossRef>
       </crossRefs>
     <text>

--- a/src/GPL-2.0-only.xml
+++ b/src/GPL-2.0-only.xml
@@ -5,6 +5,7 @@
     <crossRefs>
       <crossRef>https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html</crossRef>
       <crossRef>https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt</crossRef>
+      <crossRef>https://opensource.org/license/GPL-2.0</crossRef>
       <crossRef>https://opensource.org/licenses/GPL-2.0</crossRef>
     </crossRefs>
     <standardLicenseHeader>

--- a/src/GPL-2.0-or-later.xml
+++ b/src/GPL-2.0-or-later.xml
@@ -4,6 +4,7 @@
   name="GNU General Public License v2.0 or later">
     <crossRefs>
       <crossRef>https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html</crossRef>
+      <crossRef>https://opensource.org/license/GPL-2.0</crossRef>
       <crossRef>https://opensource.org/licenses/GPL-2.0</crossRef>
     </crossRefs>
     <notes>

--- a/src/GPL-2.0.xml
+++ b/src/GPL-2.0.xml
@@ -9,6 +9,7 @@
     </obsoletedBys>
     <crossRefs>
       <crossRef>https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html</crossRef>
+      <crossRef>https://opensource.org/license/GPL-2.0</crossRef>
       <crossRef>https://opensource.org/licenses/GPL-2.0</crossRef>
     </crossRefs>
     <standardLicenseHeader>

--- a/src/GPL-3.0+.xml
+++ b/src/GPL-3.0+.xml
@@ -7,6 +7,7 @@
       </obsoletedBys>
       <crossRefs>
          <crossRef>https://www.gnu.org/licenses/gpl-3.0-standalone.html</crossRef>
+         <crossRef>https://opensource.org/license/GPL-3.0</crossRef>
          <crossRef>https://opensource.org/licenses/GPL-3.0</crossRef>
       </crossRefs>
     <text>

--- a/src/GPL-3.0-only.xml
+++ b/src/GPL-3.0-only.xml
@@ -4,6 +4,7 @@
   name="GNU General Public License v3.0 only">
     <crossRefs>
       <crossRef>https://www.gnu.org/licenses/gpl-3.0-standalone.html</crossRef>
+      <crossRef>https://opensource.org/license/GPL-3.0</crossRef>
       <crossRef>https://opensource.org/licenses/GPL-3.0</crossRef>
     </crossRefs>
     <standardLicenseHeader>

--- a/src/GPL-3.0-or-later.xml
+++ b/src/GPL-3.0-or-later.xml
@@ -4,6 +4,7 @@
   name="GNU General Public License v3.0 or later">
     <crossRefs>
       <crossRef>https://www.gnu.org/licenses/gpl-3.0-standalone.html</crossRef>
+      <crossRef>https://opensource.org/license/GPL-3.0</crossRef>
       <crossRef>https://opensource.org/licenses/GPL-3.0</crossRef>
     </crossRefs>
     <notes>

--- a/src/GPL-3.0.xml
+++ b/src/GPL-3.0.xml
@@ -9,6 +9,7 @@
     </obsoletedBys>
     <crossRefs>
       <crossRef>https://www.gnu.org/licenses/gpl-3.0-standalone.html</crossRef>
+      <crossRef>https://opensource.org/license/GPL-3.0</crossRef>
       <crossRef>https://opensource.org/licenses/GPL-3.0</crossRef>
     </crossRefs>
     <standardLicenseHeader>

--- a/src/HPND.xml
+++ b/src/HPND.xml
@@ -3,6 +3,7 @@
    <license isOsiApproved="true" licenseId="HPND"
             name="Historical Permission Notice and Disclaimer">
       <crossRefs>
+         <crossRef>https://opensource.org/license/HPND</crossRef>
          <crossRef>https://opensource.org/licenses/HPND</crossRef>
          <crossRef>http://lists.opensource.org/pipermail/license-discuss_lists.opensource.org/2002-November/006304.html</crossRef>
       </crossRefs>

--- a/src/IPA.xml
+++ b/src/IPA.xml
@@ -2,6 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="IPA" name="IPA Font License">
       <crossRefs>
+         <crossRef>https://opensource.org/license/IPA</crossRef>
          <crossRef>https://opensource.org/licenses/IPA</crossRef>
       </crossRefs>
     <text>

--- a/src/IPL-1.0.xml
+++ b/src/IPL-1.0.xml
@@ -2,6 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="IPL-1.0" name="IBM Public License v1.0">
       <crossRefs>
+         <crossRef>https://opensource.org/license/IPL-1.0</crossRef>
          <crossRef>https://opensource.org/licenses/IPL-1.0</crossRef>
       </crossRefs>
       <notes>This license was superseded by CPL.</notes>

--- a/src/ISC.xml
+++ b/src/ISC.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>https://www.isc.org/licenses/</crossRef>
          <crossRef>https://www.isc.org/downloads/software-support-policy/isc-license/</crossRef>
+         <crossRef>https://opensource.org/license/ISC</crossRef>
          <crossRef>https://opensource.org/licenses/ISC</crossRef>
       </crossRefs>
       <notes>

--- a/src/Intel.xml
+++ b/src/Intel.xml
@@ -2,6 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="Intel" name="Intel Open Source License" listVersionAdded="1.17">
       <crossRefs>
+         <crossRef>https://opensource.org/license/Intel</crossRef>
          <crossRef>https://opensource.org/licenses/Intel</crossRef>
       </crossRefs>
       <notes>This license has been deprecated. A note at the top of the OSI license page states, "The Intel Open

--- a/src/LGPL-2.1+.xml
+++ b/src/LGPL-2.1+.xml
@@ -7,6 +7,7 @@
       </obsoletedBys>
       <crossRefs>
          <crossRef>https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</crossRef>
+         <crossRef>https://opensource.org/license/LGPL-2.1</crossRef>
          <crossRef>https://opensource.org/licenses/LGPL-2.1</crossRef>
       </crossRefs>
     <text>

--- a/src/LGPL-2.1-only.xml
+++ b/src/LGPL-2.1-only.xml
@@ -4,6 +4,7 @@
   name="GNU Lesser General Public License v2.1 only">
     <crossRefs>
       <crossRef>https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</crossRef>
+      <crossRef>https://opensource.org/license/LGPL-2.1</crossRef>
       <crossRef>https://opensource.org/licenses/LGPL-2.1</crossRef>
     </crossRefs>
     <standardLicenseHeader>

--- a/src/LGPL-2.1-or-later.xml
+++ b/src/LGPL-2.1-or-later.xml
@@ -4,6 +4,7 @@
   name="GNU Lesser General Public License v2.1 or later">
     <crossRefs>
       <crossRef>https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</crossRef>
+      <crossRef>https://opensource.org/license/LGPL-2.1</crossRef>
       <crossRef>https://opensource.org/licenses/LGPL-2.1</crossRef>
     </crossRefs>
     <notes>

--- a/src/LGPL-2.1.xml
+++ b/src/LGPL-2.1.xml
@@ -9,6 +9,7 @@
     </obsoletedBys>
     <crossRefs>
       <crossRef>https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</crossRef>
+      <crossRef>https://opensource.org/license/LGPL-2.1</crossRef>
       <crossRef>https://opensource.org/licenses/LGPL-2.1</crossRef>
     </crossRefs>
     <standardLicenseHeader>

--- a/src/LGPL-3.0+.xml
+++ b/src/LGPL-3.0+.xml
@@ -8,6 +8,7 @@
       <crossRefs>
          <crossRef>https://www.gnu.org/licenses/lgpl-3.0-standalone.html</crossRef>
          <crossRef>https://www.gnu.org/licenses/lgpl+gpl-3.0.txt</crossRef>
+         <crossRef>https://opensource.org/license/LGPL-3.0</crossRef>
          <crossRef>https://opensource.org/licenses/LGPL-3.0</crossRef>
       </crossRefs>
       <notes>

--- a/src/LGPL-3.0-only.xml
+++ b/src/LGPL-3.0-only.xml
@@ -5,6 +5,7 @@
     <crossRefs>
       <crossRef>https://www.gnu.org/licenses/lgpl-3.0-standalone.html</crossRef>
       <crossRef>https://www.gnu.org/licenses/lgpl+gpl-3.0.txt</crossRef>
+      <crossRef>https://opensource.org/license/LGPL-3.0</crossRef>
       <crossRef>https://opensource.org/licenses/LGPL-3.0</crossRef>
     </crossRefs>
     <notes>

--- a/src/LGPL-3.0-or-later.xml
+++ b/src/LGPL-3.0-or-later.xml
@@ -5,6 +5,7 @@
     <crossRefs>
       <crossRef>https://www.gnu.org/licenses/lgpl-3.0-standalone.html</crossRef>
       <crossRef>https://www.gnu.org/licenses/lgpl+gpl-3.0.txt</crossRef>
+      <crossRef>https://opensource.org/license/LGPL-3.0</crossRef>
       <crossRef>https://opensource.org/licenses/LGPL-3.0</crossRef>
     </crossRefs>
     <notes>

--- a/src/LGPL-3.0.xml
+++ b/src/LGPL-3.0.xml
@@ -10,6 +10,7 @@
     <crossRefs>
       <crossRef>https://www.gnu.org/licenses/lgpl-3.0-standalone.html</crossRef>
       <crossRef>https://www.gnu.org/licenses/lgpl+gpl-3.0.txt</crossRef>
+      <crossRef>https://opensource.org/license/LGPL-3.0</crossRef>
       <crossRef>https://opensource.org/licenses/LGPL-3.0</crossRef>
     </crossRefs>
     <notes>

--- a/src/LPL-1.0.xml
+++ b/src/LPL-1.0.xml
@@ -3,6 +3,7 @@
    <license isOsiApproved="true" licenseId="LPL-1.0"
             name="Lucent Public License Version 1.0">
       <crossRefs>
+         <crossRef>https://opensource.org/license/LPL-1.0</crossRef>
          <crossRef>https://opensource.org/licenses/LPL-1.0</crossRef>
       </crossRefs>
     <text>

--- a/src/LPL-1.02.xml
+++ b/src/LPL-1.02.xml
@@ -3,6 +3,7 @@
    <license isOsiApproved="true" licenseId="LPL-1.02" name="Lucent Public License v1.02">
       <crossRefs>
          <crossRef>http://plan9.bell-labs.com/plan9/license.html</crossRef>
+         <crossRef>https://opensource.org/license/LPL-1.02</crossRef>
          <crossRef>https://opensource.org/licenses/LPL-1.02</crossRef>
       </crossRefs>
     <text>

--- a/src/LPPL-1.3c.xml
+++ b/src/LPPL-1.3c.xml
@@ -4,6 +4,7 @@
             name="LaTeX Project Public License v1.3c">
       <crossRefs>
          <crossRef>http://www.latex-project.org/lppl/lppl-1-3c.txt</crossRef>
+         <crossRef>https://opensource.org/license/LPPL-1.3c</crossRef>
          <crossRef>https://opensource.org/licenses/LPPL-1.3c</crossRef>
       </crossRefs>
       <notes>This license was released: 4 May 2008</notes>

--- a/src/MIT.xml
+++ b/src/MIT.xml
@@ -3,6 +3,7 @@
    <license isOsiApproved="true" licenseId="MIT" name="MIT License">
       <crossRefs>
          <crossRef>https://opensource.org/license/mit/</crossRef>
+         <crossRef>https://opensource.org/licenses/mit/</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/MPL-1.0.xml
+++ b/src/MPL-1.0.xml
@@ -3,6 +3,7 @@
    <license isOsiApproved="true" licenseId="MPL-1.0" name="Mozilla Public License 1.0">
       <crossRefs>
          <crossRef>http://www.mozilla.org/MPL/MPL-1.0.html</crossRef>
+         <crossRef>https://opensource.org/license/MPL-1.0</crossRef>
          <crossRef>https://opensource.org/licenses/MPL-1.0</crossRef>
       </crossRefs>
       <notes>This license has been superseded by v1.1</notes>

--- a/src/MPL-1.1.xml
+++ b/src/MPL-1.1.xml
@@ -3,6 +3,7 @@
    <license isOsiApproved="true" licenseId="MPL-1.1" name="Mozilla Public License 1.1">
       <crossRefs>
          <crossRef>http://www.mozilla.org/MPL/MPL-1.1.html</crossRef>
+         <crossRef>https://opensource.org/license/MPL-1.1</crossRef>
          <crossRef>https://opensource.org/licenses/MPL-1.1</crossRef>
       </crossRefs>
       <notes>This license has been superseded by v2.0</notes>

--- a/src/MPL-2.0-no-copyleft-exception.xml
+++ b/src/MPL-2.0-no-copyleft-exception.xml
@@ -4,6 +4,7 @@
       name="Mozilla Public License 2.0 (no copyleft exception)">
       <crossRefs>
          <crossRef>https://www.mozilla.org/MPL/2.0/</crossRef>
+         <crossRef>https://opensource.org/license/MPL-2.0</crossRef>
          <crossRef>https://opensource.org/licenses/MPL-2.0</crossRef>
       </crossRefs>
       <notes>This license was released in January 2012. This license list entry is for use when the MPL's Exhibit B is used,

--- a/src/MPL-2.0.xml
+++ b/src/MPL-2.0.xml
@@ -3,6 +3,7 @@
    <license isOsiApproved="true" licenseId="MPL-2.0" name="Mozilla Public License 2.0">
       <crossRefs>
          <crossRef>https://www.mozilla.org/MPL/2.0/</crossRef>
+         <crossRef>https://opensource.org/license/MPL-2.0</crossRef>
          <crossRef>https://opensource.org/licenses/MPL-2.0</crossRef>
       </crossRefs>
       <notes>This license was released in January 2012. This license list entry is for use when the standard MPL 2.0 is

--- a/src/MS-PL.xml
+++ b/src/MS-PL.xml
@@ -3,6 +3,7 @@
    <license isOsiApproved="true" licenseId="MS-PL" name="Microsoft Public License">
       <crossRefs>
          <crossRef>http://www.microsoft.com/opensource/licenses.mspx</crossRef>
+         <crossRef>https://opensource.org/license/MS-PL</crossRef>
          <crossRef>https://opensource.org/licenses/MS-PL</crossRef>
       </crossRefs>
     <text>

--- a/src/MS-RL.xml
+++ b/src/MS-RL.xml
@@ -3,6 +3,7 @@
    <license isOsiApproved="true" licenseId="MS-RL" name="Microsoft Reciprocal License">
       <crossRefs>
          <crossRef>http://www.microsoft.com/opensource/licenses.mspx</crossRef>
+         <crossRef>https://opensource.org/license/MS-RL</crossRef>
          <crossRef>https://opensource.org/licenses/MS-RL</crossRef>
       </crossRefs>
     <text>

--- a/src/MirOS.xml
+++ b/src/MirOS.xml
@@ -2,6 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="MirOS" name="The MirOS Licence">
       <crossRefs>
+         <crossRef>https://opensource.org/license/MirOS</crossRef>
          <crossRef>https://opensource.org/licenses/MirOS</crossRef>
       </crossRefs>
     <text>

--- a/src/Motosoto.xml
+++ b/src/Motosoto.xml
@@ -2,6 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="Motosoto" name="Motosoto License">
       <crossRefs>
+         <crossRef>https://opensource.org/license/Motosoto</crossRef>
          <crossRef>https://opensource.org/licenses/Motosoto</crossRef>
       </crossRefs>
     <text>

--- a/src/Multics.xml
+++ b/src/Multics.xml
@@ -2,6 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="Multics" name="Multics License">
       <crossRefs>
+         <crossRef>https://opensource.org/license/Multics</crossRef>
          <crossRef>https://opensource.org/licenses/Multics</crossRef>
       </crossRefs>
       <notes>

--- a/src/NASA-1.3.xml
+++ b/src/NASA-1.3.xml
@@ -3,6 +3,7 @@
    <license isOsiApproved="true" licenseId="NASA-1.3" name="NASA Open Source Agreement 1.3">
       <crossRefs>
          <crossRef>http://ti.arc.nasa.gov/opensource/nosa/</crossRef>
+         <crossRef>https://opensource.org/license/NASA-1.3</crossRef>
          <crossRef>https://opensource.org/licenses/NASA-1.3</crossRef>
       </crossRefs>
     <text>

--- a/src/NCSA.xml
+++ b/src/NCSA.xml
@@ -4,6 +4,7 @@
             name="University of Illinois/NCSA Open Source License">
       <crossRefs>
          <crossRef>http://otm.illinois.edu/uiuc_openSource</crossRef>
+         <crossRef>https://opensource.org/license/NCSA</crossRef>
          <crossRef>https://opensource.org/licenses/NCSA</crossRef>
       </crossRefs>
     <text>

--- a/src/NGPL.xml
+++ b/src/NGPL.xml
@@ -2,6 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="NGPL" name="Nethack General Public License">
       <crossRefs>
+         <crossRef>https://opensource.org/license/NGPL</crossRef>
          <crossRef>https://opensource.org/licenses/NGPL</crossRef>
       </crossRefs>
     <text>

--- a/src/NPOSL-3.0.xml
+++ b/src/NPOSL-3.0.xml
@@ -3,6 +3,7 @@
    <license isOsiApproved="true" licenseId="NPOSL-3.0"
             name="Non-Profit Open Software License 3.0">
       <crossRefs>
+         <crossRef>https://opensource.org/license/NOSL3.0</crossRef>
          <crossRef>https://opensource.org/licenses/NOSL3.0</crossRef>
       </crossRefs>
     <text>

--- a/src/NTP.xml
+++ b/src/NTP.xml
@@ -2,6 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="NTP" name="NTP License">
       <crossRefs>
+         <crossRef>https://opensource.org/license/NTP</crossRef>
          <crossRef>https://opensource.org/licenses/NTP</crossRef>
       </crossRefs>
     <text>

--- a/src/Naumen.xml
+++ b/src/Naumen.xml
@@ -2,6 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="Naumen" name="Naumen Public License">
       <crossRefs>
+         <crossRef>https://opensource.org/license/Naumen</crossRef>
          <crossRef>https://opensource.org/licenses/Naumen</crossRef>
       </crossRefs>
     <text>

--- a/src/Nokia.xml
+++ b/src/Nokia.xml
@@ -2,6 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="Nokia" name="Nokia Open Source License">
       <crossRefs>
+         <crossRef>https://opensource.org/license/nokia</crossRef>
          <crossRef>https://opensource.org/licenses/nokia</crossRef>
       </crossRefs>
     <text>

--- a/src/OCLC-2.0.xml
+++ b/src/OCLC-2.0.xml
@@ -4,6 +4,7 @@
             name="OCLC Research Public License 2.0">
       <crossRefs>
          <crossRef>http://www.oclc.org/research/activities/software/license/v2final.htm</crossRef>
+         <crossRef>https://opensource.org/license/OCLC-2.0</crossRef>
          <crossRef>https://opensource.org/licenses/OCLC-2.0</crossRef>
       </crossRefs>
       <notes>This license was released: May 2002</notes>

--- a/src/OFL-1.1-RFN.xml
+++ b/src/OFL-1.1-RFN.xml
@@ -3,6 +3,7 @@
    <license isOsiApproved="true" licenseId="OFL-1.1-RFN" name="SIL Open Font License 1.1 with Reserved Font Name" listVersionAdded="3.8">
       <crossRefs>
          <crossRef>http://scripts.sil.org/cms/scripts/page.php?item_id=OFL_web</crossRef>
+         <crossRef>https://opensource.org/license/OFL-1.1</crossRef>
          <crossRef>https://opensource.org/licenses/OFL-1.1</crossRef>
       </crossRefs>
       <notes>This license was released 26 February 2007. The identifier OFL-1.1-RFN should only be

--- a/src/OFL-1.1-no-RFN.xml
+++ b/src/OFL-1.1-no-RFN.xml
@@ -3,6 +3,7 @@
    <license isOsiApproved="true" licenseId="OFL-1.1-no-RFN" name="SIL Open Font License 1.1 with no Reserved Font Name" listVersionAdded="3.8">
       <crossRefs>
          <crossRef>http://scripts.sil.org/cms/scripts/page.php?item_id=OFL_web</crossRef>
+         <crossRef>https://opensource.org/license/OFL-1.1</crossRef>
          <crossRef>https://opensource.org/licenses/OFL-1.1</crossRef>
       </crossRefs>
       <notes>This license was released 26 February 2007. The identifier OFL-1.1-no-RFN should only be

--- a/src/OFL-1.1.xml
+++ b/src/OFL-1.1.xml
@@ -3,6 +3,7 @@
    <license isOsiApproved="true" licenseId="OFL-1.1" name="SIL Open Font License 1.1">
       <crossRefs>
          <crossRef>http://scripts.sil.org/cms/scripts/page.php?item_id=OFL_web</crossRef>
+         <crossRef>https://opensource.org/license/OFL-1.1</crossRef>
          <crossRef>https://opensource.org/licenses/OFL-1.1</crossRef>
       </crossRefs>
       <notes>This license was released 26 February 2007. The identifier OFL-1.1 can be used to indicate that

--- a/src/OGTSL.xml
+++ b/src/OGTSL.xml
@@ -3,6 +3,7 @@
    <license isOsiApproved="true" licenseId="OGTSL" name="Open Group Test Suite License">
       <crossRefs>
          <crossRef>http://www.opengroup.org/testing/downloads/The_Open_Group_TSL.txt</crossRef>
+         <crossRef>https://opensource.org/license/OGTSL</crossRef>
          <crossRef>https://opensource.org/licenses/OGTSL</crossRef>
       </crossRefs>
     <text>

--- a/src/OLFL-1.3.xml
+++ b/src/OLFL-1.3.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>https://openlogisticsfoundation.org/licenses/</crossRef>
          <crossRef>https://opensource.org/license/olfl-1-3/</crossRef>
+         <crossRef>https://opensource.org/licenses/olfl-1-3/</crossRef>
       </crossRefs>
       <notes>This license was released January 2023</notes>
     <text>

--- a/src/OSET-PL-2.1.xml
+++ b/src/OSET-PL-2.1.xml
@@ -4,6 +4,7 @@
             name="OSET Public License version 2.1" listVersionAdded="2.4">
       <crossRefs>
          <crossRef>http://www.osetfoundation.org/public-license</crossRef>
+         <crossRef>https://opensource.org/license/OPL-2.1</crossRef>
          <crossRef>https://opensource.org/licenses/OPL-2.1</crossRef>
       </crossRefs>
     <text>

--- a/src/OSL-1.0.xml
+++ b/src/OSL-1.0.xml
@@ -2,6 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="OSL-1.0" name="Open Software License 1.0">
       <crossRefs>
+         <crossRef>https://opensource.org/license/OSL-1.0</crossRef>
          <crossRef>https://opensource.org/licenses/OSL-1.0</crossRef>
       </crossRefs>
       <notes>This license has been superseded.</notes>

--- a/src/OSL-2.1.xml
+++ b/src/OSL-2.1.xml
@@ -3,6 +3,7 @@
    <license isOsiApproved="true" licenseId="OSL-2.1" name="Open Software License 2.1">
       <crossRefs>
          <crossRef>http://web.archive.org/web/20050212003940/http://www.rosenlaw.com/osl21.htm</crossRef>
+         <crossRef>https://opensource.org/license/OSL-2.1</crossRef>
          <crossRef>https://opensource.org/licenses/OSL-2.1</crossRef>
       </crossRefs>
       <notes>Same as version 2.0 of this license except with changes to section 10</notes>

--- a/src/OSL-3.0.xml
+++ b/src/OSL-3.0.xml
@@ -3,6 +3,7 @@
    <license isOsiApproved="true" licenseId="OSL-3.0" name="Open Software License 3.0">
       <crossRefs>
          <crossRef>https://web.archive.org/web/20120101081418/http://rosenlaw.com:80/OSL3.0.htm</crossRef>
+         <crossRef>https://opensource.org/license/OSL-3.0</crossRef>
          <crossRef>https://opensource.org/licenses/OSL-3.0</crossRef>
       </crossRefs>
     <text>

--- a/src/PHP-3.0.xml
+++ b/src/PHP-3.0.xml
@@ -3,6 +3,7 @@
    <license isOsiApproved="true" licenseId="PHP-3.0" name="PHP License v3.0">
       <crossRefs>
          <crossRef>http://www.php.net/license/3_0.txt</crossRef>
+         <crossRef>https://opensource.org/license/PHP-3.0</crossRef>
          <crossRef>https://opensource.org/licenses/PHP-3.0</crossRef>
       </crossRefs>
     <text>

--- a/src/PSF-2.0.xml
+++ b/src/PSF-2.0.xml
@@ -2,6 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
   <license licenseId="PSF-2.0" name="Python Software Foundation License 2.0" listVersionAdded="3.8">
     <crossRefs>
+      <crossRef>https://opensource.org/license/Python-2.0</crossRef>
       <crossRef>https://opensource.org/licenses/Python-2.0</crossRef>
 	    <crossRef>https://matplotlib.org/stable/project/license.html</crossRef>
     </crossRefs>

--- a/src/PostgreSQL.xml
+++ b/src/PostgreSQL.xml
@@ -3,6 +3,7 @@
    <license isOsiApproved="true" licenseId="PostgreSQL" name="PostgreSQL License">
       <crossRefs>
          <crossRef>http://www.postgresql.org/about/licence</crossRef>
+         <crossRef>https://opensource.org/license/PostgreSQL</crossRef>
          <crossRef>https://opensource.org/licenses/PostgreSQL</crossRef>
       </crossRefs>
     <text>

--- a/src/Python-2.0.xml
+++ b/src/Python-2.0.xml
@@ -2,6 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="Python-2.0" name="Python License 2.0">
       <crossRefs>
+         <crossRef>https://opensource.org/license/Python-2.0</crossRef>
          <crossRef>https://opensource.org/licenses/Python-2.0</crossRef>
       </crossRefs>
       <notes>This is the overall Python license as published on the OSI website, which is comprised of several licenses.</notes>

--- a/src/QPL-1.0.xml
+++ b/src/QPL-1.0.xml
@@ -3,6 +3,7 @@
    <license isOsiApproved="true" licenseId="QPL-1.0" name="Q Public License 1.0">
       <crossRefs>
          <crossRef>http://doc.qt.nokia.com/3.3/license.html</crossRef>
+         <crossRef>https://opensource.org/license/QPL-1.0</crossRef>
          <crossRef>https://opensource.org/licenses/QPL-1.0</crossRef>
          <crossRef>https://doc.qt.io/archives/3.3/license.html</crossRef>
       </crossRefs>

--- a/src/RPL-1.1.xml
+++ b/src/RPL-1.1.xml
@@ -2,6 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="RPL-1.1" name="Reciprocal Public License 1.1" listVersionAdded="1.18">
       <crossRefs>
+         <crossRef>https://opensource.org/license/RPL-1.1</crossRef>
          <crossRef>https://opensource.org/licenses/RPL-1.1</crossRef>
       </crossRefs>
       <notes>This license has been superseded by the Reciprocal Public License, version 1.5</notes>

--- a/src/RPL-1.5.xml
+++ b/src/RPL-1.5.xml
@@ -2,6 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="RPL-1.5" name="Reciprocal Public License 1.5">
       <crossRefs>
+         <crossRef>https://opensource.org/license/RPL-1.5</crossRef>
          <crossRef>https://opensource.org/licenses/RPL-1.5</crossRef>
       </crossRefs>
       <notes>This license was released: 15 July 2007</notes>

--- a/src/RPSL-1.0.xml
+++ b/src/RPSL-1.0.xml
@@ -4,6 +4,7 @@
             name="RealNetworks Public Source License v1.0">
       <crossRefs>
          <crossRef>https://helixcommunity.org/content/rpsl</crossRef>
+         <crossRef>https://opensource.org/license/RPSL-1.0</crossRef>
          <crossRef>https://opensource.org/licenses/RPSL-1.0</crossRef>
       </crossRefs>
     <text>

--- a/src/RSCPL.xml
+++ b/src/RSCPL.xml
@@ -3,6 +3,7 @@
    <license isOsiApproved="true" licenseId="RSCPL" name="Ricoh Source Code Public License">
       <crossRefs>
          <crossRef>http://wayback.archive.org/web/20060715140826/http://www.risource.org/RPL/RPL-1.0A.shtml</crossRef>
+         <crossRef>https://opensource.org/license/RSCPL</crossRef>
          <crossRef>https://opensource.org/licenses/RSCPL</crossRef>
       </crossRefs>
     <text>

--- a/src/SISSL.xml
+++ b/src/SISSL.xml
@@ -4,6 +4,7 @@
             name="Sun Industry Standards Source License v1.1" listVersionAdded="1.17">
       <crossRefs>
          <crossRef>http://www.openoffice.org/licenses/sissl_license.html</crossRef>
+         <crossRef>https://opensource.org/license/SISSL</crossRef>
          <crossRef>https://opensource.org/licenses/SISSL</crossRef>
       </crossRefs>
     <text>

--- a/src/SPL-1.0.xml
+++ b/src/SPL-1.0.xml
@@ -2,6 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="SPL-1.0" name="Sun Public License v1.0">
       <crossRefs>
+         <crossRef>https://opensource.org/license/SPL-1.0</crossRef>
          <crossRef>https://opensource.org/licenses/SPL-1.0</crossRef>
       </crossRefs>
       <notes>

--- a/src/SimPL-2.0.xml
+++ b/src/SimPL-2.0.xml
@@ -2,6 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="SimPL-2.0" name="Simple Public License 2.0">
       <crossRefs>
+         <crossRef>https://opensource.org/license/SimPL-2.0</crossRef>
          <crossRef>https://opensource.org/licenses/SimPL-2.0</crossRef>
       </crossRefs>
     <text>

--- a/src/Sleepycat.xml
+++ b/src/Sleepycat.xml
@@ -2,6 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="Sleepycat" name="Sleepycat License">
       <crossRefs>
+         <crossRef>https://opensource.org/license/Sleepycat</crossRef>
          <crossRef>https://opensource.org/licenses/Sleepycat</crossRef>
       </crossRefs>
     <text>

--- a/src/UCL-1.0.xml
+++ b/src/UCL-1.0.xml
@@ -2,6 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="UCL-1.0" name="Upstream Compatibility License v1.0" listVersionAdded="3.7">
       <crossRefs>
+         <crossRef>https://opensource.org/license/UCL-1.0</crossRef>
          <crossRef>https://opensource.org/licenses/UCL-1.0</crossRef>
       </crossRefs>
     <text>

--- a/src/UPL-1.0.xml
+++ b/src/UPL-1.0.xml
@@ -3,6 +3,7 @@
    <license isOsiApproved="true" licenseId="UPL-1.0"
             name="Universal Permissive License v1.0" listVersionAdded="2.1">
       <crossRefs>
+         <crossRef>https://opensource.org/license/UPL</crossRef>
          <crossRef>https://opensource.org/licenses/UPL</crossRef>
       </crossRefs>
     <text>

--- a/src/VSL-1.0.xml
+++ b/src/VSL-1.0.xml
@@ -2,6 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="VSL-1.0" name="Vovida Software License v1.0">
       <crossRefs>
+         <crossRef>https://opensource.org/license/VSL-1.0</crossRef>
          <crossRef>https://opensource.org/licenses/VSL-1.0</crossRef>
       </crossRefs>
     <text>

--- a/src/W3C.xml
+++ b/src/W3C.xml
@@ -4,6 +4,7 @@
             name="W3C Software Notice and License (2002-12-31)">
       <crossRefs>
          <crossRef>http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231.html</crossRef>
+         <crossRef>https://opensource.org/license/W3C</crossRef>
          <crossRef>https://opensource.org/licenses/W3C</crossRef>
       </crossRefs>
       <standardLicenseHeader>

--- a/src/Watcom-1.0.xml
+++ b/src/Watcom-1.0.xml
@@ -3,6 +3,7 @@
    <license isOsiApproved="true" licenseId="Watcom-1.0"
             name="Sybase Open Watcom Public License 1.0">
       <crossRefs>
+         <crossRef>https://opensource.org/license/Watcom-1.0</crossRef>
          <crossRef>https://opensource.org/licenses/Watcom-1.0</crossRef>
       </crossRefs>
     <text>

--- a/src/Xnet.xml
+++ b/src/Xnet.xml
@@ -2,6 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
    <license isOsiApproved="true" licenseId="Xnet" name="X.Net License">
       <crossRefs>
+         <crossRef>https://opensource.org/license/Xnet</crossRef>
          <crossRef>https://opensource.org/licenses/Xnet</crossRef>
       </crossRefs>
       <notes>This license is the same as MIT, but with a choice of law clause. This License has been voluntarily

--- a/src/ZPL-2.0.xml
+++ b/src/ZPL-2.0.xml
@@ -3,6 +3,7 @@
    <license isOsiApproved="true" licenseId="ZPL-2.0" name="Zope Public License 2.0">
       <crossRefs>
          <crossRef>http://old.zope.org/Resources/License/ZPL-2.0</crossRef>
+         <crossRef>https://opensource.org/license/ZPL-2.0</crossRef>
          <crossRef>https://opensource.org/licenses/ZPL-2.0</crossRef>
       </crossRefs>
     <text>

--- a/src/Zlib.xml
+++ b/src/Zlib.xml
@@ -3,6 +3,7 @@
    <license isOsiApproved="true" licenseId="Zlib" name="zlib License">
       <crossRefs>
          <crossRef>http://www.zlib.net/zlib_license.html</crossRef>
+         <crossRef>https://opensource.org/license/Zlib</crossRef>
          <crossRef>https://opensource.org/licenses/Zlib</crossRef>
       </crossRefs>
     <text>

--- a/src/wxWindows.xml
+++ b/src/wxWindows.xml
@@ -5,6 +5,7 @@
          <obsoletedBy>GPL-2.0-or-later WITH WxWindows-exception-3.1</obsoletedBy>
       </obsoletedBys>
       <crossRefs>
+         <crossRef>https://opensource.org/license/WXwindows</crossRef>
          <crossRef>https://opensource.org/licenses/WXwindows</crossRef>
       </crossRefs>
       <notes>DEPRECATED: Use license expression including main license, "WITH" operator, and identifier: WxWindows-exception-3.1</notes>


### PR DESCRIPTION
Apparently OSI webite was restructured a bit some time ago. Old links to license info return HTTP 301 redirects. While it's not a problem for a browser to follow such link, some kind of parser logic at SPDX erroneously detects such URL as "no longer live" when you see "Other web pages for this license" on SPDX website.
