### PR TITLE
Fix notes for X11 License description

### DIFF
--- a/src/X11.xml
+++ b/src/X11.xml
@@ -4,7 +4,7 @@
       <crossRefs>
          <crossRef>http://www.xfree86.org/3.3.6/COPYRIGHT2.html#3</crossRef>
       </crossRefs>
-      <notes>This is same as MIT, but with no advertising clause added.</notes>
+      <notes>This is same as MIT, but with an advertising clause added.</notes>
     <text>
       <titleText>
          <p>X11 License</p>

--- a/src/X11.xml
+++ b/src/X11.xml
@@ -4,7 +4,7 @@
       <crossRefs>
          <crossRef>http://www.xfree86.org/3.3.6/COPYRIGHT2.html#3</crossRef>
       </crossRefs>
-      <notes>This is same as MIT, but with an advertising clause added.</notes>
+      <notes>This is same as MIT, but with a clause added which prohibits advertising.</notes>
     <text>
       <titleText>
          <p>X11 License</p>


### PR DESCRIPTION
Currently, the X11 license says that it is the same as MIT but without an advertising clause, but in fact, it is the same as MIT but with an advertising clause.