### PR TITLE
Update outdated "SPDX tools" link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,6 @@ Please note, a license not on the SPDX License List can be included in an SPDX d
 * Any new issues raised within the month of the next release will likely be tagged for the following release, unless it is an easy-to-resolve issue
 
 # Consuming License Data from this Repository
-Output files in the [SPDX license-list-data repository](https://github.com/spdx/license-list-data) are generated from the XML source in this repository.  These output files are stable and well-supported, and make the License List available in RDFa, HTML, text, and JSON formats. You can use [SPDX tools](https://github.com/spdx/tools) (or create your own) to consume the supported formats of the license list.
+Output files in the [SPDX license-list-data repository](https://github.com/spdx/license-list-data) are generated from the XML source in this repository.  These output files are stable and well-supported, and make the License List available in RDFa, HTML, text, and JSON formats. You can use [SPDX tools](https://spdx.dev/use/spdx-tools/) (or create your own) to consume the supported formats of the license list.
 
 Please note that the XML format for this repository is internal to the SPDX legal team and is subject to change, so any direct consumers of _this_ repository's source files should expect occasional, backwards-incompatible changes.


### PR DESCRIPTION
The tool at https://github.com/spdx/tools is no longer maintained and is now in archived status.

The repo README said:

> Following the SPDX 3.0 release in April 2024, this version of the SPDX Java tools is replaced by the new Java tools in the tools-java repo. The older version in this repo will no longer be maintained.

Change the link to https://spdx.dev/use/spdx-tools/ on the official SPDX project website instead. The page there listed SPDX tools for different ecosystems.