### PR TITLE
test-one-license: modernize bash script

### DIFF
--- a/test-one-license
+++ b/test-one-license
@@ -1,9 +1,14 @@
-#!/bin/bash
+#!/usr/bin/env bash
+#
+# Usage:
+# ./test-one-license <Short ID>
+#
+# any other command line arguments are ignored
 
-TOOL_VERSION=`awk '/^TOOL_VERSION/{print $NF}' Makefile`
+TOOL_VERSION="$(awk '/^TOOL_VERSION/{print $NF}' Makefile)"
 PUBLISHER=licenseListPublisher-${TOOL_VERSION}.jar
 
 # if license list publisher is not present, download it
-test ! -f ${PUBLISHER}  && make ${PUBLISHER}-valid
+test ! -f "${PUBLISHER}" && make "${PUBLISHER}-valid"
 
-java -jar ${PUBLISHER} TestLicenseXML "src/${@}.xml" "test/simpleTestForGenerator/${@}.txt" "test/fullTestForGenerator"
+java -jar "${PUBLISHER}" TestLicenseXML "src/${1}.xml" "test/simpleTestForGenerator/${1}.txt" "test/fullTestForGenerator"


### PR DESCRIPTION
this makes the script runnable on nixos and other distros that don't install bash in /bin