### PR TITLE
libpng-1.6.35: fix missing paren in name

### DIFF
--- a/src/libpng-1.6.35.xml
+++ b/src/libpng-1.6.35.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isOsiApproved="false" licenseId="libpng-1.6.35" name="PNG Reference Library License v1 (for libpng 0.5 through 1.6.35" listVersionAdded="3.27.0">
+   <license isOsiApproved="false" licenseId="libpng-1.6.35" name="PNG Reference Library License v1 (for libpng 0.5 through 1.6.35)" listVersionAdded="3.27.0">
       <crossRefs>
          <crossRef>http://www.libpng.org/pub/png/src/libpng-LICENSE.txt</crossRef>
       </crossRefs>


### PR DESCRIPTION
Just fixing a missing right parenthesis in the license name field.

Signed-off-by: Steve Winslow <steve@swinslow.net>