### PR TITLE
Change Elastic-2.0 license to plain text format

### DIFF
--- a/src/Elastic-2.0.xml
+++ b/src/Elastic-2.0.xml
@@ -11,16 +11,16 @@
         <p>Elastic License 2.0</p>
       </titleText>
       <optional><p>URL: https://www.elastic.co/licensing/elastic-license</p></optional>
-      <p>## Acceptance</p>
+      <p>Acceptance</p>
       <p>By using the software, you agree to all of the terms and conditions below.</p>
-      <p>## Copyright License</p>
+      <p>Copyright License</p>
       <p>
         The licensor grants you a non-exclusive, royalty-free, worldwide,
         non-sublicensable, non-transferable license to use, copy, distribute, make
         available, and prepare derivative works of the software, in each case subject to
         the limitations and conditions below.
       </p>
-      <p>## Limitations</p>
+      <p>Limitations</p>
       <p>
         You may not provide the software to third parties as a hosted or managed
         service, where the service provides users with access to any substantial set of
@@ -36,7 +36,7 @@
         of the licensor in the software. Any use of the licensor’s trademarks is subject
         to applicable law.
       </p>
-      <p>## Patents</p>
+      <p>Patents</p>
       <p>
         The licensor grants you a license, under any patent claims the licensor can
         license, or becomes able to license, to make, have made, use, sell, offer for
@@ -49,7 +49,7 @@
         such a claim, your patent license ends immediately for work on behalf of your
         company.
       </p>
-      <p>## Notices</p>
+      <p>Notices</p>
       <p>
         You must ensure that anyone who gets a copy of any part of the software from you
         also gets a copy of these terms.
@@ -58,12 +58,12 @@
         If you modify the software, you must include in any modified copies of the
         software prominent notices stating that you have modified the software.
       </p>
-      <p>## No Other Rights</p>
+      <p>No Other Rights</p>
       <p>
         These terms do not imply any licenses other than those expressly granted in
         these terms.
       </p>
-      <p>## Termination</p>
+      <p>Termination</p>
       <p>
         If you use the software in violation of these terms, such use is not licensed,
         and your licenses will automatically terminate. If the licensor provides you
@@ -73,34 +73,34 @@
         reinstatement, any additional violation of these terms will cause your licenses
         to terminate automatically and permanently.
       </p>
-      <p>## No Liability</p>
+      <p>No Liability</p>
       <p>
-        *As far as the law allows, the software comes as is, without any warranty or
+        As far as the law allows, the software comes as is, without any warranty or
         condition, and the licensor will not be liable to you for any damages arising
         out of these terms or the use or nature of the software, under any kind of
-        legal claim.*
+        legal claim.
       </p>
-      <p>## Definitions</p>
+      <p>Definitions</p>
       <p>
-        The **licensor** is the entity offering these terms, and the **software** is the
+        The licensor is the entity offering these terms, and the software is the
         software the licensor makes available under these terms, including any portion
         of it.
       </p>
-      <p>**you** refers to the individual or entity agreeing to these terms.</p>
+      <p>you refers to the individual or entity agreeing to these terms.</p>
       <p>
-        **your company** is any legal entity, sole proprietorship, or other kind of
+        your company is any legal entity, sole proprietorship, or other kind of
         organization that you work for, plus all organizations that have control over,
         are under the control of, or are under common control with that
-        organization. **control** means ownership of substantially all the assets of an
+        organization. control means ownership of substantially all the assets of an
         entity, or the power to direct its management and policies by vote, contract, or
         otherwise. Control can be direct or indirect.
       </p>
       <p>
-        **your licenses** are all the licenses granted to you for the software under
+        your licenses are all the licenses granted to you for the software under
         these terms.
       </p>
-      <p>**use** means anything you do with the software requiring one of your licenses.</p>
-      <p>**trademark** means trademarks, service marks, and similar rights.</p>
+      <p>use means anything you do with the software requiring one of your licenses.</p>
+      <p>trademark means trademarks, service marks, and similar rights.</p>
     </text>
   </license>
 </SPDXLicenseCollection>


### PR DESCRIPTION
Seems current Elastic-2.0 license in the markdown format, we should convert it into plain text format, because others licenses are in the plain text format