### PR TITLE
Request to add the ENCL-1.0 license to SPDX official list.

### DIFF
--- a/src/ENCL-1.xml
+++ b/src/ENCL-1.xml
@@ -18,19 +18,19 @@ You are NOT allowed to:
 - Monetize the software (and sofware content) or any modified copy (no selling, ads, paywalls, or indirect monetization).
 - Claim the software (and software content) or a modified copy as your own creation.
 - Add or distribute NSFW content with this software (and software content) or a modified version.
-- Make video of the mod on tiktok (the original mod or a modified copy of the mod or image of the mod or video of the mod ) 
+- Make video of the software on tiktok (the original software or a modified copy of the software or image of the software or video of the software ) 
 
 -----------------------------------
 OBLIGATIONS (if you create a modified copy)
 -----------------------------------
-If you distribute a modified copy of the mod, you MUST:
+If you distribute a modified copy of the software, you MUST:
 1. Keep the name/pseudo of the author.
-2. Clearly mention in the description which IDE was used to modify the mod.
+2. Clearly mention in the description which editing software was used to modify the software.
 3. Use this license and include this exact license text with the modified version.
 4. You MUST NOT include content that promotes or disparages or refers to any individual or group based on religion, sexual orientation, gender, or disability.
 
 -----------------------------------
 DISCLAIMER
 -----------------------------------
-This mod is provided "AS IS", without any warranty of any kind.  
-The authors are not responsible for any damages, losses, or issues caused by the use of this mod.
+This software is provided "AS IS", without any warranty of any kind.  
+The authors are not responsible for any damages, losses, or issues caused by the use of this software.


### PR DESCRIPTION
the license ENCL-1.0 stand for Electron Non-Commercial License ; this license state that any software can be copied, modified and redistributed if not comercial : no cost, no paywall, no adds, no indirect monetization ; 
it is for making a software neutral as possible (for copying, the author has all right) : all content about religion, sexual choice, gender and disability.
This license was just a custom license for my minecraft mods but it will be used in all my project and by peoples that want neutral, free, and redistributable software without having to do all the process of license creation.

[license github link  ](https://github.com/electikos/electron_non-comercial_license)

I hope this license will be accepted as ENCL-1.0 or ENCL1, thank you for your consideration.