### PR TITLE
OGL-Canada-2.0: Monarch Change

### DIFF
--- a/src/OGL-Canada-2.0.xml
+++ b/src/OGL-Canada-2.0.xml
@@ -64,7 +64,7 @@ https://open.canada.ca/en/open-government-licence-canada</crossRef>
             <p>"Information"</p>
             <p>means information resources protected by copyright or other information that is offered for use under the terms of this licence.</p>
             <p>"Information Provider"</p>
-            <p>means Her Majesty the Queen in right of Canada.</p>
+            <p>means <alt match="His Majesty the King|Her Majesty the Queen" name="monarch">His Majesty the King</alt> in right of Canada.</p>
             <p>"Personal Information"</p>
             <p>means "personal information" as defined in section 3 of the Privacy Act, R.S.C. 1985, c. P-21.</p>
             <p>"You"</p>


### PR DESCRIPTION
Issue: https://github.com/spdx/license-list-XML/issues/2898

Current Licence URL: https://open.canada.ca/en/open-government-licence-canada

This pull request makes two adjustments to version 2.0 of the Open Government Licence - Canada (OGL-Canada-2.0) due to the accession of a new monarch:

- It makes "His Majesty the King" the default language in the licence, as is currently reflected in the Current Licence URL.
- It adds an _alt_ tag to recognize "Her Majesty the Queen" as replaceable text (B.3.4 Guideline), as that had been the original licence text when added to the list.

The Government of Canada did not increment the licence version number when they updated the monarch.