### PR TITLE
Match official Apache-1.1 text

### DIFF
--- a/src/Apache-1.1.xml
+++ b/src/Apache-1.1.xml
@@ -45,7 +45,7 @@
       </item>
          <item>
             <bullet>5.</bullet>
-        <alt match="(Products derived from this software may not be called\s.+nor may\s.+appear in their name, without prior written permission of\s.+.|Products may not include\s.+in their name, without prior written permission of\s.+.)" name="Clause5">Products derived from this software may not be called "Apache" 
+        <alt match="(Products\s+derived\s+from\s+this\s+software\s+may\s+not\s+be\s+called\s+.+nor may\s+.+appear\s+in\s+their\s+name,\s+without\s+prior\s+written\s+permission\s+of\s+.+.|Products\s+may\s+not\s+include\s+.+in\s+their\s+name,\s+without\s+prior\s+written\s+permission\s+of.+)" name="Clause5">Products derived from this software may not be called "Apache" 
 		nor may "Apache" [ex. the names] appear in their name, 
 		without prior written permission of the Apache Software Foundation.</alt>
       </item>


### PR DESCRIPTION
The official Apache 1.1 license text on the website has line breaks in different words.

This PR allows for line breaks on the matching regex for the alt text.

Reference https://github.com/spdx/Spdx-Java-Library/issues/230