### PR TITLE
add more license urls

### DIFF
--- a/src/EPL-2.0.xml
+++ b/src/EPL-2.0.xml
@@ -5,6 +5,8 @@
 		<crossRefs>
 			<crossRef>https://www.eclipse.org/legal/epl-2.0</crossRef>
 			<crossRef>https://www.opensource.org/licenses/EPL-2.0</crossRef>
+			<crossRef>https://www.eclipse.org/legal/epl-v20.html</crossRef>
+			<crossRef>https://projects.eclipse.org/license/epl-2.0</crossRef>
 		</crossRefs>
     <notes>
       <p>Secondary Licenses declared via Exhibit A should be represented using the disjunctive OR operator (See: SPDX spec, section on SPDX License Expressions and https://www.eclipse.org/legal/epl-2.0/faq.php for more info).</p>

--- a/src/MIT.xml
+++ b/src/MIT.xml
@@ -3,6 +3,7 @@
    <license isOsiApproved="true" licenseId="MIT" name="MIT License">
       <crossRefs>
          <crossRef>https://opensource.org/license/mit/</crossRef>
+         <crossRef>http://opensource.org/licenses/MIT</crossRef>
       </crossRefs>
     <text>
       <titleText>


### PR DESCRIPTION
Here are some more URL mappings, please add them to your lists.

`https://www.eclipse.org/legal/epl-v20.html` used by `org.junit.jupiter:junit-jupiter-api:5.12.0`
`https://projects.eclipse.org/license/epl-2.0` used by `jakarta.json:jakarta.json-api:2.1.3`
`http://opensource.org/licenses/MIT` used by `org.checkerframework:checker-qual:3.49.1`
