### PR TITLE
SimPL-2.0: Fix OSI URL and mark last section as optional

### DIFF
--- a/src/SimPL-2.0.xml
+++ b/src/SimPL-2.0.xml
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isOsiApproved="true" licenseId="SimPL-2.0" name="Simple Public License 2.0">
-      <crossRefs>
-         <crossRef>https://opensource.org/license/SiMPL-2.0</crossRef>
-      </crossRefs>
+  <license isOsiApproved="true" licenseId="SimPL-2.0" name="Simple Public License 2.0">
+    <crossRefs>
+      <crossRef>https://opensource.org/license/SiMPL-2.0</crossRef>
+    </crossRefs>
     <text>
       <titleText>
-         <p>Simple Public License (SimPL)</p>
+        <p>Simple Public License (SimPL)</p>
       </titleText>
       <optional>
-         <p>Preamble</p>
-         <p>This Simple Public License 2.0 (SimPL 2.0 for short) is a plain language implementation of GPL 2.0. The
-         words are different, but the goal is the same - to guarantee for all users the freedom to share and
-         change software. If anyone wonders about the meaning of the SimPL, they should interpret it as
-         consistent with GPL 2.0.</p>
+        <p>Preamble</p>
+        <p>This Simple Public License 2.0 (SimPL 2.0 for short) is a plain language implementation of GPL 2.0. The
+           words are different, but the goal is the same - to guarantee for all users the freedom to share and
+           change software. If anyone wonders about the meaning of the SimPL, they should interpret it as
+           consistent with GPL 2.0.</p>
       </optional>
       <titleText>
-         <p>Simple Public License (SimPL) 2.0</p>
+        <p>Simple Public License (SimPL) 2.0</p>
       </titleText>
 
       <p>The SimPL applies to the software's source and object code and comes with any rights that I have in it
@@ -25,66 +25,66 @@
       <p>You get the royalty free right to:</p>
       <list>
         <item>
-            <bullet>-</bullet>
+          <bullet>-</bullet>
           Use the software for any purpose;
         </item>
         <item>
-            <bullet>-</bullet>
+          <bullet>-</bullet>
           Make derivative works of it (this is called a "Derived Work");
         </item>
         <item>
-            <bullet>-</bullet>
+          <bullet>-</bullet>
           Copy and distribute it and any Derived Work.
         </item>
       </list>
       <p>If you distribute the software or a Derived Work, you must give back to the community by:</p>
       <list>
         <item>
-            <bullet>-</bullet>
+          <bullet>-</bullet>
           Prominently noting the date of any changes you make;
         </item>
         <item>
-            <bullet>-</bullet>
+          <bullet>-</bullet>
           Leaving other people's copyright notices, warranty disclaimers, and license terms in place;
         </item>
         <item>
-            <bullet>-</bullet>
+          <bullet>-</bullet>
           Providing the source code, build scripts, installation scripts, and interface definitions in a
-             form that is easy to get and best to modify;
+          form that is easy to get and best to modify;
         </item>
         <item>
-            <bullet>-</bullet>
+          <bullet>-</bullet>
           Licensing it to everyone under SimPL, or substantially similar terms (such as GPL 2.0), without
-             adding further restrictions to the rights provided;
+          adding further restrictions to the rights provided;
         </item>
         <item>
-            <bullet>-</bullet>
+          <bullet>-</bullet>
           Conspicuously announcing that it is available under that license.
         </item>
       </list>
       <p>There are some things that you must shoulder:</p>
       <list>
         <item>
-            <bullet>-</bullet>
+          <bullet>-</bullet>
           You get NO WARRANTIES. None of any kind;
         </item>
         <item>
-            <bullet>-</bullet>
+          <bullet>-</bullet>
           If the software damages you in any way, you may only recover direct damages up to the amount you
-             paid for it (that is zero if you did not pay anything). You may not recover any other damages,
-             including those called "consequential damages." (The state or country where you live may not
-             allow you to limit your liability in this way, so this may not apply to you);
+          paid for it (that is zero if you did not pay anything). You may not recover any other damages,
+          including those called "consequential damages." (The state or country where you live may not
+          allow you to limit your liability in this way, so this may not apply to you);
         </item>
       </list>
       <p>The SimPL continues perpetually, except that your license rights end automatically if:</p>
       <list>
         <item>
-            <bullet>-</bullet>
+          <bullet>-</bullet>
           You do not abide by the "give back to the community" terms (your licensees get to keep their
-             rights if they abide);
+          rights if they abide);
         </item>
         <item>
-            <bullet>-</bullet>
+          <bullet>-</bullet>
           Anyone prevents you from distributing the software under the terms of the SimPL.
         </item>
       </list>

--- a/src/SimPL-2.0.xml
+++ b/src/SimPL-2.0.xml
@@ -88,11 +88,13 @@
           Anyone prevents you from distributing the software under the terms of the SimPL.
         </item>
       </list>
-      <p>License for the License</p>
-      <p>You may do anything that you want with the SimPL text; it's a license form to use in any way that you
-         find helpful. To avoid confusion, however, if you change the terms in any way then you may not call
-         your license the Simple Public License or the SimPL (but feel free to acknowledge that your license is
-         "based on the Simple Public License").</p>
+      <optional>
+        <p>License for the License</p>
+        <p>You may do anything that you want with the SimPL text; it's a license form to use in any way that you
+           find helpful. To avoid confusion, however, if you change the terms in any way then you may not call
+           your license the Simple Public License or the SimPL (but feel free to acknowledge that your license is
+           "based on the Simple Public License").</p>
+      </optional>
     </text>
   </license>
 </SPDXLicenseCollection>

--- a/src/SimPL-2.0.xml
+++ b/src/SimPL-2.0.xml
@@ -2,7 +2,7 @@
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
   <license isOsiApproved="true" licenseId="SimPL-2.0" name="Simple Public License 2.0">
     <crossRefs>
-      <crossRef>https://opensource.org/license/SiMPL-2.0</crossRef>
+      <crossRef>https://opensource.org/license/SimPL-2.0</crossRef>
     </crossRefs>
     <text>
       <titleText>

--- a/src/SimPL-2.0.xml
+++ b/src/SimPL-2.0.xml
@@ -73,7 +73,7 @@
           If the software damages you in any way, you may only recover direct damages up to the amount you
           paid for it (that is zero if you did not pay anything). You may not recover any other damages,
           including those called "consequential damages." (The state or country where you live may not
-          allow you to limit your liability in this way, so this may not apply to you);
+          allow you to limit your liability in this way, so this may not apply to you).
         </item>
       </list>
       <p>The SimPL continues perpetually, except that your license rights end automatically if:</p>


### PR DESCRIPTION
The last section of SimPL-2.0 text is not strictly part of the license itself, so this PR marks it as optional, to avoid conveying misleading guidance to users.

Additionally, the OSI URL (modified in PR #2960) has incorrect capitalization: it is written as "SiMPL" instead of "SimPL". Although that URL does work, resolving to the correct page, the capitalization does not match the actual license's short name, and can be potentially misleading, so this PR also corrects the URL.

While modifying the file, I took the opportunity to fix some indentation inconsistencies in this file.

Finally, this PR corrects a punctuation inconsistency in the list of disclaimers: the last item in that list currently ends with a semicolon, which is a leftover from an [earlier draft](https://lists.opensource.org/pipermail/license-discuss_lists.opensource.org/2007-March/012630.html) in which an additional list item followed it. When that extra item was removed, the semicolon in the item before it should have been adjusted to a period, but that detail appears to have been missed at the time. This PR fixes the punctuation to ensure the consistency of the recorded text.

Each of the changes above are made in separate, atomic commits, so that they can be reviewed independently (I would suggest viewing the [diff in whitespace-insensitive mode](https://github.com/spdx/license-list-XML/pull/2988/changes?w=1)), and dropped if undesirable (or split to separate PRs if that's preferred).
