### PR TITLE
GPL-2.0 licenses: "Lesser|Library"

### DIFF
--- a/src/GPL-2.0+.xml
+++ b/src/GPL-2.0+.xml
@@ -26,8 +26,9 @@
          contrast, the GNU General Public License is intended to guarantee your freedom to share and change
          free software--to make sure the software is free for all its users. This General Public License
          applies to most of the Free Software Foundation's software and to any other program whose authors
-         commit to using it. (Some other Free Software Foundation software is covered by the GNU Lesser General
-         Public License instead.) You can apply it to your programs, too.</p>
+         commit to using it. (Some other Free Software Foundation software is covered by the GNU
+         <alt match="Lesser|Library" name="lesserOrLibrary"/> General Public License instead.) You can apply it
+         to your programs, too.</p>
       <p>When we speak of free software, we are referring to freedom, not price. Our General Public Licenses are
          designed to make sure that you have the freedom to distribute copies of free software (and charge for
          this service if you wish), that you receive source code or can get it if you want it, that you can

--- a/src/GPL-2.0-only.xml
+++ b/src/GPL-2.0-only.xml
@@ -60,7 +60,8 @@
       make sure the software is free for all its users. This General Public
       License applies to most of the Free Software Foundation's software
       and to any other program whose authors commit to using it. (Some other
-      Free Software Foundation software is covered by the GNU Lesser General
+      Free Software Foundation software is covered by the GNU
+      <alt match="Lesser|Library" name="lesserOrLibrary"/> General
       Public License instead.) You can apply it to your programs, too.
     </p>
     <p>
@@ -468,8 +469,9 @@
         This General Public License does not permit incorporating your program into
         proprietary programs.  If your program is a subroutine library, you may
         consider it more useful to permit linking proprietary applications with the
-        library.  If this is what you want to do, use the GNU Lesser General
-        Public License instead of this License.
+        library.  If this is what you want to do, use the GNU
+        <alt match="Lesser|Library" name="lesserOrLibrary"/> General Public License
+        instead of this License.
       </p>
     </optional>
     </text>

--- a/src/GPL-2.0-or-later.xml
+++ b/src/GPL-2.0-or-later.xml
@@ -11,7 +11,7 @@
       choice to use code under GPL-2.0-or-later (i.e., GPL-2.0 or some later version),
       as distinguished from the use of code under GPL-2.0-only. The license notice (as seen
       in the Standard License Header field below) states which of these applies to
-      the code in the file. The example in the How to Apply These Terms appendix of the 
+      the code in the file. The example in the How to Apply These Terms appendix of the
       license shows the "or later" approach.
     </notes>
     <text>
@@ -40,7 +40,8 @@
       make sure the software is free for all its users. This General Public
       License applies to most of the Free Software Foundation's software
       and to any other program whose authors commit to using it. (Some other
-      Free Software Foundation software is covered by the GNU Lesser General
+      Free Software Foundation software is covered by the GNU
+      <alt match="Lesser|Library" name="lesserOrLibrary"/> General
       Public License instead.) You can apply it to your programs, too.
     </p>
     <p>
@@ -447,8 +448,9 @@
         This General Public License does not permit incorporating your program into
         proprietary programs.  If your program is a subroutine library, you may
         consider it more useful to permit linking proprietary applications with the
-        library.  If this is what you want to do, use the GNU Lesser General
-        Public License instead of this License.
+        library.  If this is what you want to do, use the GNU
+        <alt match="Lesser|Library" name="lesserOrLibrary"/> General Public License
+        instead of this License.
       </p>
     </optional>
     </text>

--- a/src/GPL-2.0.xml
+++ b/src/GPL-2.0.xml
@@ -57,7 +57,8 @@
       make sure the software is free for all its users. This General Public
       License applies to most of the Free Software Foundation's software
       and to any other program whose authors commit to using it. (Some other
-      Free Software Foundation software is covered by the GNU Lesser General
+      Free Software Foundation software is covered by the GNU
+      <alt match="Lesser|Library" name="lesserOrLibrary"/> General
       Public License instead.) You can apply it to your programs, too.
     </p>
     <p>
@@ -465,8 +466,9 @@
         This General Public License does not permit incorporating your program into
         proprietary programs.  If your program is a subroutine library, you may
         consider it more useful to permit linking proprietary applications with the
-        library.  If this is what you want to do, use the GNU Lesser General
-        Public License instead of this License.
+        library.  If this is what you want to do, use the GNU
+        <alt match="Lesser|Library" name="lesserOrLibrary"/> General Public License
+        instead of this License.
       </p>
     </optional>
     </text>


### PR DESCRIPTION
The LGPL license was originally called the "GNU LIbrary General Public License" and some license tests refer to the "original" term "Library" instead of "Lesser".

This change is to let license matchers yield a positive match for the usage of "Library" for the "GPL-2.0*" licenses. This change does not add an `<alt>` to every occurence of "Lesser" in all licenses. It's rather there to support a special case.

See also [JDK-8355388](https://bugs.openjdk.org/browse/JDK-8355388). 