### PR TITLE
PS-or-PDF-font-exception-20170817: make COPYING ref optional

### DIFF
--- a/src/exceptions/PS-or-PDF-font-exception-20170817.xml
+++ b/src/exceptions/PS-or-PDF-font-exception-20170817.xml
@@ -8,7 +8,7 @@
     <text>
       <optional>
         <p>The font and related files in this directory are distributed under the
-        GNU AFFERO GENERAL PUBLIC LICENSE Version 3 (see the file COPYING), with
+        GNU AFFERO GENERAL PUBLIC LICENSE Version 3 <optional spacing="before">(see the file COPYING)</optional>, with
         the following exemption:</p>
       </optional>
       <p>As a special exception, permission is granted to include these font


### PR DESCRIPTION
Fixes #2789 

Signed-off-by: Steve Winslow <steve@swinslow.net>