### PR TITLE
Added cross-reference link to LiLiQ-Rplus-1.1.xml, resolving issue 2624

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: CC0-1.0
 
-TOOL_VERSION = 3.1.3
+TOOL_VERSION = 3.1.4
 TEST_DATA = test/simpleTestForGenerator
 FULL_TEST_DATA = test/fullTestForGenerator
 GIT_AUTHOR = License Publisher (maintained by Gary O'Neall) <gary@sourceauditor.com>

--- a/src/LiLiQ-Rplus-1.1.xml
+++ b/src/LiLiQ-Rplus-1.1.xml
@@ -5,6 +5,7 @@
       <crossRefs>
          <crossRef>https://www.forge.gouv.qc.ca/participez/licence-logicielle/licence-libre-du-quebec-liliq-en-francais/licence-libre-du-quebec-reciprocite-forte-liliq-r-v1-1/</crossRef>
          <crossRef>http://opensource.org/licenses/LiLiQ-Rplus-1.1</crossRef>
+         <crossRef>https://forge.gouv.qc.ca/licence/liliq-r+/</crossRef>
       </crossRefs>
       <notes>French is the canonical language for this license. An English
          translation is provided here:


### PR DESCRIPTION
This time with the correct link!