### PR TITLE
Replace LLVM Exception link with Wayback archive

### DIFF
--- a/src/exceptions/LLVM-exception.xml
+++ b/src/exceptions/LLVM-exception.xml
@@ -3,6 +3,7 @@
    <exception licenseId="LLVM-exception" name="LLVM Exception">
       <crossRefs>
          <crossRef>http://llvm.org/foundation/relicensing/LICENSE.txt</crossRef>
+         <crossRef>https://web.archive.org/web/20240423023852/https://foundation.llvm.org/relicensing/LICENSE.txt</crossRef>
       </crossRefs>
       <notes>This exception was created specifically to be used with Apache-2.0</notes>
 	  <text>


### PR DESCRIPTION
The old link is now broken. Replace it with the last archive available from the Wayback Machine.
Notice there is also a redirection from http://llvm.org/foundation/ to https://foundation.llvm.org/.