### PR TITLE
Update OSI approval status of curl

### DIFF
--- a/src/curl.xml
+++ b/src/curl.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SPDXLicenseCollection xmlns="http://www.spdx.org/license">
-   <license isOsiApproved="false" licenseId="curl" name="curl License" listVersionAdded="2.3">
+   <license isOsiApproved="true" licenseId="curl" name="curl License" listVersionAdded="2.3">
       <crossRefs>
          <crossRef>https://github.com/bagder/curl/blob/master/COPYING</crossRef>
+         <crossRef>https://opensource.org/license/curl</crossRef>
       </crossRefs>
     <text>
       <titleText>


### PR DESCRIPTION
As per OSI's April board meeting, curl has been approved as an Open Source license: https://opensource.org/meeting-minutes/2026-04-17
