### PR TITLE
Add OpenWaqf License v1.0-beta (OWL-1.0-beta)

### DIFF
--- a/src/OWL-1.0-beta.xml
+++ b/src/OWL-1.0-beta.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SPDXLicenseCollection xmlns="http://spdx.org/license">
+  <license>
+    <licenseId>OWL-1.0-beta</licenseId>
+    <name>OpenWaqf License v1.0-beta</name>
+    <licenseText>
+      <![CDATA[
+      OpenWaqf License v1.0-beta (OWL-1.0-beta)
+
+      This is a Beta Version of the OpenWaqf License.
+      We are actively collecting feedback before finalizing version 1.0.
+      To share your thoughts, please email: legal@yufeed.org or join the conversation at https://github.com/yufeed/openwaqf-license/discussions.
+
+      This license incorporates principles of the GNU GPLv3 and Islamic waqf, allowing use, modification, and redistribution under ethical conditions and perpetual public endowment. All derivatives must retain this license to be considered part of the waqf.
+
+      Key features:
+      - Public waqf status (intellectual property as a charitable endowment)
+      - Copyleft inheritance (all derivatives must remain OWL-licensed to retain waqf status)
+      - Ethical use conditions (prohibited for riba, gambling, harmful activity)
+      - Optional DAO or waqf governance for community oversight
+      - Voluntary participation in the Yufeed Waqf Fund
+
+      This license is not compatible with permissive or proprietary licenses (e.g., MIT, BSD, Apache).
+      ]]>    
+    </licenseText>
+    <standardLicenseHeader>
+      <![CDATA[
+      Licensed under the OpenWaqf License v1.0-beta
+      See LICENSE.md for details.
+      ]]>
+    </standardLicenseHeader>
+    <seeAlso>https://github.com/yufeed/openwaqf-license</seeAlso>
+    <seeAlso>https://yufeed.org/fund</seeAlso>
+    <isOsiApproved>false</isOsiApproved>
+    <isFsfLibre>false</isFsfLibre>
+  </license>
+</SPDXLicenseCollection>


### PR DESCRIPTION
### 🆕 Add OpenWaqf License v1.0-beta (OWL-1.0-beta)

This PR proposes the inclusion of a new license in the SPDX License List:

- **License Name**: OpenWaqf License v1.0-beta (OWL-1.0-beta)
- **License ID**: OWL-1.0-beta
- **License File**: `src/OWL-1.0-beta.xml`
- **License URL**: https://github.com/yufeed/openwaqf-license
- **License Text**: https://github.com/yufeed/openwaqf-license/blob/main/LICENSE.md

### 🔍 Rationale

The OpenWaqf License is inspired by the GPLv3 and Islamic waqf principles. It introduces the concept of intellectual property as an **endowment (waqf)** dedicated to public good, while retaining open source freedoms (use, modify, share). The license enforces:

- **Copyleft** inheritance (derivatives must use the same license to retain waqf status)
- **Ethical use restrictions** (prohibiting riba, gambling, or harmful activity)
- **DAO/committee-based governance clause** (optional)
- **Encouraged participation** in the [Yufeed Waqf Fund](https://yufeed.org/fund) to support digital public goods

This license is intended to serve both Muslim and non-Muslim communities seeking ethical, non-proprietary licensing models grounded in social responsibility.

### ✍️ Author

**Created and maintained by**: [Yufeed](https://yufeed.org), a public-interest technology initiative supporting ethical and transparent digital waqf innovation.

### 📎 Supporting Resources

- Real-world usage: [github.com/yufeed/openwaqf-license](https://github.com/yufeed/openwaqf-license)
- SPDX XML: `OWL-1.0-beta.xml` (included)
- License text reviewed by multiple Islamic legal tech developers

---

Please let us know if additional documentation is needed for SPDX inclusion.
