### PR TITLE
Enable matches to Ty Coon or Moe Ghoul for GPL licenses

### DIFF
--- a/src/GPL-1.0+.xml
+++ b/src/GPL-1.0+.xml
@@ -227,7 +227,8 @@
          "copyright disclaimer" for the program, if necessary. Here a sample; alter the names:</p>
          <p>Yoyodyne, Inc., hereby disclaims all copyright interest in the program `Gnomovision' (a program to
          direct compilers to make passes at assemblers) written by James Hacker.</p>
-         <p>&lt;signature of Ty Coon&gt;, 1 April 1989 Ty Coon, President of Vice</p>
+         <p>&lt;signature of <alt match="Ty Coon|Moe Ghoul" name="sample-signee">Ty Coon</alt>&gt;,
+         1 April 1989 <alt match="Ty Coon|Moe Ghoul" name="sample-signee">Ty Coon</alt>, President of Vice</p>
          <p>That's all there is to it!</p>
       </optional>
     </text>

--- a/src/GPL-1.0-only.xml
+++ b/src/GPL-1.0-only.xml
@@ -354,7 +354,11 @@
         to make passes at assemblers) written by James Hacker.
       </p>
       <p>
-        &lt;signature of Ty Coon&gt;, 1 April 1989 Ty Coon, President of Vice
+        &lt;signature of 
+        <alt match="Ty Coon|Moe Ghoul" name="sample-signee">Ty Coon</alt>&gt;,
+        1 April 1989 
+        <alt match="Ty Coon|Moe Ghoul" name="sample-signee">Ty Coon</alt>,
+        President of Vice
       </p>
       <p>
         That's all there is to it!

--- a/src/GPL-1.0-or-later.xml
+++ b/src/GPL-1.0-or-later.xml
@@ -339,7 +339,11 @@
         to make passes at assemblers) written by James Hacker.
       </p>
       <p>
-        &lt;signature of Ty Coon&gt;, 1 April 1989 Ty Coon, President of Vice
+        &lt;signature of
+        <alt match="Ty Coon|Moe Ghoul" name="sample-signee">Ty Coon</alt>&gt;, 
+        1 April 1989
+        <alt match="Ty Coon|Moe Ghoul" name="sample-signee">Ty Coon</alt>,
+        President of Vice
       </p>
       <p>
         That's all there is to it!

--- a/src/GPL-1.0.xml
+++ b/src/GPL-1.0.xml
@@ -353,7 +353,11 @@
         to make passes at assemblers) written by James Hacker.
       </p>
       <p>
-        &lt;signature of Ty Coon&gt;, 1 April 1989 Ty Coon, President of Vice
+        &lt;signature of
+        <alt match="Ty Coon|Moe Ghoul" name="sample-signee">Ty Coon</alt>&gt;,
+        1 April 1989
+        <alt match="Ty Coon|Moe Ghoul" name="sample-signee">Ty Coon</alt>,
+        President of Vice
       </p>
       <p>
         That's all there is to it!

--- a/src/GPL-2.0+.xml
+++ b/src/GPL-2.0+.xml
@@ -299,7 +299,9 @@
          "copyright disclaimer" for the program, if necessary. Here is a sample; alter the names:</p>
          <p>Yoyodyne, Inc., hereby disclaims all copyright interest in the program `Gnomovision' (which makes
          passes at compilers) written by James Hacker.</p>
-         <p><optional>&lt;</optional>signature of Ty Coon<optional>&gt;</optional>, 1 April 1989 Ty Coon, President of Vice</p>
+         <p><optional>&lt;</optional>signature of
+          <alt match="Ty Coon|Moe Ghoul" name="sample-signee">Ty Coon</alt><optional>&gt;</optional>,
+          1 April 1989 <alt match="Ty Coon|Moe Ghoul" name="sample-signee">Ty Coon</alt>, President of Vice</p>
       </optional>
     </text>
   </license>

--- a/src/GPL-2.0-or-later.xml
+++ b/src/GPL-2.0-or-later.xml
@@ -440,8 +440,11 @@
         `Gnomovision' (which makes passes at compilers) written by James Hacker.
       </p>
       <p>
-	<optional spacing="none">&lt;</optional>signature of Ty Coon<optional spacing="none">&gt;</optional>,
-	1 April 1989 Ty Coon, President of Vice
+	<optional spacing="none">&lt;</optional>
+        signature of <alt match="Ty Coon|Moe Ghoul" name="sample-signee">Ty Coon</alt>
+        <optional spacing="none">&gt;</optional>,
+	1 April 1989 <alt match="Ty Coon|Moe Ghoul" name="sample-signee">Ty Coon</alt>,
+        President of Vice
       </p>
     </optional>
     <optional>

--- a/src/GPL-2.0.xml
+++ b/src/GPL-2.0.xml
@@ -457,8 +457,11 @@
         `Gnomovision' (which makes passes at compilers) written by James Hacker.
       </p>
       <p>
-	<optional spacing="none">&lt;</optional>signature of Ty Coon<optional spacing="none">&gt;</optional>,
-	1 April 1989 Ty Coon, President of Vice
+	<optional spacing="none">&lt;</optional>
+        signature of <alt match="Ty Coon|Moe Ghoul" name="sample-signee">Ty Coon</alt>
+        <optional spacing="none">&gt;</optional>,
+	1 April 1989 <alt match="Ty Coon|Moe Ghoul" name="sample-signee">Ty Coon</alt>,
+        President of Vice
       </p>
     </optional>
     <optional>

--- a/src/LGPL-2.0+.xml
+++ b/src/LGPL-2.0+.xml
@@ -420,8 +420,8 @@
         <br/>the library `Frob' (a library for tweaking knobs) written
         <br/>by James Random Hacker.
       </p>
-         <p>signature of Ty Coon, 1 April 1990
-        <br/>Ty Coon, President of Vice
+         <p>signature of <alt match="Ty Coon|Moe Ghoul" name="sample-signee">Ty Coon</alt>, 1 April 1990
+        <br/><alt match="Ty Coon|Moe Ghoul" name="sample-signee">Ty Coon</alt>, President of Vice
       </p>
          <p>That's all there is to it!</p>
       </optional>

--- a/src/LGPL-2.0-only.xml
+++ b/src/LGPL-2.0-only.xml
@@ -634,8 +634,9 @@
         by James Random Hacker.
       </p>
       <p>
-        signature of Ty Coon, 1 April 1990<br></br>
-        Ty Coon, President of Vice
+        signature of <alt match="Ty Coon|Moe Ghoul" name="sample-signee">Ty Coon</alt>,
+        1 April 1990<br></br>
+        <alt match="Ty Coon|Moe Ghoul" name="sample-signee">Ty Coon</alt>, President of Vice
       </p>
       <p>
         That's all there is to it!

--- a/src/LGPL-2.0-or-later.xml
+++ b/src/LGPL-2.0-or-later.xml
@@ -624,8 +624,9 @@
         by James Random Hacker.
       </p>
       <p>
-        signature of Ty Coon, 1 April 1990<br></br>
-        Ty Coon, President of Vice
+        signature of <alt match="Ty Coon|Moe Ghoul" name="sample-signee">Ty Coon</alt>,
+        1 April 1990<br></br>
+        <alt match="Ty Coon|Moe Ghoul" name="sample-signee">Ty Coon</alt>, President of Vice
       </p>
       <p>
         That's all there is to it!

--- a/src/LGPL-2.0.xml
+++ b/src/LGPL-2.0.xml
@@ -630,8 +630,9 @@
         by James Random Hacker.
       </p>
       <p>
-        signature of Ty Coon, 1 April 1990<br></br>
-        Ty Coon, President of Vice
+        signature of <alt match="Ty Coon|Moe Ghoul" name="sample-signee">Ty Coon</alt>,
+        1 April 1990<br></br>
+        <alt match="Ty Coon|Moe Ghoul" name="sample-signee">Ty Coon</alt>, President of Vice
       </p>
       <p>
         That's all there is to it!

--- a/src/LGPL-2.1+.xml
+++ b/src/LGPL-2.1+.xml
@@ -432,8 +432,10 @@
         <br/>the library `Frob' (a library for tweaking knobs) written
         <br/>by James Random Hacker.
       </p>
-         <p><optional>&lt;</optional>signature of Ty Coon<optional>&gt;</optional>, 1 April 1990
-        <br/>Ty Coon, President of Vice
+         <p><optional>&lt;</optional>
+         signature of <alt match="Ty Coon|Moe Ghoul" name="sample-signee">Ty Coon</alt>
+         <optional>&gt;</optional>, 1 April 1990
+        <br/><alt match="Ty Coon|Moe Ghoul" name="sample-signee">Ty Coon</alt>, President of Vice
         <br/>That's all there is to it!
       </p>
       </optional>

--- a/src/LGPL-2.1-only.xml
+++ b/src/LGPL-2.1-only.xml
@@ -656,9 +656,12 @@
         by James Random Hacker.
       </p>
       <p>
-	<optional>&lt;</optional>signature of Ty Coon<optional>&gt;</optional>,
+	<optional>&lt;</optional>
+        signature of <alt match="Ty Coon|Moe Ghoul" name="sample-signee">Ty Coon</alt>
+        <optional>&gt;</optional>,
 	1 April 1990<br></br>
-        Ty Coon, President of Vice<br></br>
+        <alt match="Ty Coon|Moe Ghoul" name="sample-signee">Ty Coon</alt>,
+        President of Vice<br></br>
         That's all there is to it!
       </p>
     </optional>

--- a/src/LGPL-2.1-or-later.xml
+++ b/src/LGPL-2.1-or-later.xml
@@ -637,9 +637,12 @@
         by James Random Hacker.
       </p>
       <p>
-	<optional>&lt;</optional>signature of Ty Coon<optional>&gt;</optional>,
+	<optional>&lt;</optional>
+        signature of <alt match="Ty Coon|Moe Ghoul" name="sample-signee">Ty Coon</alt>
+        <optional>&gt;</optional>,
 	1 April 1990<br></br>
-        Ty Coon, President of Vice<br></br>
+        <alt match="Ty Coon|Moe Ghoul" name="sample-signee">Ty Coon</alt>,
+        President of Vice<br></br>
         That's all there is to it!
       </p>
     </optional>

--- a/src/LGPL-2.1.xml
+++ b/src/LGPL-2.1.xml
@@ -654,9 +654,12 @@
         by James Random Hacker.
       </p>
       <p>
-	<optional>&lt;</optional>signature of Ty Coon<optional>&gt;</optional>,
+	<optional>&lt;</optional>
+        signature of <alt match="Ty Coon|Moe Ghoul" name="sample-signee">Ty Coon</alt>
+        <optional>&gt;</optional>,
 	1 April 1990<br></br>
-        Ty Coon, President of Vice<br></br>
+        <alt match="Ty Coon|Moe Ghoul" name="sample-signee">Ty Coon</alt>,
+        President of Vice<br></br>
         That's all there is to it!
       </p>
     </optional>


### PR DESCRIPTION
Many FSF license now use the website <https://www.gnu.org/licenses/> rather than a mailing address as the location to obtain a copy of the license.