### PR TITLE
NIST-Software: Add reference to source text at nist.gov

### DIFF
--- a/src/NIST-Software.xml
+++ b/src/NIST-Software.xml
@@ -3,6 +3,7 @@
    <license isOsiApproved="false" licenseId="NIST-Software"
    name="NIST Software License" listVersionAdded="3.21">
       <crossRefs>
+         <crossRef>https://www.nist.gov/open/copyright-fair-use-and-licensing-statements-srd-data-software-and-technical-series-publications</crossRef>
          <crossRef>https://github.com/open-quantum-safe/liboqs/blob/40b01fdbb270f8614fde30e65d30e9da18c02393/src/common/rand/rand_nist.c#L1-L15</crossRef>
       </crossRefs>
       <text>


### PR DESCRIPTION
The current source text of the license is available at [`nist.gov`](https://www.nist.gov/open/copyright-fair-use-and-licensing-statements-srd-data-software-and-technical-series-publications), so I thought I'd add it as a reference in the license data.