### PR TITLE
Add new cross-reference to Apache-2.0.xml

### DIFF
--- a/src/Apache-2.0.xml
+++ b/src/Apache-2.0.xml
@@ -4,6 +4,7 @@
       <crossRefs>
          <crossRef>https://www.apache.org/licenses/LICENSE-2.0</crossRef>
          <crossRef>https://opensource.org/licenses/Apache-2.0</crossRef>
+         <crossRef>https://opensource.org/license/apache-2-0</crossRef>
       </crossRefs>
       <notes>This license was released January 2004</notes>
     <text>


### PR DESCRIPTION
Add a new cross-reference to the Apache-2.0 license XML file.

* Add `<crossRef>https://opensource.org/license/apache-2-0</crossRef>` under the `<crossRefs>` section in `src/Apache-2.0.xml`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/spdx/license-list-XML/pull/2695?shareId=8879add6-6cc2-446f-bb71-20f182b6b925).