### PR TITLE
Remove UTF-8 BOM from text in GPL-3.0-with-GCC-exception.xml

### DIFF
--- a/src/GPL-3.0-with-GCC-exception.xml
+++ b/src/GPL-3.0-with-GCC-exception.xml
@@ -11,7 +11,7 @@
       </crossRefs>
       <notes>DEPRECATED: Use license expression including main license, "WITH" operator, and identifier: GCC-exception-3.1</notes>
     <text>
-	  <p>﻿insert GPL v3 text here</p>
+	  <p>insert GPL v3 text here</p>
       <titleText>
          <p>GCC RUNTIME LIBRARY EXCEPTION</p>
          <p>Version 3.1, 31 March 2009</p>


### PR DESCRIPTION
For no discernible reason, and being the only file to do so, ``GPL-3.0-with-GCC-exception.xml`` contains an UTF-8 BOM (Byte Order Marker) _in the middle of the file_. Normally a byte order marker is at the very start of the file.

The BOM character is not visible with normal text rendering here in GitHub. Some text editors like VS Code might show an invalid character. But a hex editor clearly shows the BOM bytes. For my own work, the BOM caused a string mismatch problem that was quite hard to spot. Furthermore, the BOM propagates into the license texts found in the `license-list-data` repo. 
 
I propose to remove this random and misplaced UTF-8 BOM.