### PR TITLE
AFL-2.1: Add optional appendix

### DIFF
--- a/src/AFL-2.1.xml
+++ b/src/AFL-2.1.xml
@@ -9,7 +9,7 @@
     <text>
       <titleText>
          <p>The Academic Free License
-        <br/>v.2.1
+        <br/>v.<alt match=" ?" name="extraSpace"> </alt>2.1
       </p>
       </titleText>
       <optional>
@@ -191,6 +191,53 @@
         <br/>Permission is hereby granted to copy and distribute this license without modification. This license
              may not be modified without the express written permission of its copyright owner.
       </p>
+      <optional>
+        <optional><p>--</p></optional>
+        <p>
+          END OF ACADEMIC FREE LICENSE. The following is intended to describe the essential
+          differences between the Academic Free License (AFL) version 1.0 and other
+          open source licenses:
+        </p>
+        <p>
+          The Academic Free License is similar to the BSD, MIT, UoI/NCSA and Apache
+          licenses in many respects but it is intended to solve a few problems with
+          those licenses.
+        </p>
+        <list>
+          <item>
+            <bullet>*</bullet> The AFL is written so as to make it clear what software is being
+            licensed (by the inclusion of a statement following the copyright notice
+            in the software). This way, the license functions better than a template
+            license. The BSD, MIT and UoI/NCSA licenses apply to unidentified software.
+          </item>
+          <item>
+            <bullet>*</bullet> The AFL contains a complete copyright grant to the software. The BSD
+            and Apache licenses are vague and incomplete in that respect.
+          </item>
+          <item>
+            <bullet>*</bullet> The AFL contains a complete patent grant to the software. The BSD, MIT,
+            UoI/NCSA and Apache licenses rely on an implied patent license and contain
+            no explicit patent grant.
+          </item>
+          <item>
+            <bullet>*</bullet> The AFL makes it clear that no trademark rights are granted to the
+            licensor's trademarks. The Apache license contains such a provision, but the
+            BSD, MIT and UoI/NCSA licenses do not.
+          </item>
+          <item>
+            <bullet>*</bullet> The AFL includes the warranty by the licensor that it either owns the
+            copyright or that it is distributing the software under a license. None of
+            the other licenses contain that warranty. All other warranties are disclaimed,
+            as is the case for the other licenses.
+          </item>
+          <item>
+            <bullet>*</bullet> The AFL is itself copyrighted (with the right granted to copy and distribute
+            without modification). This ensures that the owner of the copyright to the
+            license will control changes. The Apache license contains a copyright notice,
+            but the BSD, MIT and UoI/NCSA licenses do not.
+          </item>
+        </list>
+      </optional>
     </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/AFL-2.1.xml
+++ b/src/AFL-2.1.xml
@@ -3,6 +3,8 @@
    <license isOsiApproved="true" licenseId="AFL-2.1" name="Academic Free License v2.1">
       <crossRefs>
          <crossRef>http://opensource.linux-mirror.org/licenses/afl-2.1.txt</crossRef>
+         <crossRef>https://web.archive.org/web/20061013013632/http://opensource.linux-mirror.org/licenses/afl-2.1.txt</crossRef>
+         <crossRef>https://gitlab.freedesktop.org/dbus/dbus/-/blob/789d97ad53044f94351a958e785c2923643b346a/COPYING#L11-207</crossRef>
       </crossRefs>
     <text>
       <titleText>

--- a/src/AFL-2.1.xml
+++ b/src/AFL-2.1.xml
@@ -191,8 +191,8 @@
         <br/>Permission is hereby granted to copy and distribute this license without modification. This license
              may not be modified without the express written permission of its copyright owner.
       </p>
+      <optional><p>--</p></optional>
       <optional>
-        <optional><p>--</p></optional>
         <p>
           END OF ACADEMIC FREE LICENSE. The following is intended to describe the essential
           differences between the Academic Free License (AFL) version 1.0 and other

--- a/test/simpleTestForGenerator/AFL-2.1.txt
+++ b/test/simpleTestForGenerator/AFL-2.1.txt
@@ -123,7 +123,7 @@ conflict-of-law provisions. The application of the United Nations
 Convention on Contracts for the International Sale of Goods is
 expressly excluded. Any use of the Original Work outside the scope of
 this License or after its termination shall be subject to the
-requirements and penalties of the U.S. Copyright Act, 17 U.S.C. Â§ 101
+requirements and penalties of the U.S. Copyright Act, 17 U.S.C. § 101
 et seq., the equivalent laws of other countries, and international
 treaty. This section shall survive the termination of this License.
 

--- a/test/simpleTestForGenerator/AFL-2.1.txt
+++ b/test/simpleTestForGenerator/AFL-2.1.txt
@@ -1,45 +1,197 @@
 The Academic Free License
-v.2.1
+v. 2.1
 
 This Academic Free License (the "License") applies to any original work of authorship (the "Original Work") whose owner (the "Licensor") has placed the following notice immediately following the copyright notice for the Original Work:
 
-     Licensed under the Academic Free License version 2.1
+Licensed under the Academic Free License version 2.1
 
-1) Grant of Copyright License. Licensor hereby grants You a world-wide, royalty-free, non-exclusive, perpetual, sublicenseable license to do the following:
+1) Grant of Copyright License. Licensor hereby grants You a
+world-wide, royalty-free, non-exclusive, perpetual, sublicenseable
+license to do the following:
 
-     a) to reproduce the Original Work in copies;
-     b) to prepare derivative works ("Derivative Works") based upon the Original Work;
-     c) to distribute copies of the Original Work and Derivative Works to the public;
-     d) to perform the Original Work publicly; and
-     e) to display the Original Work publicly.
+a) to reproduce the Original Work in copies;
 
-2) Grant of Patent License. Licensor hereby grants You a world-wide, royalty-free, non-exclusive, perpetual, sublicenseable license, under patent claims owned or controlled by the Licensor that are embodied in the Original Work as furnished by the Licensor, to make, use, sell and offer for sale the Original Work and Derivative Works.
+b) to prepare derivative works ("Derivative Works") based upon the Original Work;
 
-3) Grant of Source Code License. The term "Source Code" means the preferred form of the Original Work for making modifications to it and all available documentation describing how to modify the Original Work. Licensor hereby agrees to provide a machine-readable copy of the Source Code of the Original Work along with each copy of the Original Work that Licensor distributes. Licensor reserves the right to satisfy this obligation by placing a machine-readable copy of the Source Code in an information repository reasonably calculated to permit inexpensive and convenient access by You for as long as Licensor continues to distribute the Original Work, and by publishing the address of that information repository in a notice immediately following the copyright notice that applies to the Original Work.
+c) to distribute copies of the Original Work and Derivative Works to the public;
 
-4) Exclusions From License Grant. Neither the names of Licensor, nor the names of any contributors to the Original Work, nor any of their trademarks or service marks, may be used to endorse or promote products derived from this Original Work without express prior written permission of the Licensor. Nothing in this License shall be deemed to grant any rights to trademarks, copyrights, patents, trade secrets or any other intellectual property of Licensor except as expressly stated herein. No patent license is granted to make, use, sell or offer to sell embodiments of any patent claims other than the licensed claims defined in Section 2. No right is granted to the trademarks of Licensor even if such marks are included in the Original Work. Nothing in this License shall be interpreted to prohibit Licensor from licensing under different terms from this License any Original Work that Licensor otherwise would have a right to license.
+d) to perform the Original Work publicly; and
+
+e) to display the Original Work publicly.
+
+2) Grant of Patent License. Licensor hereby grants You a world-wide,
+royalty-free, non-exclusive, perpetual, sublicenseable license, under
+patent claims owned or controlled by the Licensor that are embodied in
+the Original Work as furnished by the Licensor, to make, use, sell and
+offer for sale the Original Work and Derivative Works.
+
+3) Grant of Source Code License. The term "Source Code" means the
+preferred form of the Original Work for making modifications to it and
+all available documentation describing how to modify the Original
+Work. Licensor hereby agrees to provide a machine-readable copy of the
+Source Code of the Original Work along with each copy of the Original
+Work that Licensor distributes. Licensor reserves the right to satisfy
+this obligation by placing a machine-readable copy of the Source Code
+in an information repository reasonably calculated to permit
+inexpensive and convenient access by You for as long as Licensor
+continues to distribute the Original Work, and by publishing the
+address of that information repository in a notice immediately
+following the copyright notice that applies to the Original Work.
+
+4) Exclusions From License Grant. Neither the names of Licensor, nor
+the names of any contributors to the Original Work, nor any of their
+trademarks or service marks, may be used to endorse or promote
+products derived from this Original Work without express prior written
+permission of the Licensor. Nothing in this License shall be deemed to
+grant any rights to trademarks, copyrights, patents, trade secrets or
+any other intellectual property of Licensor except as expressly stated
+herein. No patent license is granted to make, use, sell or offer to
+sell embodiments of any patent claims other than the licensed claims
+defined in Section 2. No right is granted to the trademarks of
+Licensor even if such marks are included in the Original Work. Nothing
+in this License shall be interpreted to prohibit Licensor from
+licensing under different terms from this License any Original Work
+that Licensor otherwise would have a right to license.
 
 5) This section intentionally omitted.
 
-6) Attribution Rights. You must retain, in the Source Code of any Derivative Works that You create, all copyright, patent or trademark notices from the Source Code of the Original Work, as well as any notices of licensing and any descriptive text identified therein as an "Attribution Notice." You must cause the Source Code for any Derivative Works that You create to carry a prominent Attribution Notice reasonably calculated to inform recipients that You have modified the Original Work.
+6) Attribution Rights. You must retain, in the Source Code of any
+Derivative Works that You create, all copyright, patent or trademark
+notices from the Source Code of the Original Work, as well as any
+notices of licensing and any descriptive text identified therein as an
+"Attribution Notice." You must cause the Source Code for any
+Derivative Works that You create to carry a prominent Attribution
+Notice reasonably calculated to inform recipients that You have
+modified the Original Work.
 
-7) Warranty of Provenance and Disclaimer of Warranty. Licensor warrants that the copyright in and to the Original Work and the patent rights granted herein by Licensor are owned by the Licensor or are sublicensed to You under the terms of this License with the permission of the contributor(s) of those copyrights and patent rights. Except as expressly stated in the immediately proceeding sentence, the Original Work is provided under this License on an "AS IS" BASIS and WITHOUT WARRANTY, either express or implied, including, without limitation, the warranties of NON-INFRINGEMENT, MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY OF THE ORIGINAL WORK IS WITH YOU. This DISCLAIMER OF WARRANTY constitutes an essential part of this License. No license to Original Work is granted hereunder except under this disclaimer.
+7) Warranty of Provenance and Disclaimer of Warranty. Licensor
+warrants that the copyright in and to the Original Work and the patent
+rights granted herein by Licensor are owned by the Licensor or are
+sublicensed to You under the terms of this License with the permission
+of the contributor(s) of those copyrights and patent rights. Except as
+expressly stated in the immediately proceeding sentence, the Original
+Work is provided under this License on an "AS IS" BASIS and WITHOUT
+WARRANTY, either express or implied, including, without limitation,
+the warranties of NON-INFRINGEMENT, MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY OF THE ORIGINAL
+WORK IS WITH YOU. This DISCLAIMER OF WARRANTY constitutes an essential
+part of this License. No license to Original Work is granted hereunder
+except under this disclaimer.
 
-8) Limitation of Liability. Under no circumstances and under no legal theory, whether in tort (including negligence), contract, or otherwise, shall the Licensor be liable to any person for any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or the use of the Original Work including, without limitation, damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses. This limitation of liability shall not apply to liability for death or personal injury resulting from Licensor's negligence to the extent applicable law prohibits such limitation. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so this exclusion and limitation may not apply to You.
+8) Limitation of Liability. Under no circumstances and under no legal
+theory, whether in tort (including negligence), contract, or
+otherwise, shall the Licensor be liable to any person for any direct,
+indirect, special, incidental, or consequential damages of any
+character arising as a result of this License or the use of the
+Original Work including, without limitation, damages for loss of
+goodwill, work stoppage, computer failure or malfunction, or any and
+all other commercial damages or losses. This limitation of liability
+shall not apply to liability for death or personal injury resulting
+from Licensor's negligence to the extent applicable law prohibits such
+limitation. Some jurisdictions do not allow the exclusion or
+limitation of incidental or consequential damages, so this exclusion
+and limitation may not apply to You.
 
- 9) Acceptance and Termination. If You distribute copies of the Original Work or a Derivative Work, You must make a reasonable effort under the circumstances to obtain the express assent of recipients to the terms of this License. Nothing else but this License (or another written agreement between Licensor and You) grants You permission to create Derivative Works based upon the Original Work or to exercise any of the rights granted in Section 1 herein, and any attempt to do so except under the terms of this License (or another written agreement between Licensor and You) is expressly prohibited by U.S. copyright law, the equivalent laws of other countries, and by international treaty. Therefore, by exercising any of the rights granted to You in Section 1 herein, You indicate Your acceptance of this License and all of its terms and conditions.
+9) Acceptance and Termination. If You distribute copies of the
+Original Work or a Derivative Work, You must make a reasonable effort
+under the circumstances to obtain the express assent of recipients to
+the terms of this License. Nothing else but this License (or another
+written agreement between Licensor and You) grants You permission to
+create Derivative Works based upon the Original Work or to exercise
+any of the rights granted in Section 1 herein, and any attempt to do
+so except under the terms of this License (or another written
+agreement between Licensor and You) is expressly prohibited by
+U.S. copyright law, the equivalent laws of other countries, and by
+international treaty. Therefore, by exercising any of the rights
+granted to You in Section 1 herein, You indicate Your acceptance of
+this License and all of its terms and conditions.
 
-10) Termination for Patent Action. This License shall terminate automatically and You may no longer exercise any of the rights granted to You by this License as of the date You commence an action, including a cross-claim or counterclaim, against Licensor or any licensee alleging that the Original Work infringes a patent. This termination provision shall not apply for an action alleging patent infringement by combinations of the Original Work with other software or hardware.
+10) Termination for Patent Action. This License shall terminate
+automatically and You may no longer exercise any of the rights granted
+to You by this License as of the date You commence an action,
+including a cross-claim or counterclaim, against Licensor or any
+licensee alleging that the Original Work infringes a patent. This
+termination provision shall not apply for an action alleging patent
+infringement by combinations of the Original Work with other software
+or hardware.
 
-11) Jurisdiction, Venue and Governing Law. Any action or suit relating to this License may be brought only in the courts of a jurisdiction wherein the Licensor resides or in which Licensor conducts its primary business, and under the laws of that jurisdiction excluding its conflict-of-law provisions. The application of the United Nations Convention on Contracts for the International Sale of Goods is expressly excluded. Any use of the Original Work outside the scope of this License or after its termination shall be subject to the requirements and penalties of the U.S. Copyright Act, 17 U.S.C. § 101 et seq., the equivalent laws of other countries, and international treaty. This section shall survive the termination of this License.
+11) Jurisdiction, Venue and Governing Law. Any action or suit relating
+to this License may be brought only in the courts of a jurisdiction
+wherein the Licensor resides or in which Licensor conducts its primary
+business, and under the laws of that jurisdiction excluding its
+conflict-of-law provisions. The application of the United Nations
+Convention on Contracts for the International Sale of Goods is
+expressly excluded. Any use of the Original Work outside the scope of
+this License or after its termination shall be subject to the
+requirements and penalties of the U.S. Copyright Act, 17 U.S.C. Â§ 101
+et seq., the equivalent laws of other countries, and international
+treaty. This section shall survive the termination of this License.
 
-12) Attorneys Fees. In any action to enforce the terms of this License or seeking damages relating thereto, the prevailing party shall be entitled to recover its costs and expenses, including, without limitation, reasonable attorneys' fees and costs incurred in connection with such action, including any appeal of such action. This section shall survive the termination of this License.
+12) Attorneys Fees. In any action to enforce the terms of this License
+or seeking damages relating thereto, the prevailing party shall be
+entitled to recover its costs and expenses, including, without
+limitation, reasonable attorneys' fees and costs incurred in
+connection with such action, including any appeal of such action. This
+section shall survive the termination of this License.
 
-13) Miscellaneous. This License represents the complete agreement concerning the subject matter hereof. If any provision of this License is held to be unenforceable, such provision shall be reformed only to the extent necessary to make it enforceable.
+13) Miscellaneous. This License represents the complete agreement
+concerning the subject matter hereof. If any provision of this License
+is held to be unenforceable, such provision shall be reformed only to
+the extent necessary to make it enforceable.
 
-14) Definition of "You" in This License. "You" throughout this License, whether in upper or lower case, means an individual or a legal entity exercising rights under, and complying with all of the terms of, this License. For legal entities, "You" includes any entity that controls, is controlled by, or is under common control with you. For purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+14) Definition of "You" in This License. "You" throughout this
+License, whether in upper or lower case, means an individual or a
+legal entity exercising rights under, and complying with all of the
+terms of, this License. For legal entities, "You" includes any entity
+that controls, is controlled by, or is under common control with
+you. For purposes of this definition, "control" means (i) the power,
+direct or indirect, to cause the direction or management of such
+entity, whether by contract or otherwise, or (ii) ownership of fifty
+percent (50%) or more of the outstanding shares, or (iii) beneficial
+ownership of such entity.
 
-15) Right to Use. You may use the Original Work in all ways not otherwise restricted or conditioned by this License or by law, and Licensor promises not to interfere with or be responsible for such uses by You.
+15) Right to Use. You may use the Original Work in all ways not
+otherwise restricted or conditioned by this License or by law, and
+Licensor promises not to interfere with or be responsible for such
+uses by You.
 
-This license is Copyright (C) 2003-2004 Lawrence E. Rosen. All rights reserved.
-Permission is hereby granted to copy and distribute this license without modification. This license may not be modified without the express written permission of its copyright owner.
+This license is Copyright (C) 2003-2004 Lawrence E. Rosen. All rights
+reserved. Permission is hereby granted to copy and distribute this
+license without modification. This license may not be modified without
+the express written permission of its copyright owner.
+
+
+--
+END OF ACADEMIC FREE LICENSE. The following is intended to describe the essential
+differences between the Academic Free License (AFL) version 1.0 and other
+open source licenses:
+
+The Academic Free License is similar to the BSD, MIT, UoI/NCSA and Apache
+licenses in many respects but it is intended to solve a few problems with
+those licenses.
+
+* The AFL is written so as to make it clear what software is being
+licensed (by the inclusion of a statement following the copyright notice
+in the software). This way, the license functions better than a template
+license. The BSD, MIT and UoI/NCSA licenses apply to unidentified software.
+
+* The AFL contains a complete copyright grant to the software. The BSD
+and Apache licenses are vague and incomplete in that respect.
+
+* The AFL contains a complete patent grant to the software. The BSD, MIT,
+UoI/NCSA and Apache licenses rely on an implied patent license and contain
+no explicit patent grant.
+
+* The AFL makes it clear that no trademark rights are granted to the
+licensor's trademarks. The Apache license contains such a provision, but the
+BSD, MIT and UoI/NCSA licenses do not.
+
+* The AFL includes the warranty by the licensor that it either owns the
+copyright or that it is distributing the software under a license. None of
+the other licenses contain that warranty. All other warranties are disclaimed,
+as is the case for the other licenses.
+
+* The AFL is itself copyrighted (with the right granted to copy and distribute
+without modification). This ensures that the owner of the copyright to the
+license will control changes. The Apache license contains a copyright notice,
+but the BSD, MIT and UoI/NCSA licenses do not.


### PR DESCRIPTION
[dbus](https://gitlab.freedesktop.org/dbus/dbus) is probably one of the most prolific projects licensed under AFL-2.1 and [their original AFL 2.1 license text](https://gitlab.freedesktop.org/dbus/dbus/-/blob/789d97ad53044f94351a958e785c2923643b346a/COPYING#L11-207) had an appendix (similar to the last part of GPL licenses) which ironically was lost when they made their repository REUSE-compliant and used REUSE's tooling to replace the license with the license text downloaded from this very repository!

I replaced the test license text with the license text from dbus, since it appears to be the most complete reproduction of the original AFL 2.1 license text. Apologies in advance to any maintainers for the change in text wrapping.

Additionally, both the dbus license text and the text in https://web.archive.org/web/20061013013632/http://opensource.linux-mirror.org/licenses/afl-2.1.txt has a space between the "v." and the "2.1". But because the license text from this repo has already proliferated, we can't correct the mistake outright and have to accept both a space and no space.