### PR TITLE
Update LicenseListPublisher to version 3.1.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: CC0-1.0
 
-TOOL_VERSION = 3.1.3
+TOOL_VERSION = 3.1.4
 TEST_DATA = test/simpleTestForGenerator
 FULL_TEST_DATA = test/fullTestForGenerator
 GIT_AUTHOR = License Publisher (maintained by Gary O'Neall) <gary@sourceauditor.com>


### PR DESCRIPTION
Fixes CI failures for changes to existing SPDX license XMLs