### PR TITLE
allow more than one test file for a license

### DIFF
--- a/rename-license
+++ b/rename-license
@@ -20,6 +20,11 @@ rm "src/$1.xml"
 tests="test/simpleTestForGenerator"
 if [ -f "$tests/$1.txt" ]; then
   mv "$tests/$1.txt" "$tests/$2.txt"
-else
-  echo "No test file found."
 fi
+for test_file in $tests/$1.*.txt; do
+  if [ -f "$test_file" ]; then
+    # Extract the middle part of the filename
+    middle_part=$(echo "$test_file" | sed -E "s/test\/simpleTestForGenerator\/$1\.(.*)\.txt/\1/")
+    mv "$tests/$1.${middle_part}.txt" "$tests/$2.${middle_part}.txt"
+  fi
+done

--- a/test-one-license
+++ b/test-one-license
@@ -6,4 +6,11 @@ PUBLISHER=licenseListPublisher-${TOOL_VERSION}.jar
 # if license list publisher is not present, download it
 test ! -f ${PUBLISHER}  && make ${PUBLISHER}-valid
 
-java -jar ${PUBLISHER} TestLicenseXML "src/${@}.xml" "test/simpleTestForGenerator/${@}.txt"
+for test_file in \
+        "test/simpleTestForGenerator/$1.txt" \
+        test/simpleTestForGenerator/$1.*.txt; do
+        if [ -f "$test_file" ]; then
+                echo "Testing $test_file"
+                java -jar ${PUBLISHER} TestLicenseXML "src/$1.xml" "$test_file"
+        fi
+done

--- a/test/simpleTestForGenerator/BSD-3-Clause.edl-v10.txt
+++ b/test/simpleTestForGenerator/BSD-3-Clause.edl-v10.txt
@@ -1,0 +1,11 @@
+Copyright (c) 2007, Eclipse Foundation, Inc. and its licensors.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+    Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+    Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+    Neither the name of the Eclipse Foundation, Inc. nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
For now, we allow only one test file for license.
Various licenses have variation. And we are adding more and more markup variations. But we do not have tests for them.

I propose to test not just
  test/simpleTestForGenerator/${LICENSE}.txt
but also
  test/simpleTestForGenerator/${LICENSE}.*.txt
files. If they exists.

Adding test/simpleTestForGenerator/BSD-3-Clause.edl-v10.txt as an example.

This include enhancement to `test-one-license` only. Needs to be followed by enhancement of `LicenseRDFAGenerator` in `licenselistpublisher`.

The output of `test-one-license` looks like:
```
$ ./test-one-license BSD-3-Clause
Testing test/simpleTestForGenerator/BSD-3-Clause.txt
WARNING: sun.reflect.Reflection.getCallerClass is not supported. This will impact performance.
License BSD 3-Clause "New" or "Revised" License passed
Testing test/simpleTestForGenerator/BSD-3-Clause.edl-v10.txt
WARNING: sun.reflect.Reflection.getCallerClass is not supported. This will impact performance.
License BSD 3-Clause "New" or "Revised" License passed
```