### PR TITLE
NIST-PD: Fix typo in reference to US Code

### DIFF
--- a/src/NIST-PD.xml
+++ b/src/NIST-PD.xml
@@ -13,7 +13,7 @@
         This software was developed by employees of the National Institute of
         Standards and Technology (NIST), and others.
         This software has been contributed to the public domain.
-        Pursuant to title 15 Untied States Code Section 105, works of NIST
+        Pursuant to title 17 Untied States Code Section 105, works of NIST
         employees are not subject to copyright protection in the United States
         and are considered to be in the public domain.
         As a result, a formal license is not needed to use this software.


### PR DESCRIPTION
There's no such thing as 15 USC § 105. 

Instead, ref https://www.law.cornell.edu/uscode/text/17/105