### PR TITLE
Add CryptoSwift

### DIFF
--- a/src/CryptoSwift.xml
+++ b/src/CryptoSwift.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SPDXLicenseCollection xmlns="http://www.spdx.org/license">
+   <license isOsiApproved="false" licenseId="CryptoSwift"
+   name="CryptoSwift License" listVersionAdded="3.27.0">
+      <crossRefs>
+         <crossRef>https://github.com/krzyzanowskim/CryptoSwift/blob/main/LICENSE</crossRef>
+      </crossRefs>
+      <notes>
+        This license is similar to Cube and zlib, but adds an acknowledgment requirement.
+      </notes>
+      <text>
+	<copyrightText>Copyright (C) 2014-3099 Marcin Krzyżanowski</copyrightText>
+
+	<p>This software is provided 'as-is', without any express or implied warranty.</p>
+
+	<p>In no event will the authors be held liable for any damages arising from the use of this software.</p>
+
+	<p>Permission is granted to anyone to use this software for any purpose,including commercial applications, and to alter it and redistribute it freely, subject to the following restrictions:</p>
+
+	<list>
+		<item><bullet>-</bullet> The origin of this software must not be misrepresented; you must not claim that you wrote the original software. If you use this software in a product, an acknowledgment in the product documentation is required.</item>
+		<item><bullet>-</bullet> Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.</item>
+		<item><bullet>-</bullet> This notice may not be removed or altered from any source or binary distribution.</item>
+		<item><bullet>-</bullet> Redistributions of any form whatsoever must retain the following acknowledgment: 'This product includes software developed by the "Marcin Krzyzanowski" (http://krzyzanowskim.com/).'</item>
+	</list>
+      </text>
+   </license>
+</SPDXLicenseCollection>
+

--- a/test/simpleTestForGenerator/CryptoSwift.txt
+++ b/test/simpleTestForGenerator/CryptoSwift.txt
@@ -1,0 +1,11 @@
+Copyright (C) 2014-3099 Marcin Krzyżanowski
+This software is provided 'as-is', without any express or implied warranty.
+
+In no event will the authors be held liable for any damages arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,including commercial applications, and to alter it and redistribute it freely, subject to the following restrictions:
+
+- The origin of this software must not be misrepresented; you must not claim that you wrote the original software. If you use this software in a product, an acknowledgment in the product documentation is required.
+- Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
+- This notice may not be removed or altered from any source or binary distribution.
+- Redistributions of any form whatsoever must retain the following acknowledgment: 'This product includes software developed by the "Marcin Krzyzanowski" (http://krzyzanowskim.com/).'


### PR DESCRIPTION
Fixes #2610 

Note that I omitted the personal email address that was included in the original upstream license. Since it's in the `<copyrightText>` tag, it won't make a difference for matching purposes. But I felt like it made sense to leave out the personal email address here, since this one wasn't submitted by the license author / steward themselves.

Signed-off-by: Steve Winslow <steve@swinslow.net>