### PR TITLE
Mark Python-2.0.1 and affected CNRI portion OSI approved

### DIFF
--- a/src/CNRI-Python-GPL-Compatible.xml
+++ b/src/CNRI-Python-GPL-Compatible.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isOsiApproved="false" licenseId="CNRI-Python-GPL-Compatible"
+   <license isOsiApproved="true" licenseId="CNRI-Python-GPL-Compatible"
             name="CNRI Python Open Source GPL Compatible License Agreement">
       <crossRefs>
          <crossRef>http://www.python.org/download/releases/1.6.1/download_win/</crossRef>
+         <crossRef>https://opensource.org/license/CNRI-Python-GPL-Compatible</crossRef>
       </crossRefs>
+      <notes>GPL-compatible CNRI portion of the multi-part Python License (Python-2.0.1)</notes>
     <text>
       <titleText>
          <p>CNRI OPEN SOURCE GPL-COMPATIBLE LICENSE AGREEMENT</p>

--- a/src/Python-2.0.1.xml
+++ b/src/Python-2.0.1.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license licenseId="Python-2.0.1" name="Python License 2.0.1" listVersionAdded="3.18">
+   <license isOsiApproved="true" licenseId="Python-2.0.1" name="Python License 2.0.1" listVersionAdded="3.18">
       <crossRefs>
          <crossRef>https://www.python.org/download/releases/2.0.1/license/</crossRef>
          <crossRef>https://docs.python.org/3/license.html</crossRef>
          <crossRef>https://github.com/python/cpython/blob/main/LICENSE</crossRef>
+         <crossRef>https://opensource.org/license/Python-2.0.1</crossRef>
       </crossRefs>
       <notes>
          For Python release 1.6.1, apparently the CNRI-Python license part of the stack was replaced with CNRI-Python-GPL-Compatible


### PR DESCRIPTION
Implements the OSI board decision to approve both licenses: https://opensource.org/meeting-minutes/2026-06-29

However, both licenses are not yet present on opensource.org/licenses, so it's probably best to wait until this is done.

`Python-2.0` and `CNRI-Python` will both marked as superseded by the new versions by OSI. As far as I understood the docs, this won't be reflected in the SPDX data, right?