### PR TITLE
Update LicenseListPublisher to version 3.0.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: CC0-1.0
 
-TOOL_VERSION = 3.0.0
+TOOL_VERSION = 3.0.1
 TEST_DATA = test/simpleTestForGenerator
+FULL_TEST_DATA = test/fullTestForGenerator
 GIT_AUTHOR = License Publisher (maintained by Gary O'Neall) <gary@sourceauditor.com>
 GIT_AUTHOR_EMAIL = gary@sourceauditor.com
 LICENSE_DATA_REPO_NO_SCHEME = github.com/spdx/license-list-data.git
@@ -24,18 +25,18 @@ STATIC_FILES = equivalentwords.txt
 STATIC_FILES_DEST = $(LICENSE_OUTPUT_DIR)/website/
 
 .PHONY: validate-canonical-match
-validate-canonical-match: licenseListPublisher-$(TOOL_VERSION).jar-valid $(TEST_DATA) $(LICENSE_OUTPUT_DIR)
+validate-canonical-match: licenseListPublisher-$(TOOL_VERSION).jar-valid $(TEST_DATA) $(FULL_TEST_DATA) $(LICENSE_OUTPUT_DIR)
 	echo Validating source files from $(LICENSE_SOURCE)
-	java -jar -DLocalFsfFreeJson=true -DlistedLicenseSchema="schema/ListedLicense.xsd" licenseListPublisher-$(TOOL_VERSION).jar LicenseRDFAGenerator '$(LICENSE_SOURCE:;=)' '$(LICENSE_OUTPUT_DIR)' 1.0 2000-01-01 $(TEST_DATA) expected-warnings
+	java -jar -DLocalFsfFreeJson=true -DlistedLicenseSchema="schema/ListedLicense.xsd" licenseListPublisher-$(TOOL_VERSION).jar LicenseRDFAGenerator '$(LICENSE_SOURCE:;=)' '$(LICENSE_OUTPUT_DIR)' 1.0 2000-01-01 $(TEST_DATA) expected-warnings $(FULL_TEST_DATA)
 
 .PHONY: deploy-license-data
-deploy-license-data: licenseListPublisher-$(TOOL_VERSION).jar-valid $(TEST_DATA)
+deploy-license-data: licenseListPublisher-$(TOOL_VERSION).jar-valid $(TEST_DATA) $(FULL_TEST_DATA)
 	rm -rf '$(LICENSE_OUTPUT_DIR)'
 	git clone --quiet --depth 1 $(LICENSE_DATA_URL) '$(LICENSE_OUTPUT_DIR)'
 	# Clean out the old data directories
 	find '$(LICENSE_OUTPUT_DIR)' -mindepth 1 -maxdepth 1 -name .git -prune -o -name .github -prune -o -type d -exec rm -rf {} \+
 	rm -f $(LICENSE_OUTPUT_DIR)/licenses.md
-	java -jar -DLocalFsfFreeJson=true -DlistedLicenseSchema="schema/ListedLicense.xsd" licenseListPublisher-$(TOOL_VERSION).jar LicenseRDFAGenerator '$(LICENSE_SOURCE_DIR)' '$(LICENSE_OUTPUT_DIR)' $(VERSION) $(RELEASE_DATE) $(TEST_DATA) expected-warnings
+	java -jar -DLocalFsfFreeJson=true -DlistedLicenseSchema="schema/ListedLicense.xsd" licenseListPublisher-$(TOOL_VERSION).jar LicenseRDFAGenerator '$(LICENSE_SOURCE_DIR)' '$(LICENSE_OUTPUT_DIR)' $(VERSION) $(RELEASE_DATE) $(TEST_DATA) expected-warnings $(FULL_TEST_DATA)
 	$(foreach f, $(STATIC_FILES), cp ${f} $(STATIC_FILES_DEST);)
 	git -C '$(LICENSE_OUTPUT_DIR)' add -A .
 	git config user.email "$(GIT_AUTHOR_EMAIL)"

--- a/test-one-license
+++ b/test-one-license
@@ -6,4 +6,4 @@ PUBLISHER=licenseListPublisher-${TOOL_VERSION}.jar
 # if license list publisher is not present, download it
 test ! -f ${PUBLISHER}  && make ${PUBLISHER}-valid
 
-java -jar ${PUBLISHER} TestLicenseXML "src/${@}.xml" "test/simpleTestForGenerator/${@}.txt"
+java -jar ${PUBLISHER} TestLicenseXML "src/${@}.xml" "test/simpleTestForGenerator/${@}.txt" "test/fullTestForGenerator"

--- a/test/fullTestForGenerator/BSD-3-Clause/license/bad/must-not-reproduce.txt
+++ b/test/fullTestForGenerator/BSD-3-Clause/license/bad/must-not-reproduce.txt
@@ -1,0 +1,11 @@
+Copyright (c) <year> <owner>. 
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must not reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/test/fullTestForGenerator/BSD-3-Clause/license/good/changed-copyright.txt
+++ b/test/fullTestForGenerator/BSD-3-Clause/license/good/changed-copyright.txt
@@ -1,0 +1,11 @@
+Copyright (c) 2024 Source Auditor Inc. 
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/test/fullTestForGenerator/BSD-3-Clause/license/good/original.txt
+++ b/test/fullTestForGenerator/BSD-3-Clause/license/good/original.txt
@@ -1,0 +1,11 @@
+Copyright (c) <year> <owner>. 
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
In addition to the [changes in version 3.0.0](https://github.com/spdx/license-list-XML/pull/2636#issue-2745950964), this release fixes the test-single-license mentioned in [this comment](https://github.com/spdx/license-list-XML/pull/2636#issuecomment-2553185321).

This release also add support for full testing of license texts.  The full testing is now done in the CI when there is a pull request or merge to main.  The script test-single-license has also been updated to do full testing for the single license being tested.

To add a positive test for text that should match, add text of the file under `test/fullTestForGenerator/{license-or-exceptionId}/good/{test-id}.txt`

To add a negative test for text that should not match, add text of the file under `test/fullTestForGenerator/{license-or-exceptionId}/bad/{test-id}.txt`