### PR TITLE
Remove duplicate text in alt node organizationClause4

### DIFF
--- a/src/BSD-4-Clause.xml
+++ b/src/BSD-4-Clause.xml
@@ -38,7 +38,7 @@
         <item>
             <bullet>4.</bullet>
          <alt match="(The name of.+may not)|(Neither the name of.+nor the names of (its|their) contributors may)" name="organizationClause4">
-                 Neither the name of the copyright holder nor the names the copyright holder nor the names of its
+                 Neither the name of the copyright holder nor the names of its
            contributors may</alt> be used to endorse or promote products derived from this software without
             specific prior written permission.
 


### PR DESCRIPTION
The current non-alt license text [as presented on the SPDX site][1] does not correspond to the original license's bullet 4.

This removes the superfluous and duplicated sentence part added in commit de07000d812e768727af9a1db0a566d7161deb27 (2022-09-14) to again align with the historical license text.

[1]: https://spdx.org/licenses/BSD-4-Clause.html