### PR TITLE
Update license list publisher to version 3.0.0

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
       - uses: actions/checkout@v4
       - name: Fetch changes for git diff
         id: fetchdiff

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -24,9 +24,10 @@ jobs:
     name: Validate canonical match
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
-          java-version: '11'
+          distribution: 'temurin'
+          java-version: '17'
       - uses: actions/checkout@v4
       - name: Fetch changes for git diff
         id: fetchdiff

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: CC0-1.0
 
-TOOL_VERSION = 2.2.10
+TOOL_VERSION = 3.0.0
 TEST_DATA = test/simpleTestForGenerator
 GIT_AUTHOR = License Publisher (maintained by Gary O'Neall) <gary@sourceauditor.com>
 GIT_AUTHOR_EMAIL = gary@sourceauditor.com


### PR DESCRIPTION
This version of the publisher generates SPDX spec version 3.0 compliant licenses.

See https://github.com/spdx/LicenseListPublisher/issues/183 for a detailed description of the changes for the SPDX 3 license list support.