### PR TITLE
DocBook-DTD: Match full docbook DTD as well as simplified

### DIFF
--- a/src/DocBook-DTD.xml
+++ b/src/DocBook-DTD.xml
@@ -22,19 +22,21 @@
          </copyrightText>
          <p>
             Permission to use, copy, modify and distribute the DocBook
-            XML DTD and its accompanying documentation for any purpose
-            and without fee is hereby granted in perpetuity, provided
-            that the above copyright notice and this paragraph appear
-            in all copies. The copyright holders make no representation
-            about the suitability of the DTD for any purpose. It is
-            provided "as is" without expressed or implied warranty.
+            <optional>XML</optional> DTD and its accompanying documentation
+            for any purpose and without fee is hereby granted in perpetuity,
+            provided that the above copyright notice and this
+            paragraph appear in all copies. The copyright holders
+            make no representation about the suitability of the DTD
+            for any purpose. It is provided "as is" without
+            expressed or implied warranty.
          </p>
          <p>
-            If you modify the Simplified DocBook DTD in any
-            way, except for declaring and referencing additional
-            sets of general entities and declaring additional
-            notations, label your DTD as a variant of DocBook. See
-            the maintenance documentation for more information.
+            If you modify the <optional>Simplified</optional> DocBook
+            DTD in any way, except for declaring and referencing
+            additional sets of general entities and declaring
+            additional notations, label your DTD as a variant of
+            DocBook. See the maintenance documentation for more
+            information.
          </p>
          <p>
             Please direct all questions, bug reports, or suggestions for


### PR DESCRIPTION
Makes the work "Simplified" optional in the Docbook DTD license so that it will match both the full Docbook DTD license and the Simplified Docbook DTD license.